### PR TITLE
fix: lower confidence with impact cvss score mismatches

### DIFF
--- a/src/aegis_ai/features/__init__.py
+++ b/src/aegis_ai/features/__init__.py
@@ -67,6 +67,8 @@ class Feature:
 
     async def _run(self, call_str, prompt, **kwargs):
         try:
+            if prompt.static_context:
+                logger.debug(f"{call_str}: static_context keys: {list(prompt.static_context.keys())}")
             runner = self.agent.run(prompt.to_string(), **kwargs)
             return await run_with_heartbeat(runner, prefix=call_str)
 

--- a/src/aegis_ai/features/cve/__init__.py
+++ b/src/aegis_ai/features/cve/__init__.py
@@ -36,10 +36,31 @@ class SuggestImpact(Feature):
             cvss3_score_by_vector = cvss.CVSS3(output.cvss3_vector).scores()[0]
         except Exception:
             cvss3_score_by_vector = float("nan")
-
-        if cvss3_score == cvss3_score_by_vector:
+        cvss_score_mismatch = cvss3_score != cvss3_score_by_vector
+        if not cvss_score_mismatch:
             # already consistent
             return
+
+        impact_score_mismatch = (
+            (output.impact == "CRITICAL" and not cvss3_score_by_vector >= 9.0)
+            or (output.impact == "IMPORTANT" and not cvss3_score_by_vector >= 7.0)
+            or (output.impact == "MODERATE" and not cvss3_score_by_vector >= 5.0)
+            or (output.impact == "LOW" and not cvss3_score_by_vector < 5.0)
+        )
+
+        # TODO: remove, probably: we may not necessarily want to lower confidence on every self-correction
+        # if cvss_score_mismatch:
+        #     # adjust confidence score based on the difference, rounded to one decimal place
+        #     difference = abs(cvss3_score - cvss3_score_by_vector)
+        #     delta = round(1.0 - difference / 10.0, 1)
+        #     output.confidence = max(0.0, output.confidence - delta)
+
+        if impact_score_mismatch:
+            # adjust confidence based on mismatch of impact values
+            delta = self.distance_from_expected_impact(
+                output.impact, cvss3_score_by_vector
+            )
+            output.confidence = max(0.0, output.confidence - delta)
 
         logger.warning(
             f"{call_str}: adjusting cvss3_score to match cvss3_vector: {cvss3_score} -> {cvss3_score_by_vector}"
@@ -96,6 +117,47 @@ class SuggestImpact(Feature):
             result.output, call_str
         )  # TODO: extract this to process on SuggestImpactModel data model rather then here.
         return result
+
+    def expected_impact_from_cvss_score(self, cvss3_score: float) -> str:
+        """
+        Return the expected impact based on the CVSS 3.1 score.
+        """
+        if cvss3_score == 0.0:
+            return "NONE"
+        elif cvss3_score >= 0.0 and cvss3_score < 4.0:
+            return "LOW"
+        elif cvss3_score >= 4.0 and cvss3_score < 7.0:
+            return "MODERATE"
+        elif cvss3_score >= 7.0 and cvss3_score < 9.0:
+            return "IMPORTANT"
+        elif cvss3_score >= 9.0:
+            return "CRITICAL"
+        else:
+            return ""
+            # raise ValueError(f"Invalid CVSS 3.1 score: {cvss3_score}")
+
+    def does_impact_match_cvss_score(self, impact: str, cvss3_score: float) -> bool:
+        """
+        "NONE": 0.0 -> 0
+        "LOW": 2.0 -> 0..4
+        "MODERATE": 5.5 -> 4..7
+        "IMPORTANT": 8.0 -> 7..9
+        "CRITICAL" -> 9..10
+        """
+        return self.expected_impact_from_cvss_score(cvss3_score) == impact
+
+    def distance_from_expected_impact(self, impact: str, cvss3_score: float) -> float:
+        """
+        Return the distance from the expected impact based on the CVSS 3.1 score.
+        """
+        impacts = ["NONE", "LOW", "MODERATE", "IMPORTANT", "CRITICAL"]
+        return (
+            abs(
+                impacts.index(impact)
+                - impacts.index(self.expected_impact_from_cvss_score(cvss3_score))
+            )
+            / 4.0
+        )
 
 
 class SuggestCWE(Feature):

