### PR TITLE
fix: enable `mergeTargetBranch` in the `push` pipeline, too

### DIFF
--- a/.tekton/aegis-eval-container-push.yaml
+++ b/.tekton/aegis-eval-container-push.yaml
@@ -132,6 +132,10 @@ spec:
         value: $(params.git-url)
       - name: revision
         value: $(params.revision)
+      - name: depth
+        value: 0  # needed for mergeTargetBranch to work (artificial merge conflicts are reported without this)
+      - name: mergeTargetBranch
+        value: true
       - name: ociStorage
         value: $(params.output-image).git
       - name: ociArtifactExpiresAfter


### PR DESCRIPTION
The remote branch is needed for the offline cloning of the source code git repository in the `build-container` task.

Related: https://issues.redhat.com/browse/AEGIS-118