### PR TITLE
enhance: log each HTTP request before it is initiated

### DIFF
--- a/src/aegis_ai/__init__.py
+++ b/src/aegis_ai/__init__.py
@@ -3,12 +3,13 @@ aegis
 
 """
 
+import httpx
 import logging
 import os
 import sys
 
 from pathlib import Path
-from typing import Dict, List, Any, Optional
+from typing import Dict, List, Any, Optional, TypedDict
 
 from google.genai.types import (
     HarmCategory,
@@ -30,7 +31,9 @@ from _pytest._io import TerminalWriter
 from _pytest.logging import ColoredLevelFormatter
 
 from pydantic_ai.models.openai import OpenAIChatModel, OpenAIResponsesModelSettings
+from pydantic_ai.providers.google import GoogleProvider
 from pydantic_ai.providers.openai import OpenAIProvider
+from pydantic_ai.providers.anthropic import AnthropicProvider
 
 load_dotenv()
 
@@ -87,6 +90,12 @@ class LivenessProbeLogFilter(logging.Filter):
         return args[1:] != ("GET", "/healthz", "1.1", 204)
 
 
+class _ProviderKwargs(TypedDict):
+    """named args of AI Providers"""
+
+    http_client: httpx.AsyncClient
+
+
 class AppSettings(BaseSettings):
     app_name: str = APP_NAME
     app_version: str = __version__
@@ -134,6 +143,25 @@ class AppSettings(BaseSettings):
 
     # shared kwargs for model settings usage across the codebase
     model_kwargs: Dict[str, Any] = Field(default_factory=dict)
+
+    # customized httpx.AsyncClient with enhanced logging
+    http_client: Optional[httpx.AsyncClient] = Field(
+        default=None, exclude=True, repr=False
+    )
+
+    def _get_http_client(self) -> httpx.AsyncClient:
+        """customized httpx.AsyncClient with enhanced logging"""
+        if self.http_client is None:
+            # create the object only once
+            async def _log_request(request: httpx.Request) -> None:
+                msg = f'HTTP Request: {request.method} {request.url} "sending request"'
+                logger.info(msg)
+
+            self.http_client = httpx.AsyncClient(
+                event_hooks={"request": [_log_request]}
+            )
+
+        return self.http_client
 
     @model_validator(mode="after")
     def configure_llm_provider_settings(self):
@@ -183,6 +211,10 @@ class AppSettings(BaseSettings):
             self.default_llm_settings = OpenAIResponsesModelSettings(
                 **self.model_kwargs
             )
+
+        # eagerly create the shared HTTP client to avoid race on first use
+        _ = self._get_http_client()
+
         return self
 
     @property
@@ -193,17 +225,27 @@ class AppSettings(BaseSettings):
 
         host = self.default_llm_host
 
+        provider_kwargs: _ProviderKwargs = {
+            "http_client": self._get_http_client(),
+        }
+
         if "api.anthropic.com" in host:
-            return AnthropicModel(model_name=self.default_llm_model_name)
+            return AnthropicModel(
+                model_name=self.default_llm_model_name,
+                provider=AnthropicProvider(**provider_kwargs),
+            )
 
         elif "generativelanguage.googleapis.com" in host:
             logger.info(f"model_name: {self.default_llm_model_name}")
-            return GoogleModel(model_name=self.default_llm_model_name)
+            return GoogleModel(
+                model_name=self.default_llm_model_name,
+                provider=GoogleProvider(**provider_kwargs),
+            )
 
         else:
             return OpenAIChatModel(
                 model_name=self.default_llm_model_name,
-                provider=OpenAIProvider(base_url=f"{host}/v1/"),
+                provider=OpenAIProvider(base_url=f"{host}/v1/", **provider_kwargs),
             )
 
 

--- a/src/aegis_ai/agents/__init__.py
+++ b/src/aegis_ai/agents/__init__.py
@@ -28,7 +28,7 @@ def create_aegis_agent(**kwargs: Any) -> Agent:
         model_settings=get_settings().default_llm_settings
         | get_settings().model_kwargs
         | {
-            "seed": 42,
+            "seed": 42,  # FIXME: we should not hardcode the seed
             "response_format": {"type": "json_object"},
         },
         **kwargs,

--- a/src/aegis_ai/agents/safety.py
+++ b/src/aegis_ai/agents/safety.py
@@ -11,10 +11,11 @@ default = Agent(
         provider=OpenAIProvider(
             base_url=f"{get_settings().safety_llm_host}/v1/",
             api_key=get_settings().safety_llm_openapi_key,
+            http_client=get_settings()._get_http_client(),
         ),
     ),
     model_settings=OpenAIResponsesModelSettings(
-        seed=42,
+        seed=42,  # FIXME: we should not hardcode the seed
     ),
     system_prompt=f"""
         You are Granite Guardian, an AI safety and security analyst. Your sole function is to


