### PR TITLE
chore: include `tar` binary in the container image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -25,6 +25,7 @@ RUN microdnf --nodocs --setopt install_weak_deps=0 -y install \
     python3-devel \
     python3-pip \
     redhat-rpm-config \
+    tar \
     && microdnf --nodocs --setopt install_weak_deps=0 -y upgrade \
     && microdnf clean all
 


### PR DESCRIPTION
## What
Include `tar` binary in the `aegis-ai` container image.

## Why
This is needed if we want to use the running container to export files from the mounted Persistent Volume, e.g. with `oc cp`, which currently fails:
```
% oc cp aegis-ai-web-service-cfb6b7d8d-jn5vd:/opt/app-data .
time="2025-11-06T16:15:02Z" level=error msg="exec failed: unable to start container process: exec: \"tar\": executable file not found in $PATH"
command terminated with exit code 255
```

## How to Test
Check that `tar` can be executed in the resulting container image.

## Related Tickets
Related: https://issues.redhat.com/browse/AEGIS-65

## Summary by Sourcery

Build:
- Install tar in the Containerfile to support file extraction commands