### PR TITLE
enhance: read the `AEGIS_CORS_TARGET_REGEX` env var

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - simplified `AegisFeatureModel` to reduce LLM overhead
 - refactored agents and toolsets internals
 - renamed `rewrite-{description,statement}` to `suggest-{description,statement}`, respectively
+- `AEGIS_CORS_TARGET_URL` was replaced by `AEGIS_CORS_TARGET_REGEX` to support multiple CORS origins
 
 ### Added
 - added `/healthz` endpoint of the web server without authentication and logging

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -23,7 +23,7 @@
 | `AEGIS_WEB_FEATURE_AGENT`  | Set to `redhat` to use rh profile         | `public`                          |
 | `AEGIS_WEB_SPN`            | Service Principal Name for Kerberos auth  |                                   |
 | `KRB5_KTNAME`              | Path to the keytab file for Kerberos auth | `/etc/krb5.keytab`                |
-| `AEGIS_CORS_TARGET_URL`    | CORS origin url                           | `http://localhost:5173`           |
+| `AEGIS_CORS_TARGET_REGEX`  | CORS origin URLs specified by a regex     | `http(s)?://localhost(:5173)?"`   |
 | `AEGIS_WEB_FEEDBACK_LOG`    | Feedback log file                         | `~/.config/aegis_ai/feedback.log` |
 | `AEGIS_WEB_ENABLE_CONSOLE`  | Enable web console                        | `false`                            |
 

--- a/src/aegis_ai_web/src/main.py
+++ b/src/aegis_ai_web/src/main.py
@@ -85,18 +85,13 @@ if kerberos_spn:
     app.add_middleware(CustomGSSAPIMiddleware, spn=kerberos_spn)
 
 # middleware enabling CORS
-cors_target_url = os.getenv("AEGIS_CORS_TARGET_URL", "http://localhost:5173")
-origins = [
-    cors_target_url,
-    "https://localhost",
-    "https://localhost:5173",
-]
+cors_target_regex = os.getenv("AEGIS_CORS_TARGET_REGEX", "http(s)?://localhost(:5173)?")
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=origins,
-    allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
+    allow_credentials=True,
+    allow_origin_regex=cors_target_regex,
 )
 
 BASE_DIR = Path(__file__).parent


### PR DESCRIPTION
## What
Read the `AEGIS_CORS_TARGET_REGEX` env var.

Also do not accept `https://localhost` and `https://localhost:5173` when `AEGIS_CORS_TARGET_REGEX` is set to a regex that does not match these URLs.

## Why
So that one can specify multiple URLs as CORS origins, such as:
```
export AEGIS_CORS_TARGET_REGEX='https://osim-(stage|uat)\.example\.com'
```

## How to Test
Specify multiple CORS target URLs as outlined above.

## Related Tickets
Related: https://issues.redhat.com/browse/AEGIS-230