### PR TITLE
evals: add forgotten fixture for `CVE-2022-50558`

### DIFF
--- a/evals/osidb_cache/CVE-2022-50558.json
+++ b/evals/osidb_cache/CVE-2022-50558.json
@@ -1,0 +1,332 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2022-50558",
+    "title": "regmap-irq: Use the new num_config_regs property in regmap_add_irq_chip_fwnode",
+    "statement": "",
+    "comment_zero": "In the Linux kernel, the following vulnerability has been resolved:\n\nregmap-irq: Use the new num_config_regs property in regmap_add_irq_chip_fwnode\n\nCommit faa87ce9196d (\"regmap-irq: Introduce config registers for irq\ntypes\") added the num_config_regs, then commit 9edd4f5aee84 (\"regmap-irq:\nDeprecate type registers and virtual registers\") suggested to replace\nnum_type_reg with it. However, regmap_add_irq_chip_fwnode wasn't modified\nto use the new property. Later on, commit 255a03bb1bb3 (\"ASoC: wcd9335:\nConvert irq chip to config regs\") removed the old num_type_reg property\nfrom the WCD9335 driver's struct regmap_irq_chip, causing a null pointer\ndereference in regmap_irq_set_type when it tried to index d->type_buf as\nit was never allocated in regmap_add_irq_chip_fwnode:\n\n[   39.199374] Unable to handle kernel NULL pointer dereference at virtual address 0000000000000000\n\n[   39.200006] Call trace:\n[   39.200014]  regmap_irq_set_type+0x84/0x1c0\n[   39.200026]  __irq_set_trigger+0x60/0x1c0\n[   39.200040]  __setup_irq+0x2f4/0x78c\n[   39.200051]  request_threaded_irq+0xe8/0x1a0\n\nUse num_config_regs in regmap_add_irq_chip_fwnode instead of num_type_reg,\nand fall back to it if num_config_regs isn't defined to maintain backward\ncompatibility.",
+    "comments": "Upstream advisory:\nhttps://lore.kernel.org/linux-cve-announce/2025102206-CVE-2022-50558-444f@gregkh/T ",
+    "description": "",
+    "components": [
+        "kernel"
+    ],
+    "references": [
+        {
+            "url": "https://lore.kernel.org/linux-cve-announce/2025102206-CVE-2022-50558-444f@gregkh/T"
+        }
+    ],
+    "affects": [
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "rhel-6",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "kernel",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-7",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "kernel",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-7",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "kernel-rt",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-8",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "kernel",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-8",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "kernel",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-8",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "kernel",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-8",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "kernel",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-8",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "kernel",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-8",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "kernel-rt",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-8",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "kernel-rt",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-8",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "kernel-rt",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-8",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "kernel-rt",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-8",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "kernel-rt",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-9",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "kernel",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-9",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "kernel",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-9",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "kernel",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-9",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "kernel",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-9",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "kernel",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-9",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "kernel",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-9",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "kernel",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-9",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "kernel-rt",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-9",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "kernel-rt",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-9",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "kernel-rt",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-9",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "kernel-rt",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-9",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "kernel-rt",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-9",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "kernel-rt",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-9",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "kernel-rt",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "rhel-10",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "kernel",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "rhel-10",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "kernel",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "rhel-10",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "kernel",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "rhel-10",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "kernel",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhivos-1",
+            "ps_product": "Red Hat In-Vehicle OS",
+            "ps_component": "kernel",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhivos-1",
+            "ps_product": "Red Hat In-Vehicle OS",
+            "ps_component": "kernel",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhivos-1",
+            "ps_product": "Red Hat In-Vehicle OS",
+            "ps_component": "kernel",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        }
+    ],
+    "cvss_scores": [
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:L/AC:H/PR:H/UI:N/S:U/C:N/I:N/A:H"
+        }
+    ]
+}


### PR DESCRIPTION
## What
evals: add forgotten fixture for `CVE-2022-50558`

## Why
... so that OSIDB access is not needed for the evaluation suite.

## How to Test
The following case failure disappears in the evaluation log in CI:
```
                                                                   Case Failures                                                                    
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Case ID                        ┃ Inputs         ┃ Error Message                                                                                  ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ suggest-cwe-for-CVE-2022-50558 │ CVE-2022-50558 │ ValueError: Could not retrieve CVE-2022-50558 'OSIDBClient' object has no attribute '_session' │
└────────────────────────────────┴────────────────┴────────────────────────────────────────────────────────────────────────────────────────────────┘
```

## Related Tickets
Fixes: commit 8d695703bb1227f7df4f2b8cf1583a4ddf7b15f1

## Summary by Sourcery

Tests:
- Add new CVE-2022-50558.json fixture under evals/osidb_cache to support evaluation without OSIDBClient