--- a/src/aegis_ai_cli/main.py
+++ b/src/aegis_ai_cli/main.py
@@ -3,7 +3,9 @@ aegis cli
 
 """
 
+import json
 import logging
+import sys
 
 import click
 import asyncio
@@ -22,6 +24,27 @@ from aegis_ai.features import component, cve
 from aegis_ai.features.data_models import AegisAnswer
 
 from aegis_ai_cli import print_version, feature_agent
+
+
+def _load_context(context_str):
+    """Load static context from a JSON file path, stdin ('-'), or inline JSON string."""
+    if context_str is None:
+        return None
+    if context_str == "-":
+        return json.load(sys.stdin)
+    # Try as file path first
+    try:
+        with open(context_str) as f:
+            return json.load(f)
+    except OSError:
+        pass
+    # Fall back to inline JSON
+    try:
+        return json.loads(context_str)
+    except json.JSONDecodeError as e:
+        raise click.BadParameter(
+            f"Could not parse --context as a file path or JSON string: {e}"
+        )
 
 console = Console()
 
@@ -94,14 +117,16 @@ def search(query):
 
 @aegis_cli.command()
 @click.argument("cve_id", type=CVEID)
-def identify_pii(cve_id):
+@click.option("--context", "-c", "context_src", default=None, help="Static context as a JSON file path, inline JSON string, or '-' for stdin.")
+def identify_pii(cve_id, context_src):
     """
     Identify PII contained in CVE record.
     """
+    static_context = _load_context(context_src)
 
     async def _doit():
         feature = cve.IdentifyPII(cli_agent)
-        return await feature.exec(cve_id)
+        return await feature.exec(cve_id, static_context=static_context)
 
     result = asyncio.run(_doit())
     if result:
@@ -111,14 +136,16 @@ def identify_pii(cve_id):
 
 @aegis_cli.command()
 @click.argument("cve_id", type=CVEID)
-def suggest_impact(cve_id):
+@click.option("--context", "-c", "context_src", default=None, help="Static context as a JSON file path, inline JSON string, or '-' for stdin.")
+def suggest_impact(cve_id, context_src):
     """
     Suggest overall impact of CVE.
     """
+    static_context = _load_context(context_src)
 
     async def _doit():
         feature = cve.SuggestImpact(cli_agent)
-        return await feature.exec(cve_id)
+        return await feature.exec(cve_id, static_context=static_context)
 
     result = asyncio.run(_doit())
     if result:
@@ -128,14 +155,16 @@ def suggest_impact(cve_id):
 
 @aegis_cli.command()
 @click.argument("cve_id", type=CVEID)
-def suggest_cwe(cve_id):
+@click.option("--context", "-c", "context_src", default=None, help="Static context as a JSON file path, inline JSON string, or '-' for stdin.")
+def suggest_cwe(cve_id, context_src):
     """
     Suggest CWE.
     """
+    static_context = _load_context(context_src)
 
     async def _doit():
         feature = cve.SuggestCWE(cli_agent)
-        return await feature.exec(cve_id)
+        return await feature.exec(cve_id, static_context=static_context)
 
     result = asyncio.run(_doit())
     if result:
@@ -145,14 +174,16 @@ def suggest_cwe(cve_id):
 
 @aegis_cli.command()
 @click.argument("cve_id", type=CVEID)
-def suggest_description(cve_id):
+@click.option("--context", "-c", "context_src", default=None, help="Static context as a JSON file path, inline JSON string, or '-' for stdin.")
+def suggest_description(cve_id, context_src):
     """
     Suggest CVE description text.
     """
+    static_context = _load_context(context_src)
 
     async def _doit():
         feature = cve.SuggestDescriptionText(cli_agent)
-        return await feature.exec(cve_id)
+        return await feature.exec(cve_id, static_context=static_context)
 
     result = asyncio.run(_doit())
     if result:
@@ -162,14 +193,16 @@ def suggest_description(cve_id):
 
 @aegis_cli.command()
 @click.argument("cve_id", type=CVEID)
-def suggest_statement(cve_id):
+@click.option("--context", "-c", "context_src", default=None, help="Static context as a JSON file path, inline JSON string, or '-' for stdin.")
+def suggest_statement(cve_id, context_src):
     """
     Suggest CVE statement text.
     """
+    static_context = _load_context(context_src)
 
     async def _doit():
         feature = cve.SuggestStatementText(cli_agent)
-        return await feature.exec(cve_id)
+        return await feature.exec(cve_id, static_context=static_context)
 
     result = asyncio.run(_doit())
     if result:
@@ -179,14 +212,16 @@ def suggest_statement(cve_id):
 
 @aegis_cli.command()
 @click.argument("cve_id", type=CVEID)
-def cvss_diff(cve_id):
+@click.option("--context", "-c", "context_src", default=None, help="Static context as a JSON file path, inline JSON string, or '-' for stdin.")
+def cvss_diff(cve_id, context_src):
     """
     CVSS Diff explainer.
     """
+    static_context = _load_context(context_src)
 
     async def _doit():
         feature = cve.CVSSDiffExplainer(cli_agent)
-        return await feature.exec(cve_id)
+        return await feature.exec(cve_id, static_context=static_context)
 
     result = asyncio.run(_doit())
     if result:


### PR DESCRIPTION
chore: formatting

## What

## Why

## How to Test

## Related Tickets
Related: https://issues.redhat.com/browse/AEGIS-349

## Summary by Sourcery

Adjust CVE post-processing to align impact confidence adjustments with CVSS 3.1 scores and derived impact levels.

Bug Fixes:
- Only lower confidence when the declared impact does not match the impact implied by the CVSS 3.1 score instead of on any score/vector mismatch.

Enhancements:
- Introduce helpers to derive expected impact from a CVSS 3.1 score and to quantify distance between actual and expected impact for confidence adjustment.

## Summary by Sourcery

Adjust CVE post-processing to only lower confidence when the declared impact level conflicts with the impact implied by the CVSS 3.1 score, and introduce helpers for mapping and comparing impacts to scores.

Bug Fixes:
- Restrict confidence reduction to cases where the reported impact level is inconsistent with the CVSS 3.1-derived impact rather than any CVSS score or vector mismatch.

Enhancements:
- Add helper methods to derive the expected impact from a CVSS 3.1 score, check consistency between impact and score, and quantify their distance for confidence adjustments.