### PR TITLE
fix: use stable version string in stable container images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,5 @@
 .attic/
-docs/
 etc
-src/aegis_ai_ml
 
 
 # Environment
@@ -30,9 +28,6 @@ htmlcov/
 dist/
 build/
 *.egg-info/
-
-# Git
-.gitignore
 
 # Compiled files
 __pycache__/

--- a/Containerfile
+++ b/Containerfile
@@ -56,8 +56,8 @@ RUN pip3 install --no-cache-dir gssapi uv \
         "$(uv run python -c 'import aegis_ai; print(aegis_ai.__version__)')" \
     | tee -a pyproject.toml
 
-# remove git repo after the version string is initialized
-RUN rm -fr .git
+# remove git repo (and files maintained in it) after the version string is initialized
+RUN rm -fr .git docs src/aegis_ai_ml
 
 RUN chgrp -R 0 /opt/app-root && \
     chmod -R g=u /opt/app-root

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1]
+
+### Fixed
+- use stable version string in stable container images
+
 ## [0.3.0] - 2025-10-10
 
 ### Added


### PR DESCRIPTION
## What
fix: use stable version string in stable container images

## Why
Some files maintained in the repo were excluded due to `.dockerignore`. This made `hatch-vcs` see uncommitted changes, which caused an unstable version string to be produced in the stable container image.

We need to remove these files after the version string is initialized.

## How to Test
See the version string in the container image produced on the next stable release.

## Related Tickets
Related: https://issues.redhat.com/browse/AEGIS-198

## Summary by Sourcery

Fix the container build process to produce a stable version string by removing the git repository and related files after version initialization and update the changelog.

Bug Fixes:
- Ensure stable container images use a stable version string by cleaning up all repo files before build

Documentation:
- Add 0.3.1 fix entry to CHANGELOG