### PR TITLE
fix: increase timeout for build of the FAISS index

### DIFF
--- a/scripts/run_web_service.sh
+++ b/scripts/run_web_service.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -x
 
 # trigger build of the FAISS index
-uv run aegis suggest-cwe CVE-2025-23395
+AEGIS_LLM_TIMEOUT_SECS=900 uv run aegis suggest-cwe CVE-2025-23395
 
 # run the web service
 uv run uvicorn aegis_ai_web.src.main:app --port 9000 --loop uvloop --http httptools --host 0.0.0.0


### PR DESCRIPTION
## What
increase timeout for build of the FAISS index

## Why

I was unable to start the `aegis-ai-web-service` pod properly in the stage environment.  Both the replicas hit the 300s overall LLM prompt timeout on startup:
```
+ uv run aegis suggest-cwe CVE-2025-23395
   Building aegis-ai @ file:///opt/app-root
      Built aegis-ai @ file:///opt/app-root
Uninstalled 1 package in 2ms
Installed 1 package in 3ms
2025-10-24 11:53:43 [INFO] Aegis cli_agent: PublicFeatureAgent (src/aegis_ai_cli/main.py:53)
2025-10-24 11:53:43 [INFO] SuggestCWE(CVE-2025-23395) = ? (src/aegis_ai/features/__init__.py:31)
2025-10-24 11:53:48 [INFO] HTTP Request: POST https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent "HTTP/1.1 200 OK" (.venv/lib/python3.13/site-packages/httpx/_client.py:1740)
2025-10-24 11:53:48 [INFO] [tool call] osv_dev_cve_tool(cve_id='CVE-2025-23395') started (src/aegis_ai/toolsets.py:45)
2025-10-24 11:53:48 [INFO] Looking up osv.dev vulnerability for CVE-2025-23395... (src/aegis_ai/tools/osvdev/__init__.py:171)
Querying for vulnerability ID: CVE-2025-23395
2025-10-24 11:53:48 [INFO] [tool call] osv_dev_cve_tool(cve_id='CVE-2025-23395') finished after 0.1677s (src/aegis_ai/toolsets.py:51)
2025-10-24 11:53:51 [INFO] HTTP Request: POST https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent "HTTP/1.1 200 OK" (.venv/lib/python3.13/site-packages/httpx/_client.py:1740)
2025-10-24 11:53:51 [INFO] [tool call] mitre_cwe_search_cwes(query='privilege escalation setuid root') started (src/aegis_ai/toolsets.py:45)
2025-10-24 11:53:51 [INFO] Loading sentence-transformer model: all-mpnet-base-v2 (src/aegis_ai/tools/cwe/__init__.py:64)
2025-10-24 11:53:51 [INFO] Use pytorch device_name: cpu (.venv/lib/python3.13/site-packages/sentence_transformers/SentenceTransformer.py:219)
2025-10-24 11:53:51 [INFO] Load pretrained SentenceTransformer: all-mpnet-base-v2 (.venv/lib/python3.13/site-packages/sentence_transformers/SentenceTransformer.py:227)
2025-10-24 11:53:54 [INFO] No CWE definitions file found. Fetching from MITRE. (src/aegis_ai/tools/cwe/__init__.py:164)
2025-10-24 11:53:54 [INFO] Fetching CWE definitions from 'https://cwe.mitre.org/data/csv/699.csv.zip'... (src/aegis_ai/tools/cwe/__init__.py:77)
2025-10-24 11:53:54 [INFO] HTTP Request: GET https://cwe.mitre.org/data/csv/699.csv.zip "HTTP/1.1 200 OK" (.venv/lib/python3.13/site-packages/httpx/_client.py:1740)
2025-10-24 11:53:54 [INFO] Writing CWE definitions to '/tmp/aegis_ai/mitre_cwe/cwe_full_defs.json'. (src/aegis_ai/tools/cwe/__init__.py:166)
2025-10-24 11:53:54 [INFO] Building and caching new FAISS vector index... (src/aegis_ai/tools/cwe/__init__.py:117)
2025-10-24 11:53:54 [INFO] Generating embeddings for 399 CWEs. This may take a moment... (src/aegis_ai/tools/cwe/__init__.py:126)
2025-10-24 11:58:43 [WARNING] SuggestCWE(CVE-2025-23395): LLM request timed out after 300 seconds (src/aegis_ai/features/__init__.py:44)
Traceback (most recent call last):
  File "/opt/app-root/.local/share/uv/python/cpython-3.13.9-linux-x86_64-gnu/lib/python3.13/asyncio/tasks.py", line 507, in wait_for
    return await fut
           ^^^^^^^^^
  File "/opt/app-root/.venv/lib/python3.13/site-packages/pydantic_ai/agent/abstract.py", line 235, in run
    async for node in agent_run:
    ...<4 lines>...
                await event_stream_handler(_agent_graph.build_run_context(agent_run.ctx), stream)
  File "/opt/app-root/.venv/lib/python3.13/site-packages/pydantic_ai/run.py", line 150, in __anext__
    next_node = await self._graph_run.__anext__()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/.venv/lib/python3.13/site-packages/pydantic_graph/graph.py", line 758, in __anext__
    return await self.next(self._next_node)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/.venv/lib/python3.13/site-packages/pydantic_graph/graph.py", line 731, in next
    self._next_node = await node.run(ctx)
                      ^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/.venv/lib/python3.13/site-packages/pydantic_ai/_agent_graph.py", line 539, in run
    async with self.stream(ctx):
               ~~~~~~~~~~~^^^^^
  File "/opt/app-root/.local/share/uv/python/cpython-3.13.9-linux-x86_64-gnu/lib/python3.13/contextlib.py", line 221, in __aexit__
    await anext(self.gen)
  File "/opt/app-root/.venv/lib/python3.13/site-packages/pydantic_ai/_agent_graph.py", line 553, in stream
    async for _event in stream:
        pass
  File "/opt/app-root/.venv/lib/python3.13/site-packages/pydantic_ai/_agent_graph.py", line 667, in _run_stream
    async for event in self._events_iterator:
        yield event
  File "/opt/app-root/.venv/lib/python3.13/site-packages/pydantic_ai/_agent_graph.py", line 628, in _run_stream
    async for event in self._handle_tool_calls(ctx, tool_calls):
        yield event
  File "/opt/app-root/.venv/lib/python3.13/site-packages/pydantic_ai/_agent_graph.py", line 683, in _handle_tool_calls
    async for event in process_tool_calls(
    ...<8 lines>...
        yield event
  File "/opt/app-root/.venv/lib/python3.13/site-packages/pydantic_ai/_agent_graph.py", line 880, in process_tool_calls
    async for event in _call_tools(
    ...<9 lines>...
        yield event
  File "/opt/app-root/.venv/lib/python3.13/site-packages/pydantic_ai/_agent_graph.py", line 1007, in _call_tools
    done, pending = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/.local/share/uv/python/cpython-3.13.9-linux-x86_64-gnu/lib/python3.13/asyncio/tasks.py", line 451, in wait
    return await _wait(fs, timeout, return_when, loop)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/.local/share/uv/python/cpython-3.13.9-linux-x86_64-gnu/lib/python3.13/asyncio/tasks.py", line 537, in _wait
    await waiter
asyncio.exceptions.CancelledError

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/app-root/src/aegis_ai/features/__init__.py", line 40, in run_if_safe
    result = await asyncio.wait_for(runner, timeout=llm_prompt_timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/.local/share/uv/python/cpython-3.13.9-linux-x86_64-gnu/lib/python3.13/asyncio/tasks.py", line 506, in wait_for
    async with timeouts.timeout(timeout):
               ~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/opt/app-root/.local/share/uv/python/cpython-3.13.9-linux-x86_64-gnu/lib/python3.13/asyncio/timeouts.py", line 116, in __aexit__
    raise TimeoutError from exc_val
TimeoutError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/app-root/.venv/bin/aegis", line 10, in <module>
    sys.exit(aegis_cli())
             ~~~~~~~~~^^
  File "/opt/app-root/.venv/lib/python3.13/site-packages/click/core.py", line 1462, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/opt/app-root/.venv/lib/python3.13/site-packages/click/core.py", line 1383, in main
    rv = self.invoke(ctx)
  File "/opt/app-root/.venv/lib/python3.13/site-packages/click/core.py", line 1850, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/opt/app-root/.venv/lib/python3.13/site-packages/click/core.py", line 1246, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/.venv/lib/python3.13/site-packages/click/core.py", line 814, in invoke
    return callback(*args, **kwargs)
  File "/opt/app-root/src/aegis_ai_cli/main.py", line 139, in suggest_cwe
    result = asyncio.run(_doit())
  File "/opt/app-root/.local/share/uv/python/cpython-3.13.9-linux-x86_64-gnu/lib/python3.13/asyncio/runners.py", line 195, in run
    return runner.run(main)
           ~~~~~~~~~~^^^^^^
  File "/opt/app-root/.local/share/uv/python/cpython-3.13.9-linux-x86_64-gnu/lib/python3.13/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/opt/app-root/.local/share/uv/python/cpython-3.13.9-linux-x86_64-gnu/lib/python3.13/asyncio/base_events.py", line 725, in run_until_complete
    return future.result()
           ~~~~~~~~~~~~~^^
  File "/opt/app-root/src/aegis_ai_cli/main.py", line 137, in _doit
    return await feature.exec(cve_id)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/src/aegis_ai/features/cve/__init__.py", line 86, in exec
    return await self.run_if_safe(prompt, output_type=SuggestCWEModel)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/src/aegis_ai/features/__init__.py", line 45, in run_if_safe
    raise RuntimeError(msg)
RuntimeError: SuggestCWE(CVE-2025-23395): LLM request timed out after 300 seconds
```

## How to Test
Trigger deployment on the stage environment.

## Related Tickets
Realted: https://issues.redhat.com/browse/AEGIS-189
Related: https://github.com/RedHatProductSecurity/aegis-ai/pull/266

## Summary by Sourcery

Bug Fixes:
- Set AEGIS_LLM_TIMEOUT_SECS to 900 seconds when running suggest-cwe in run_web_service.sh to avoid the default 300s timeout during FAISS index construction