### PR TITLE
fix: make aegis work again with `ollama`

### DIFF
--- a/src/aegis_ai/data_models.py
+++ b/src/aegis_ai/data_models.py
@@ -50,7 +50,7 @@ CVSS4Vector = _make_cvss_model("CVSS4")
 CVEID = Annotated[
     str,
     StringConstraints(
-        pattern=r"^CVE-\d{4}-\d{4,7}$",
+        pattern=r"^CVE-[0-9]{4}-[0-9]{4,7}$",
         strict=True,
         strip_whitespace=True,
     ),

--- a/tests/test_data_models.py
+++ b/tests/test_data_models.py
@@ -19,4 +19,4 @@ def test_cveid():
     with pytest.raises(ValidationError) as excinfo:
         cve_id = CVEID("BAD-CVE-4")
         assert cveid_validator.validate_python(cve_id)
-    assert "String should match pattern '^CVE-\\d{4}-\\d{4,7}$'" in str(excinfo)
+    assert "String should match pattern '^CVE-[0-9]{4}-[0-9]{4,7}$'" in str(excinfo)


### PR DESCRIPTION
`ollama` does not accept `\d` in regular expressions, which results in the following, difficult to debug, failure:
```
pydantic_ai.exceptions.ModelHTTPError: status_code: 400, model_name: mistral:7b-v3, body: {'code': 400, 'message': 'Failed to parse grammar', 'type': 'invalid_request_error'}
```

Note that if we apply this one-line patch on commit b351bf6fc258b3cb4564cabb57106c37b6757205, it does not fix the bug on its own because the commit introduced other issues with `ollama`, which were later fixed by commit 5934a9061154de2a890a37cad7ea06223cef4590 (although the other commit is not tagged as a fix).

Fixes: commit b351bf6fc258b3cb4564cabb57106c37b6757205
Fixes: https://github.com/RedHatProductSecurity/aegis-ai/issues/146
Related: https://github.com/ollama/ollama/issues/10591
Related: https://issues.redhat.com/browse/AEGIS-118