### PR TITLE
fix: do not throw a validation error for CWE missing in the cache of `cwe_tool`

### DIFF
--- a/src/aegis_ai/tools/cwe/__init__.py
+++ b/src/aegis_ai/tools/cwe/__init__.py
@@ -131,6 +131,7 @@ async def cwe_lookup(cwe_id: CWEID) -> CWE | None:
                 cwe_id=validated_cwe_id,
                 name="UNKNOWN",
                 description="UNKNOWN",
+                extended_description="UNKNOWN",
                 disallowed=True,
             )
 


### PR DESCRIPTION
## What
fix: do not throw a validation error for CWE missing in the cache of `cwe_tool`

## Why
The issue was introduced in commit 61f2f657ed3f77758c7333bf96799713a55eccda by mistake.

## How to Test
Run the evaluation suite a few times.  The error captured in #191 should no longer occur.

## Related Tickets
Related: https://github.com/RedHatProductSecurity/aegis-ai/pull/156
Resolves: https://github.com/RedHatProductSecurity/aegis-ai/issues/191

## Summary by Sourcery

Prevent validation errors when a CWE is not found in the cache by providing a default extended_description in the placeholder response.

Bug Fixes:
- Avoid throwing a validation error for missing CWE entries in the cache to resolve issue #191.

Enhancements:
- Populate the extended_description field with "UNKNOWN" in the placeholder CWE object to satisfy validation requirements.