### PR TITLE
chore: fix a type error in the `safety` module

### DIFF
--- a/src/aegis_ai/agents/safety.py
+++ b/src/aegis_ai/agents/safety.py
@@ -1,11 +1,11 @@
 from pydantic_ai import Agent
-from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.models.openai import OpenAIChatModel, OpenAIResponsesModelSettings
 from pydantic_ai.providers.openai import OpenAIProvider
 
 from aegis_ai import get_settings
 from aegis_ai.data_models import SafetyReport
 
-default = Agent(  # type: ignore
+default = Agent(
     model=OpenAIChatModel(
         model_name=get_settings().safety_llm_model,
         provider=OpenAIProvider(
@@ -13,10 +13,9 @@ default = Agent(  # type: ignore
             api_key=get_settings().safety_llm_openapi_key,
         ),
     ),
-    model_settings={
-        "seed": 42,
-        "response_format": {"type": "json_object"},
-    },
+    model_settings=OpenAIResponsesModelSettings(
+        seed=42,
+    ),
     system_prompt=f"""
         You are Granite Guardian, an AI safety and security analyst. Your sole function is to
         analyze a user-submitted prompt and determine if it could lead to harmful, unethical,


### PR DESCRIPTION
## What
Fix a type error in the `safety` module instead of suppressing it by an inline annotation.

## Why
This will re-enable type checking for this part of the code.

## How to Test
See the CI results.

## Related Tickets
Related: https://issues.redhat.com/browse/AEGIS-78

## Summary by Sourcery

Enable static type checking in the safety module by replacing the suppressed inline annotation and dict-based settings with the OpenAIResponsesModelSettings class.

Bug Fixes:
- Fix type error in safety module by replacing inline type suppression with the proper model settings class

Enhancements:
- Import and use OpenAIResponsesModelSettings for Agent.model_settings instead of a plain dict