### PR TITLE
Provide field for rejection explanation, change logging

### DIFF
--- a/src/aegis_ai_web/src/data_models.py
+++ b/src/aegis_ai_web/src/data_models.py
@@ -25,9 +25,10 @@ class Feedback(BaseModel):
     cve_id: Optional[CVEID] = Field("", max_length=50)
     email: Optional[str] = Field("", max_length=100)
     request_time: Optional[str] = Field("", max_length=50)
-    actual: Optional[str] = Field("", max_length=200)  # Increased for longer values
-    expected: Optional[str] = Field("", max_length=200)  # Increased for longer values
+    actual: Optional[str] = Field("", max_length=5000)  # Increased for longer values
+    expected: Optional[str] = Field("", max_length=5000)  # Increased for longer values
     accept: bool = Field(False)
+    rejection_comment: Optional[str] = Field("", max_length=5000)
 
 
 @dataclass(frozen=True)
@@ -59,6 +60,7 @@ class FeedbackSchema:
                 "expected",  # Expected value from user
                 "request_time",  # Original request timestamp
                 "accept",  # User acceptance (True/False)
+                "rejection_comment",  # Comment provided when rejecting the result
             ],
         )
 
@@ -127,6 +129,7 @@ class FeedbackSchema:
             "expected": "Expected value provided by the user",
             "request_time": "Timestamp of the original request",
             "accept": "Whether the user accepted the result (True/False)",
+            "rejection_comment": "Comment provided by the user when rejecting the result",
         }
         return descriptions.get(field_name)
 

--- a/src/aegis_ai_web/src/main.py
+++ b/src/aegis_ai_web/src/main.py
@@ -309,6 +309,7 @@ async def save_feedback(feedback: Feedback):
             "expected": feedback.expected or "",
             "request_time": feedback.request_time or "",
             "accept": str(feedback.accept),
+            "rejection_comment": feedback.rejection_comment or "",
         }
 
         # Write to CSV file (automatic escaping)

--- a/src/aegis_ai_web/tests/test_feedback_schema.py
+++ b/src/aegis_ai_web/tests/test_feedback_schema.py
@@ -36,6 +36,7 @@ class TestFeedbackSchema:
             "expected",
             "request_time",
             "accept",
+            "rejection_comment",
         ]
 
         assert FEEDBACK_SCHEMA.field_names == expected_fields
@@ -55,6 +56,7 @@ class TestFeedbackSchema:
             "expected": "CRITICAL",
             "request_time": "",
             "accept": "False",
+            "rejection_comment": "",
         }
 
         assert FEEDBACK_SCHEMA.validate_parsed_log(valid_data) is True
@@ -81,6 +83,7 @@ class TestFeedbackSchema:
             "expected": "CRITICAL",
             "request_time": "",
             "accept": "False",
+            "rejection_comment": "",
             "extra_field": "should not be here",  # Extra field
         }
 
@@ -101,6 +104,7 @@ class TestFeedbackSchema:
             "expected": "CRITICAL",
             "request_time": "",
             "accept": "False",
+            "rejection_comment": "",
         }
 
         # Cast to expected type for type checker; we're intentionally testing None values
@@ -120,6 +124,7 @@ class TestFeedbackSchema:
             "expected",
             "request_time",
             "accept",
+            "rejection_comment",
         ]
 
         assert FEEDBACK_SCHEMA.validate_csv_headers(valid_headers) is True
@@ -135,6 +140,7 @@ class TestFeedbackSchema:
             "expected",
             "request_time",
             "accept",
+            "rejection_comment",
         ]
 
         assert FEEDBACK_SCHEMA.validate_csv_headers(invalid_headers) is False
@@ -177,6 +183,7 @@ class TestValidationFunctions:
             "expected": "CRITICAL",
             "request_time": "",
             "accept": "False",
+            "rejection_comment": "",
         }
 
         assert validate_log_parser_output(valid_data) is True
@@ -212,6 +219,7 @@ class TestValidationFunctions:
             "expected",
             "request_time",
             "accept",
+            "rejection_comment",
         ]
 
         assert validate_csv_headers(valid_headers) is True


### PR DESCRIPTION
## What
- Added field for rejection explanation
- Log trace only in debug mode

## Why
Allow users to provide context in the form of rationale for rejection and correction of Aegis-suggested values

## How to Test
`make test`

## Related Tickets
Related: https://issues.redhat.com/browse/AEGIS-262

## Summary by Sourcery

Add support for capturing and storing a rejection comment in feedback submissions and adjust feedback error logging behavior.

New Features:
- Allow users to provide an optional rejection comment when submitting feedback, persisted alongside other feedback fields.

Enhancements:
- Update feedback logging to emit a concise warning on failure while deferring full error details to debug-level logging.

Tests:
- Extend feedback schema tests to cover the new rejection comment field in field names, validation, and CSV header validation.