### PR TITLE
fix: make `AEGIS_LLM_MAX_JOBS` work again

### DIFF
--- a/src/aegis_ai/features/__init__.py
+++ b/src/aegis_ai/features/__init__.py
@@ -42,7 +42,7 @@ class Feature:
                 logger.info(msg)
                 raise RuntimeError(msg)
 
-        result = await self._timeout_wrap(prompt, **kwargs)
+            result = await self._timeout_wrap(prompt, **kwargs)
 
         # check how many input tokens were processed by the LLM
         input_tokens = result._state.usage.input_tokens


### PR DESCRIPTION
## What
fix: make `AEGIS_LLM_MAX_JOBS` work again

## Why
After refactoring the code of `run_if_safe()` one line was incorrectly indented, which prevented the `AEGIS_LLM_MAX_JOBS` feature from taking an effect.  This commit fixes it.

## How to Test
You can observe reduced parallelism (4 jobs at a time by default) while running the evaluation suite.

## Related Tickets
Fixes: commit 3e4c0e58983ea13fdf738ba57894edbb5fa65f19
Related: https://issues.redhat.com/browse/AEGIS-188

## Summary by Sourcery

Bug Fixes:
- Re-indent the timeout-wrap invocation in run_if_safe so the AEGIS_LLM_MAX_JOBS parallelism cap is applied