### PR TITLE
fix: do not inherit from Agent, which is a final class

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ format:
 	uvx ruff format
 
 check-type:
-	uvx ty check --exit-zero
+	uvx ty check
     
 check: format lint check-type
 

--- a/src/aegis_ai/agents.py
+++ b/src/aegis_ai/agents.py
@@ -16,42 +16,38 @@ from aegis_ai.tools.osidb import osidb_tool
 from aegis_ai.toolsets import public_toolset
 
 
-class AegisAgent(Agent):
+def create_aegis_agent(**kwargs: Any) -> Agent:
     """
-    AegisAgent: A specialized pydantic-ai Agent.
+    Factory for a pre-configured `Agent` that mirrors the previous AegisAgent defaults
+    without subclassing the (final) `Agent` class.
     """
-
-    def __init__(
-        self,
-        **kwargs: Any,
-    ):
-        super().__init__(
-            model=default_llm_model,
-            model_settings=get_settings().default_llm_settings
-            | {
-                "temperature": 0.055,
-                "top_p": 0.8,
-                "seed": 42,
-                "response_format": {"type": "json_object"},
-            },
-            **kwargs,
-        )
+    return Agent(
+        model=default_llm_model,
+        model_settings=get_settings().default_llm_settings
+        | {
+            "temperature": 0.055,
+            "top_p": 0.8,
+            "seed": 42,
+            "response_format": {"type": "json_object"},
+        },
+        **kwargs,
+    )
 
 
-simple_agent = AegisAgent(
+simple_agent = create_aegis_agent(
     name="SimpleAgent",
     output_type=AegisAnswer,
 )
 
 
-rh_feature_agent = AegisAgent(
+rh_feature_agent = create_aegis_agent(
     name="RHFeatureAgent",
     retries=2,  # FIXME: this should be made configurable, was included as brutish technique for revalidations
     tools=[osidb_tool, cwe_tool],
 )
 
 
-public_feature_agent = AegisAgent(
+public_feature_agent = create_aegis_agent(
     name="PublicFeatureAgent",
     retries=5,  # FIXME: this should be made configurable, was included as brutish technique for revalidations
     toolsets=[public_toolset],

--- a/src/aegis_ai/features/__init__.py
+++ b/src/aegis_ai/features/__init__.py
@@ -1,6 +1,21 @@
+import logging
 from pydantic_ai import Agent
+
+
+logger = logging.getLogger(__name__)
 
 
 class Feature:
     def __init__(self, agent: Agent):
         self.agent = agent
+
+    async def run_if_safe(self, prompt, **kwargs):
+        """
+        Execute `self.agent.run(...)` only if the provided prompt passes `prompt.is_safe()`.
+        Returns the model output on success, otherwise None.
+        """
+        if await prompt.is_safe():
+            return await self.agent.run(prompt.to_string(), **kwargs)
+
+        logger.info("Safety agent identified issue with query.")
+        return None

--- a/src/aegis_ai/features/component/__init__.py
+++ b/src/aegis_ai/features/component/__init__.py
@@ -60,9 +60,4 @@ class ComponentIntelligence(Feature):
             output_schema=ComponentIntelligenceModel.model_json_schema(),
         )
         logger.debug(prompt.to_string())
-        if await prompt.is_safe():
-            return await self.agent.run(
-                prompt.to_string(), output_type=ComponentIntelligenceModel
-            )
-        else:
-            logger.info("Safety agent identified issue with query.")
+        return await self.run_if_safe(prompt, output_type=ComponentIntelligenceModel)

--- a/src/aegis_ai/features/cve/__init__.py
+++ b/src/aegis_ai/features/cve/__init__.py
@@ -59,12 +59,7 @@ class SuggestImpact(Feature):
             static_context=static_context,
             output_schema=SuggestImpactModel.model_json_schema(),
         )
-        if await prompt.is_safe():
-            return await self.agent.run(
-                prompt.to_string(), output_type=SuggestImpactModel
-            )
-        else:
-            logger.info("Safety agent identified issue with query.")
+        return await self.run_if_safe(prompt, output_type=SuggestImpactModel)
 
 
 class SuggestCWE(Feature):
@@ -133,10 +128,7 @@ class SuggestCWE(Feature):
             static_context=static_context,
             output_schema=SuggestCWEModel.model_json_schema(),
         )
-        if await prompt.is_safe():
-            return await self.agent.run(prompt.to_string(), output_type=SuggestCWEModel)
-        else:
-            logger.info("Safety agent identified issue with query.")
+        return await self.run_if_safe(prompt, output_type=SuggestCWEModel)
 
 
 class IdentifyPII(Feature):
@@ -298,10 +290,7 @@ class IdentifyPII(Feature):
             static_context=static_context,
             output_schema=PIIReportModel.model_json_schema(),
         )
-        if await prompt.is_safe():
-            return await self.agent.run(prompt.to_string(), output_type=PIIReportModel)
-        else:
-            logger.info("Safety agent identified issue with query.")
+        return await self.run_if_safe(prompt, output_type=PIIReportModel)
 
 
 class RewriteDescriptionText(Feature):
@@ -428,12 +417,7 @@ class RewriteDescriptionText(Feature):
             static_context=static_context,
             output_schema=RewriteDescriptionModel.model_json_schema(),
         )
-        if await prompt.is_safe():
-            return await self.agent.run(
-                prompt.to_string(), output_type=RewriteDescriptionModel
-            )
-        else:
-            logger.info("Safety agent identified issue with query.")
+        return await self.run_if_safe(prompt, output_type=RewriteDescriptionModel)
 
 
 class RewriteStatementText(Feature):
@@ -515,12 +499,7 @@ class RewriteStatementText(Feature):
             static_context=static_context,
             output_schema=RewriteStatementModel.model_json_schema(),
         )
-        if await prompt.is_safe():
-            return await self.agent.run(
-                prompt.to_string(), output_type=RewriteStatementModel
-            )
-        else:
-            logger.info("Safety agent identified issue with query.")
+        return await self.run_if_safe(prompt, output_type=RewriteStatementModel)
 
 
 class CVSSDiffExplainer(Feature):
@@ -581,9 +560,4 @@ class CVSSDiffExplainer(Feature):
             static_context=static_context,
             output_schema=CVSSDiffExplainerModel.model_json_schema(),
         )
-        if await prompt.is_safe():
-            return await self.agent.run(
-                prompt.to_string(), output_type=CVSSDiffExplainerModel
-            )
-        else:
-            logger.info("Safety agent identified issue with query.")
+        return await self.run_if_safe(prompt, output_type=CVSSDiffExplainerModel)


### PR DESCRIPTION
This fixes the following warning on `uvx ty check`:
```
error[subclass-of-final-class]: Class `AegisAgent` cannot inherit from final class `Agent`
  --> src/aegis_ai/agents.py:19:18
   |   
19 | class AegisAgent(Agent):
   |                  ^^^^^
20 |     """ 
21 |     AegisAgent: A specialized pydantic-ai Agent.
   |   
info: rule `subclass-of-final-class` is enabled by default
```

Also deduplicate the code calling `prompt.is_safe()` in each class that inherits from the Feature class.

Fixes: https://github.com/RedHatProductSecurity/aegis-ai/issues/112
Resolves: https://issues.redhat.com/browse/AEGIS-109