### PR TITLE
chore: run up to 16 LLM prompts concurrently in Konflux CI

### DIFF
--- a/.tekton/aegis-build-pipeline.yaml
+++ b/.tekton/aegis-build-pipeline.yaml
@@ -686,6 +686,8 @@ spec:
                   value: "https://generativelanguage.googleapis.com"
                 - name: AEGIS_LLM_MODEL
                   value: "gemini-2.5-flash"
+                - name: AEGIS_LLM_MAX_JOBS
+                  value: "16"
                 # FIXME: this should be removed once we have (more) reliable evals
                 - name: AEGIS_EVALS_MIN_PASSED
                   value: "5"


### PR DESCRIPTION
## What
Run up to 16 LLM prompts concurrently in Konflux CI.

## Why
This will help to deliver evaluation suite results in the CI faster.

## How to Test
See the CI results.

## Related Tickets
Related: https://issues.redhat.com/browse/AEGIS-183

## Summary by Sourcery

CI:
- Add AEGIS_LLM_MAX_JOBS environment variable to configure up to 16 concurrent LLM prompts