### PR TITLE
fix: trigger build of the FAISS index before starting the web service

### DIFF
--- a/scripts/run_web_service.sh
+++ b/scripts/run_web_service.sh
@@ -1,3 +1,7 @@
-#!/usr/bin/env bash
+#!/bin/bash -x
 
+# trigger build of the FAISS index
+uv run aegis suggest-cwe CVE-2025-23395
+
+# run the web service
 uv run uvicorn aegis_ai_web.src.main:app --port 9000 --loop uvloop --http httptools --host 0.0.0.0


### PR DESCRIPTION
## What
Trigger build of the FAISS index before starting the web service.

## Why
This ensures there will be no excessive delays in Aegis responses after rollout in OpenShift (because the routing to the new pod will not be updated until the FAISS index is built).

## How to Test
Once the web service is started, it should respond to the very first API call without an excessive delay.

## Related Tickets
Related: https://issues.redhat.com/browse/AEGIS-205

## Summary by Sourcery

Build the FAISS index before launching the web service to eliminate first-request delays and enable debug logging in the startup script.

Enhancements:
- Pre-trigger the FAISS index build via uv run aegis suggest-cwe before starting the web service
- Update the run_web_service.sh shebang to /bin/bash -x for startup script debugging