### PR TITLE
Allow multiple origins in CORS policy

### DIFF
--- a/src/aegis_ai_web/src/main.py
+++ b/src/aegis_ai_web/src/main.py
@@ -71,7 +71,7 @@ origins = [
 ]
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=cors_target_url,
+    allow_origins=origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## What
Permit the list of origins in CORS policy middleware configuration.

## Why
Expected header is absent from response header upon resolution of client request from origin `https://localhost:5713`

## How to Test
Deploy and cross fingers?

## Related Tickets

## Summary by Sourcery

Allow specifying multiple origins in CORS policy by changing the middleware configuration to use a list of origins

Bug Fixes:
- Fix missing CORS response header by supporting multiple allowed origins

Enhancements:
- Update CORS middleware configuration to accept a list of origins instead of a single URL