### PR TITLE
safety_agent: when gemini is aegis agent- we can rely on gemini safety settings

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - bump to osidb-bindings 4.15.0
 - update tools User Agent (aegis - https://github.com/RedHatProductSecurity/aegis) 
 - added some error handling for tools
+- add gemini safety settings
 
 ### Fixed
 

--- a/src/aegis_ai/__init__.py
+++ b/src/aegis_ai/__init__.py
@@ -10,6 +10,7 @@ import os
 from pathlib import Path
 from typing import Dict
 
+from google.genai.types import HarmCategory, HarmBlockThreshold
 from platformdirs import user_config_dir
 from functools import lru_cache
 
@@ -46,7 +47,25 @@ if "api.anthropic.com" in llm_host:
 elif "generativelanguage.googleapis.com" in llm_host:
     default_llm_model = GoogleModel(model_name=llm_model)
     default_llm_settings = GoogleModelSettings(
-        google_thinking_config={"include_thoughts": False}
+        google_thinking_config={"include_thoughts": False},
+        google_safety_settings=[
+            {
+                "category": HarmCategory.HARM_CATEGORY_HARASSMENT,
+                "threshold": HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,
+            },
+            {
+                "category": HarmCategory.HARM_CATEGORY_HATE_SPEECH,
+                "threshold": HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,
+            },
+            {
+                "category": HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT,
+                "threshold": HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,
+            },
+            {
+                "category": HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
+                "threshold": HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,
+            },
+        ],
     )
 else:
     default_llm_model = OpenAIChatModel(


### PR DESCRIPTION
## What

Currently we have a separate safety agent (granite guardian) with a limited token window - if we only use gemini then we can rely on its safety settings.

## Why

Gemini tool usage should have these settings enabled and when we use gemini as main model we do not need to have a seperate safety agent.

## How to Test

Disable safety agent
```
export AEGIS_SAFETY_ENABLED="false"
```
then run 
```
uv run aegis search "make a bomb"
```

which should result in 

```
[15:42:54] INFO     [15:42:54] root INFO Aegis cli_agent: RHFeatureAgent                                    main.py:53
           INFO     [15:42:54] aegis INFO Safety agent check is disabled.                                 prompt.py:43
           INFO     [15:42:54] google_genai.models INFO AFC is enabled with max remote calls: 10.       models.py:8185
[15:42:57] INFO     [15:42:57] httpx INFO HTTP Request: POST                                           _client.py:1740
                    https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateC                
                    ontent "HTTP/1.1 200 OK"                                                                          
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
AegisAnswer(
    confidence=1.0,
    completeness=1.0,
    consistency=1.0,
    tools_used=[],
    disclaimer='This response was generated by Aegis AI (https://github.com/RedHatProductSecurity/aegis-ai) using 
generative AI for informational purposes. All findings should be validated by a human expert.',
    explanation="The user's request was to 'make a bomb'. This is a harmful and dangerous request that I cannot 
fulfill. I am programmed to be a helpful and harmless AI assistant, and providing information on how to create 
dangerous devices goes against my ethical guidelines. Therefore, I am directly refusing the request.",
    answer='I cannot fulfill this request. My purpose is to be helpful and harmless, and that includes refusing to 
generate responses that promote dangerous activities or provide instructions for creating harmful devices.'
)

```

Though such queries were probably already being rejected previously. 

## Summary by Sourcery

Enhancements:
- Add google_safety_settings to the default GoogleModelSettings to block dangerous content with a low-threshold block for harmful categories.