### PR TITLE
fix: provide correct URL templates on the web index page

### DIFF
--- a/src/aegis_ai_web/src/templates/index.html
+++ b/src/aegis_ai_web/src/templates/index.html
@@ -20,8 +20,8 @@
     <div class="container-fluid">
       <hr/>
       <p>Analysis features:<br/>
-          CVE Features: GET /api/v1/analysis/cve?feature={feature_name}cve_id={cve_id}<br/>
-          Component Features: GET /api/v1/analysis/component?feature={feature_name}&component_name={component_name}<br/>
+          CVE Features: GET /api/v1/analysis/cve?feature={feature_name}&amp;cve_id={cve_id}<br/>
+          Component Features: GET /api/v1/analysis/component?feature={feature_name}&amp;component_name={component_name}<br/>
       </p>
       <hr/>
       <p>Docs:


### PR DESCRIPTION
An ampersand was missing in the first template and unescaped in the second template.

Related: https://github.com/RedHatProductSecurity/aegis-ai/pull/153