### PR TITLE
chore: eliminate unneeded dependencies in the container image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,4 @@
-# TODO: consider using the ubi10-minimal to reduce size of the output image
-FROM registry.access.redhat.com/ubi10:10.0-1758699521
+FROM registry.access.redhat.com/ubi10-minimal:10.0-1758699349
 
 LABEL summary="AEGIS" \
       maintainer="Product Security DevOps <prodsec-dev@redhat.com>"
@@ -15,28 +14,19 @@ ENV PYTHONUNBUFFERED=1 \
 
 EXPOSE 9000
 
-# install dependencies and security updates
-# FIXME: remove unneeded dependencies from the list (see Containerfile.eval)
-RUN dnf --nodocs --setopt install_weak_deps=false -y install \
-    cargo \
+# install dependencies and updates
+RUN microdnf --nodocs --setopt install_weak_deps=0 -y install \
     gcc \
-    git \
+    git-core \
     krb5-devel \
     krb5-workstation \
-    libffi-devel \
-    logrotate \
     make \
-    openldap-devel \
     openssl-devel \
-    podman \
-    postgresql-devel \
-    procps-ng \
     python3-devel \
     python3-pip \
     redhat-rpm-config \
-    which \
-    && dnf --nodocs --setopt install_weak_deps=false -y upgrade --security \
-    && dnf clean all
+    && microdnf --nodocs --setopt install_weak_deps=0 -y upgrade \
+    && microdnf clean all
 
 # create a non-privileged user
 RUN useradd -d /opt/app-root -g 0 -m aegis


### PR DESCRIPTION
## What
Eliminate unneeded OS-level dependencies in the container image.

## Why
This reduces the image size by ~200 MiB.  Moreover, this reduces the security footprint, which is important for the `SEC-PATCH-REQ-2` ESS control (OS Patching).

## How to Test
- Check the resulting image size.
- Check that everything works as before.

## Related Tickets
Related: https://issues.redhat.com/browse/AEGIS-78

## Summary by Sourcery

Reduce container image size and security footprint by switching to a minimal base image, replacing dnf with microdnf, and removing unnecessary OS-level dependencies.

Enhancements:
- Switch to UBI minimal base image to shrink the built image by ~200 MiB
- Replace dnf with microdnf for package installation and upgrades
- Remove unneeded OS-level packages from the installation list
- Clean up package manager cache after upgrades

Tests:
- Verify resulting image size reduction and confirm application functionality remains unchanged