### PR TITLE
fix: print log messages to `stderr` in CLI

### DIFF
--- a/src/aegis_ai/__init__.py
+++ b/src/aegis_ai/__init__.py
@@ -186,6 +186,11 @@ def config_logging(level="INFO"):
         logger = logging.getLogger(logger_name)
         logger.setLevel(level)
 
+        if not logger.handlers:
+            # if no handlers are configured, use the basic logging handler
+            handler = logging.StreamHandler()
+            logging.basicConfig(level=level, handlers=[handler])
+
         # avoid duplicated uvicorn log messages
         if logger_name != "uvicorn":
             # Optional log file path: write to one file for root and uvicorn loggers
@@ -193,11 +198,6 @@ def config_logging(level="INFO"):
             if log_file_path:
                 file_handler = logging.FileHandler(log_file_path)
                 logger.addHandler(file_handler)
-
-        if not logger.handlers:
-            # if no handlers are configured, use the basic logging handler
-            handler = logging.StreamHandler()
-            logging.basicConfig(level=level, handlers=[handler])
 
         for handler in logger.handlers:
             # enable colors if connected to a TTY


### PR DESCRIPTION
## What
Print log messages to `stderr` in CLI even when the `AEGIS_LOG_FILE` environment variable is set.

## Why
The code to handle the logging to file was accidentally misplaced in commit 22eefbf9b7dddaf77a4329f72a5c1fb6842c7655.

## How to Test
The following command should print log messages to both `stderr` and `aegis-cli.log`:
```
AEGIS_LOG_FILE=./aegis-cli.log uv run aegis suggest-cwe CVE-2025-23395
```

## Related Tickets
Related: https://issues.redhat.com/browse/AEGIS-65

## Summary by Sourcery

Fix logging configuration in the CLI to always emit logs to stderr alongside file output

Bug Fixes:
- Ensure CLI log messages are printed to stderr even when AEGIS_LOG_FILE is set

Enhancements:
- Reorder logging handler configuration to set up stderr StreamHandler before file handlers