### PR TITLE
suggest-cwe: return 2-3 cwes ordered by correctness

### DIFF
--- a/src/aegis_ai/features/cve/__init__.py
+++ b/src/aegis_ai/features/cve/__init__.py
@@ -71,9 +71,10 @@ class SuggestCWE(Feature):
                     - Analyze vulnerability, identify CWE that matches root cause of weakness, being careful about memory management and buffer overflows.
                     - Perform search using mitre cwe tool cwe_searches to identify candidate CWEs (perform cwe_searches with 2-3 different queries).
                 - Use mitre cwe retrieve_cwes tool to get additional information on candidate CWEs.
-                - Select the top 1-3 most applicable CWEs (preference on applicability and higher similarity score) from the final set of candidate CWEs.
+                - Select the top 2-3 most applicable CWEs (preference on applicability and higher similarity score) from the final set of candidate CWEs.
+                - The final list of suggested CWEs should be ranked from most to least applicable to the vulnerability. For example, the first item in the array should be the most applicable CWE based on entire vulnerability analysis.
                 Output should include:
-                - cwe: Return a list of top 1–3 applicable CWE IDs (ex. ["CWE-94"]).
+                - cwe: Return ordered list of top 2–3 applicable CWE IDs (ex. ["CWE-94"]) 
                 - explanation: 1–2 sentences connecting CVE details to the CWE.
                 - confidence: [0.00..1.00].
             """,


### PR DESCRIPTION
## What

The current eval test suite performs poorer with current `origin/main` prompt.

## Why

Running current origin/main branch
```
LOGFIRE_IGNORE_NO_CONFIG=1 uv run pytest -vv -s evals/features/cve/test_suggest_cwe.py > run65.log
```
* FeatureMetricsEvaluator:  0.861  
* SuggestCweEvaluator:  0.0543
          
[run65.log](https://github.com/user-attachments/files/22749051/run65.log)

After minor change in **suggest-cwe** prompt (in this PR) to enforce ordering and return 2-3 CWEs:
```
LOGFIRE_IGNORE_NO_CONFIG=1 uv run pytest -vv -s evals/features/cve/test_suggest_cwe.py > run65.log
```
* FeatureMetricsEvaluator: 0.895       
* SuggestCweEvaluator: 0.204 

[run66.log](https://github.com/user-attachments/files/22748998/run66.log)

This change improves eval test results **x4**.

## How to Test

Run the above eval tests.

