### PR TITLE
chore: use `gemini-2.5-flash-lite` for `run-evals`

### DIFF
--- a/.tekton/aegis-build-pipeline.yaml
+++ b/.tekton/aegis-build-pipeline.yaml
@@ -641,7 +641,7 @@ spec:
                   - name: AEGIS_LLM_HOST
                     value: "https://generativelanguage.googleapis.com"
                   - name: AEGIS_LLM_MODEL
-                    value: "gemini-2.5-flash"
+                    value: "gemini-2.5-flash-lite"
                   # FIXME: this should be removed once we have (more) reliable evals
                   - name: AEGIS_EVALS_MIN_PASSED
                     value: "5"


### PR DESCRIPTION
## What
use `gemini-2.5-flash-lite` for `run-evals`

## Why
TBD

## How to Test
TBD

## Related Tickets
TBD

## Summary by Sourcery

Chores:
- Switch AEGIS_LLM_MODEL to gemini-2.5-flash-lite for the run-evals task in aegis-build-pipeline.yaml