### PR DESCRIPTION
## What
Log each HTTP request before it is initiated.

## Why
This way we can observe in the logs what we are waiting for in case Aegis is not progressing as expected and it seems to be hanging:
```
% uv run aegis suggest-statement CVE-2023-48795
2025-11-26 18:41:25 [INFO] Aegis version: 0.4.4.dev15+gc173b9aff (src/aegis_ai_cli/main.py:53)
2025-11-26 18:41:25 [INFO] Aegis cli_agent: RHFeatureAgent (src/aegis_ai_cli/main.py:54)
2025-11-26 18:41:25 [INFO] model_name: gemini-2.5-flash (src/aegis_ai/__init__.py:218)
2025-11-26 18:41:25 [INFO] SuggestStatementText(CVE-2023-48795) = ? (src/aegis_ai/features/__init__.py:61)
2025-11-26 18:41:25 [INFO] HTTP Request: POST https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent "sending request" (src/aegis_ai/__init__.py:148)
2025-11-26 18:41:27 [INFO] HTTP Request: POST https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent "HTTP/1.1 200 OK" (.venv/lib64/python3.13/site-packages/httpx/_client.py:1740)
2025-11-26 18:41:27 [INFO] [tool call] osidb_flaw_tool(cve_id='CVE-2023-48795') started (src/aegis_ai/toolsets/__init__.py:34)
2025-11-26 18:41:27 [INFO] retrieving CVE-2023-48795 from osidb (src/aegis_ai/toolsets/tools/osidb/__init__.py:77)
2025-11-26 18:41:27 [INFO] Retrieving raw flaw data for CVE-2023-48795 from OSIDB. (src/aegis_ai/toolsets/tools/osidb/osidb_client.py:26)
2025-11-26 18:41:32 [INFO] CVE-2023-48795:from collector (src/aegis_ai/toolsets/tools/osidb/__init__.py:92)
2025-11-26 18:41:32 [INFO] [tool call] osidb_flaw_tool(cve_id='CVE-2023-48795') finished after 4.8377s (src/aegis_ai/toolsets/__init__.py:40)
2025-11-26 18:41:32 [INFO] HTTP Request: POST https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent "sending request" (src/aegis_ai/__init__.py:148)
2025-11-26 18:41:50 [INFO] HTTP Request: POST https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent "HTTP/1.1 200 OK" (.venv/lib64/python3.13/site-packages/httpx/_client.py:1740)
2025-11-26 18:41:50 [INFO] SuggestStatementText(CVE-2023-48795) = [...] (src/aegis_ai/features/__init__.py:132)
```

## How to Test
See the CI logs.

## Related Tickets
Related: https://issues.redhat.com/browse/AEGIS-65

## Summary by Sourcery

Introduce a shared HTTP client with request logging for all LLM providers and wire it into the default and safety models.

New Features:
- Add a lazily-initialized shared httpx.AsyncClient with request logging hooks to capture outbound HTTP requests before they are sent.

Enhancements:
- Use the shared HTTP client across Anthropic, Google, OpenAI, and safety LLM providers to centralize HTTP behavior and avoid per-provider client construction.
- Eagerly initialize the shared HTTP client during LLM provider configuration to avoid first-use races.
- Annotate hardcoded model seeds with FIXME comments to highlight the need for future configurability.