### PR TITLE
chore: eliminate a type check warning

### DIFF
--- a/evals/conftest.py
+++ b/evals/conftest.py
@@ -32,7 +32,9 @@ def setup_logging_for_session():
 @pytest.fixture(scope="session", autouse=True)
 def override_rh_feature_agent():
     # Replace the first inner FunctionToolset with one that contains our wrapper
-    ts.redhat_cve_toolset.toolsets[0] = FunctionToolset(tools=[osidb_tool])
+    ts_list = ts.redhat_cve_toolset.toolsets
+    if isinstance(ts_list, list):
+        ts_list[0] = FunctionToolset(tools=[osidb_tool])
 
 
 # Optionally exit successfully if ${AEGIS_EVALS_MIN_PASSED} tests have succeeded


### PR DESCRIPTION
... in the evaluation suite fixture:
```
warning[possibly-unbound-implicit-call]: Method `__setitem__` of type `Unknown | Sequence[AbstractToolset[None]]` is possibly unbound
  --> evals/conftest.py:35:5
   |
33 | def override_rh_feature_agent():
34 |     # Replace the first inner FunctionToolset with one that contains our wrapper
35 |     ts.redhat_cve_toolset.toolsets[0] = FunctionToolset(tools=[osidb_tool])
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
info: rule `possibly-unbound-implicit-call` is enabled by default
```