### PR TITLE
chore: update `CHANGELOG.md` for the upcoming 0.4.3 release

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,14 +4,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### Added
-- added `AEGIS_LLM_TEMPERATURE`,`AEGIS_LLM_TOP_P` and `AEGIS_LLM_MAX_TOKENS` env var.
+## [0.4.3] - 2025-11-25
 
 ### Changed
-- bump to pydantic-evals,pydantic-ai 1.20.0
-- dynamic filtering of CVE data - using data deps injection with `osidb_tool`.
-- dynamic filtering of CVE data when supplied direct with static content.
-- enhanced `suggest-statement` analysis feature.
+- bump to pydantic-evals,pydantic-ai 1.22.0
+- dynamic filtering of CVE data - using data dependencies injection with `osidb_tool`
+- dynamic filtering of CVE data when supplied direct with static content
+- enhanced `suggest-statement` analysis feature to also suggest `mitigation`
+- increased `AEGIS_LLM_INPUT_TOKENS_WARN_THR` to 65536
+
+### Added
+- added `AEGIS_LLM_TEMPERATURE`, `AEGIS_LLM_TOP_P`, and `AEGIS_LLM_MAX_TOKENS` env vars
+- retry the prompt with a gradually increasing delay on an internal failure of the LLM provider
+- added evaluation cases based on the feedback from security analysts
+- `suggest-description` now expands all acronyms used in the description
+
+### Fixed
+- `title` and `description` are now more consistent with each other in `suggest-description`
+
 
 ## [0.4.2] - 2025-11-14
 


### PR DESCRIPTION
## What
Update `CHANGELOG.md` for the 0.4.3 release.

## Why
So that `aegis-0.4.3` can be released, as described in [DEVELOP.md](https://github.com/RedHatProductSecurity/aegis-ai/blob/ea71ac48e530e58bfe4ec6e011caadd45334211d/DEVELOP.md#publishing--releasing).

## How to Test
Check for typos, copy/paste errors, and similar mistakes in the change log.

## Related Tickets
Depends-on: https://github.com/RedHatProductSecurity/aegis-ai/pull/351
Depends-on: https://github.com/RedHatProductSecurity/aegis-ai/pull/355
Related: https://issues.redhat.com/browse/AEGIS-250
Related: https://issues.redhat.com/browse/AEGIS-251

## Summary by Sourcery

Prepare changelog entries for the 0.4.3 release, documenting recent behavioral changes and improvements.

New Features:
- Document new environment variables controlling LLM behavior and added retry logic on internal LLM provider failures.
- Record new evaluation cases and enhancements to description and mitigation suggestion features.

Bug Fixes:
- Note improved consistency between generated titles and descriptions in suggest-description.

Enhancements:
- Update documented dependency versions and configuration thresholds, including LLM token warning limits, and refine suggest-statement behavior.

Documentation:
- Update CHANGELOG.md with a new 0.4.3 section summarizing changes, additions, and fixes since 0.4.2.