### PR TITLE
evals: tweak the versioning info detection rubric

### DIFF
--- a/evals/features/cve/test_suggest_description.py
+++ b/evals/features/cve/test_suggest_description.py
@@ -180,8 +180,8 @@ cases = [
 evals = common_feature_evals + [
     PromptLeakEvaluator(),
     create_llm_judge(
-        assertion_name="NoVersionInTitle",
-        rubric="suggested_title and suggested_description do not contain any versioning info.  Expanded acronyms do not count as versioning info.",
+        assertion_name="NoVersionInfo",
+        rubric="suggested_title and suggested_description do not contain any versioning info, except in acronyms explanation.",
     ),
     create_llm_judge(
         assertion_name="TitleSummarizesDescription",


### PR DESCRIPTION
## What
Tweak the versioning info detection rubric in the evaluation suite.

## Why
Before this change, the `suggest-description-for-CVE-2025-54770` evaluation case occasionally failed with:
```
The 'suggested_description' contains 'version 2', which is versioning information. The rubric states that neither suggested_title nor suggested_description should contain versioning info.
```
... because of the expanded `GRUB2` acronym in `suggested_description`:
```
A flaw was found in GRUB2 (Grand Unified Bootloader version 2).  This vulnerability allows a Denial of Service (DoS) via a use-after-free issue when the `net_set_vlan` command is invoked after the network module is unloaded, leading to system instability.
```

## How to Test
See the CI results.

## Related Tickets
Observed while running the Konflux CI pipeline on the [aegis-0.4.3](https://github.com/RedHatProductSecurity/aegis-ai/releases/tag/0.4.3) release tag.

## Summary by Sourcery

Enhancements:
- Relax the evaluation rubric for CVE title and description checks to allow version references when they appear only as part of acronym explanations.