### PR TITLE
enhance: make the REST API support Kerberos auth

### DIFF
--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -4,7 +4,6 @@
 | Environment Variable           | Description                                 | Default Value |
 |--------------------------------|---------------------------------------------|---------------|
 | `AEGIS_CLI_FEATURE_AGENT`      | Set to `redhat` to use rh profile           | `public`      |
-| `AEGIS_WEB_FEATURE_AGENT`      | Set to `redhat` to use rh profile           | `public`      |
 | `AEGIS_LLM_HOST`               | Aegis LLM host                              | `localhost:11434` |
 | `AEGIS_LLM_MODEL`              | Aegis LLM model                             | `llama3.2:latest` |
 | `AEGIS_SAFETY_ENABLED`         | Enable separate model to check model safety | `false`       |
@@ -12,6 +11,14 @@
 | `AEGIS_SAFETY_LLM_MODEL`       | Safety LLM model                            | `granite3-guardian-2b`|
 | `AEGIS_SAFETY_OPENAPI_KEY`     | Safety openai key                           |               |
 | `AEGIS_ML_CVE_DATA_DIR`        | Directory containing CVE training data      |               |
+
+
+# REST API settings
+| Environment Variable           | Description                                 | Default Value      |
+|--------------------------------|---------------------------------------------|--------------------|
+| `AEGIS_WEB_FEATURE_AGENT`      | Set to `redhat` to use rh profile           | `public`           |
+| `AEGIS_WEB_SPN`                | Service Principal Name for Kerberos auth    |                    |
+| `KRB5_KTNAME`                  | Path to the keytab file for Kerberos auth   | `/etc/krb5.keytab` |
 
 
 # Tool settings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "cvss>=3.4",
     "dotenv>=0.9.9",
     "fastapi>=0.116.1",
+    "fastapi-gssapi>=0.1.1",
     "httpx>=0.28.1",
     "jinja2>=3.1.6",
     "logfire[fastapi,httpx,sqlite3]>=4.4.0",

--- a/src/aegis_ai_web/src/main.py
+++ b/src/aegis_ai_web/src/main.py
@@ -53,6 +53,15 @@ app = FastAPI(
 # unless it is received over HTTPS)
 app.add_middleware(HSTSHeaderMiddleware)
 
+# optionally enable Kerberos authentication
+kerberos_spn = os.getenv("AEGIS_WEB_SPN")
+if kerberos_spn:
+    # do not depend on `fastapi-gssapi` unless it is actually needed
+    from fastapi_gssapi import GSSAPIMiddleware
+
+    # middleware to add GSSAPI authentication
+    app.add_middleware(GSSAPIMiddleware, spn=kerberos_spn)
+
 logfire.instrument_fastapi(app)
 
 BASE_DIR = Path(__file__).parent


### PR DESCRIPTION
If the `AEGIS_WEB_SPN` environment variable is set to the Service Principal Name, the REST API requires Kerberos authentication.

The keytab file can optionally be specified by the `KRB5_KTNAME` environment variable.  If not, it defaults to `/etc/krb5.keytab`.

Related: https://issues.redhat.com/browse/AEGIS-126