### PR TITLE
ci-test: trigger an artificial move of the `:latest` tag

### DIFF
--- a/.tekton/aegis-ai-pull-request.yaml
+++ b/.tekton/aegis-ai-pull-request.yaml
@@ -28,6 +28,9 @@ spec:
     value: 5d
   - name: dockerfile
     value: Containerfile
+  # FIXME: for testing purposes only
+  - name: ADDITIONAL_TAGS
+    value: [latest]
   pipelineRef:
     # include the shared pipeline definition from aegis-build-pipeline.yaml
     resolver: git


### PR DESCRIPTION
## What
ci-test: trigger an artificial move of the `:latest` tag

## Why
for testing purposes only

## How to Test
The `:latest` tag is moved.

## Related Tickets
Related: https://issues.redhat.com/browse/AEGIS-30

## Summary by Sourcery

CI:
- Add ADDITIONAL_TAGS environment variable in the Tekton pipeline config to include the latest tag