### PR TITLE
chore: make SAST scanning work in Konflux CI

### DIFF
--- a/.tekton/aegis-ai-pull-request.yaml
+++ b/.tekton/aegis-ai-pull-request.yaml
@@ -42,6 +42,14 @@ spec:
       value: pipeline
   taskRunTemplate:
     serviceAccountName: build-pipeline-aegis-ai
+  taskRunSpecs:
+  - pipelineTaskName: sast-coverity-check
+    computeResources:
+      requests:
+        cpu: 1
+        memory: 4Gi
+      limits:
+        memory: 8Gi
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/aegis-ai-push.yaml
+++ b/.tekton/aegis-ai-push.yaml
@@ -42,6 +42,14 @@ spec:
       value: pipeline
   taskRunTemplate:
     serviceAccountName: build-pipeline-aegis-ai
+  taskRunSpecs:
+  - pipelineTaskName: sast-coverity-check
+    computeResources:
+      requests:
+        cpu: 1
+        memory: 4Gi
+      limits:
+        memory: 8Gi
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/aegis-build-pipeline.yaml
+++ b/.tekton/aegis-build-pipeline.yaml
@@ -413,6 +413,7 @@ spec:
     - name: IMP_FINDINGS_ONLY
       value: "false"
     runAfter:
+    - build-image-index
     - coverity-availability-check
     taskRef:
       params:
@@ -433,8 +434,6 @@ spec:
       values:
       - success
   - name: coverity-availability-check
-    runAfter:
-    - build-image-index
     taskRef:
       params:
       - name: name

--- a/.tekton/aegis-build-pipeline.yaml
+++ b/.tekton/aegis-build-pipeline.yaml
@@ -408,6 +408,10 @@ spec:
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    - name: COV_ANALYZE_ARGS
+      value: '--enable HARDCODED_CREDENTIALS --security --concurrency --tu-pattern=!file(".cache/uv/")&&!file(".venv/")'
+    - name: IMP_FINDINGS_ONLY
+      value: "false"
     runAfter:
     - coverity-availability-check
     taskRef:

--- a/.tekton/aegis-build-pipeline.yaml
+++ b/.tekton/aegis-build-pipeline.yaml
@@ -455,6 +455,10 @@ spec:
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    - name: IMP_FINDINGS_ONLY
+      value: "false"
+    - name: TARGET_DIRS
+      value: docs,evals,scripts,src,tests
     runAfter:
     - build-image-index
     taskRef:


### PR DESCRIPTION
## What
Configure SAST scanning in Konflux CI:
- `sast-coverity-check`
- `sast-shell-check`
- `sast-snyk-check`

## Why
So that all code changes are SAST scanned.  This is needed for the `SEC-APP-REQ-2` ESS Control.

## How to Test
The SAST scanners should be started automatically for each pull request and each push to the `main branch`.

## Related Tickets
Related: https://issues.redhat.com/browse/AEGIS-78

## Summary by Sourcery

Configure SAST scanning in Konflux CI by integrating Coverity, shell, and Snyk checks into the Tekton build and CI pipelines to satisfy SEC-APP-REQ-2

Enhancements:
- Add COV_ANALYZE_ARGS, IMP_FINDINGS_ONLY, and TARGET_DIRS environment variables to the build pipeline
- Reorder tasks to run sast-coverity-check after build-image-index and coverity availability
- Specify CPU and memory requests and limits for the sast-coverity-check task in PR and push pipelines