### PR TITLE
chore: record 0.4.0 release date in `CHANGELOG.md`

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [0.4.0] - not yet released
+## [0.4.0] - 2025-11-04
 
 ### Changed
 - web console disabled by default


### PR DESCRIPTION
## What
Record 0.4.0 release date in `CHANGELOG.md`.

## Why
So that `aegis-0.4.0` can be released, as described in [DEVELOP.md](https://github.com/RedHatProductSecurity/aegis-ai/blob/ea71ac48e530e58bfe4ec6e011caadd45334211d/DEVELOP.md#publishing--releasing).

## How to Test
Check for typos, copy/paste errors, and similar mistakes in the change log.

## Related Tickets
Related: https://github.com/RedHatProductSecurity/aegis-ai/pull/301
Related: https://issues.redhat.com/browse/AEGIS-125

## Summary by Sourcery

Documentation:
- Specify the release date for version 0.4.0 in CHANGELOG.md