### PR TITLE
fix: suggest-cwe context length fix by returning on available cwe-ids…

### DIFF
--- a/src/aegis_ai/features/cve/__init__.py
+++ b/src/aegis_ai/features/cve/__init__.py
@@ -61,8 +61,9 @@ class SuggestCWE(Feature):
                 - Return a short explanation and confidence.
             """,
             rules="""
-                Use mitre cwe tool to retrieve all allowed cwe definitions first so this context can be used to try and identify cwe in vulnerability.
+                Use mitre cwe tool retrieve_allowed_cwe_ids first to constrain available CWE to select from.
                 Always use kernel_cve tool to provide additional CVE context if CVE component is kernel.
+                Candidate CWEs should be selected from allowed cwe ids which have disallowed=false.
                 Output should include:
                 - cwe: a list of 1–3 likely CWE IDs (e.g., ["CWE-125"]).
                 - explanation: 1–2 sentences connecting CVE details to the CWE.

--- a/src/aegis_ai/tools/cwe/__init__.py
+++ b/src/aegis_ai/tools/cwe/__init__.py
@@ -4,7 +4,7 @@ import io
 import json
 import logging
 import os
-from typing import List, Dict, Any
+from typing import List
 
 from zipfile import ZipFile
 
@@ -18,8 +18,6 @@ from aegis_ai.data_models import CWEID, cweid_validator
 from aegis_ai.tools import BaseToolOutput, default_tool_http_headers, BaseToolInput
 
 logger = logging.getLogger(__name__)
-
-JsonBlob = Dict[str, Any]
 
 # retrieve allowed cwes from cwe.mitre.org
 CWE_URLS = [
@@ -158,9 +156,9 @@ async def cwe_lookup(cwe_id: CWEID) -> CWE | None:
 
 
 @Tool
-async def retrieve_all_cwes(ctx: RunContext) -> JsonBlob | None:
-    """Retrieve all allowed cwe definitions."""
-    logger.info("retrieving allowed cwe definitions.")
+async def retrieve_allowed_cwe_ids(ctx: RunContext) -> List[CWEID] | None:
+    """Retrieve all allowed CWE-IDs."""
+    logger.info("retrieving allowed cwe-ids.")
 
     file_path = os.path.join(CACHE_DIR, CACHE_FILE)
 
@@ -175,7 +173,7 @@ async def retrieve_all_cwes(ctx: RunContext) -> JsonBlob | None:
             with open(file_path, "w") as f:
                 json.dump(data, f, indent=2)
 
-        return data
+        return [key for key in data.keys() if not data[key].get("disallowed", False)]
     except Exception as e:
         logger.error(f"An error occurred: {e}")
 
@@ -186,12 +184,14 @@ async def retrieve_cwes(ctx: RunContext, inputs: CWEToolInput) -> List[CWE]:
     logger.info(f"retrieving {inputs.cwe_ids} cwe definitions.")
     results = []
     for input in inputs.cwe_ids:
-        results.append(await cwe_lookup(input))
+        result = await cwe_lookup(input)
+        if result and not result.disallowed:
+            results.append(result)
     return results
 
 
 toolset = FunctionToolset(
-    tools=[retrieve_cwes, retrieve_all_cwes],
+    tools=[retrieve_cwes, retrieve_allowed_cwe_ids],
 )
 
 cwe_toolset = toolset.prefixed("cwe")


### PR DESCRIPTION
## What

Minimise context sent from cwe-tool to just allowed CWE-IDs instead of entire definitions.

## Why

Context length of entire CWE definitions is too large to inject into every llm call. In the future we will have similarity search to retrieve queries on CWE embeddings data.
How to Test

run eval

## Summary by Sourcery

Limit CWE context by replacing full CWE definition retrieval with a function that returns only allowed CWE IDs and update references accordingly.

Enhancements:
- Replace retrieve_all_cwes tool with retrieve_allowed_cwe_ids to return only allowed CWE IDs.
- Filter out disallowed CWE entries when loading cached data to minimize context size.
- Update CVE feature documentation to reference retrieve_allowed_cwe_ids instead of full CWE definitions.