### PR TITLE
fix: pen-test hardening — feedback APIs, OSIDB/component errors, and logging

### DIFF
--- a/src/aegis_ai/__init__.py
+++ b/src/aegis_ai/__init__.py
@@ -112,6 +112,33 @@ class LivenessProbeLogFilter(logging.Filter):
         return args[1:] != ("GET", "/healthz", "1.1", 204)
 
 
+class SuppressThirdPartyTracebackFilter(logging.Filter):
+    """
+    Remove exception tracebacks from selected third-party loggers (Kerberos/GSSAPI)
+    when not at DEBUG level. Those libraries log ERROR with exc_info=True, which
+    floods operator logs during expected missing-credential scenarios.
+    """
+
+    _LOGGER_PREFIXES = ("requests_gssapi", "gssapi")
+
+    def __init__(self, show_tracebacks: bool) -> None:
+        super().__init__()
+        self._show_tracebacks = show_tracebacks
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if self._show_tracebacks or not record.exc_info:
+            return True
+        name = record.name
+        if any(
+            name == prefix or name.startswith(prefix + ".")
+            for prefix in self._LOGGER_PREFIXES
+        ):
+            record.exc_info = None
+            record.exc_text = None
+            record.stack_info = None
+        return True
+
+
 class _ProviderKwargs(TypedDict):
     """named args of AI Providers"""
 
@@ -349,6 +376,9 @@ def config_logging(level="INFO"):
 
             # Avoid using basename only in log messages (especially __init__.py is ambiguous)
             handler.addFilter(RelativePathFilter())
+            handler.addFilter(
+                SuppressThirdPartyTracebackFilter(show_tracebacks=(level == "DEBUG"))
+            )
 
             # Suppress liveness probe access logs on uvicorn.access
             if logger_name == "uvicorn.access":

--- a/src/aegis_ai/toolsets/tools/osidb/__init__.py
+++ b/src/aegis_ai/toolsets/tools/osidb/__init__.py
@@ -17,6 +17,7 @@ from aegis_ai.toolsets.tools import BaseToolOutput, BaseToolInput
 from aegis_ai.toolsets.tools.osidb.osidb_client import (
     OSIDBClient,
     OSIDBFlawNotFoundError,
+    OSIDBUnauthorizedError,
 )
 
 logger = logging.getLogger(__name__)
@@ -237,6 +238,8 @@ async def cve_retrieve(cve_id: CVEID) -> CVE:
             cvss_scores=cvss_scores,
         )
     except OSIDBFlawNotFoundError:
+        raise
+    except OSIDBUnauthorizedError:
         raise
     except Exception as e:
         logger.error(

--- a/src/aegis_ai/toolsets/tools/osidb/__init__.py
+++ b/src/aegis_ai/toolsets/tools/osidb/__init__.py
@@ -14,7 +14,10 @@ from aegis_ai import get_env_flag
 from aegis_ai.data_models import CVEID, cveid_validator
 from aegis_ai.features.data_models import feature_deps
 from aegis_ai.toolsets.tools import BaseToolOutput, BaseToolInput
-from aegis_ai.toolsets.tools.osidb.osidb_client import OSIDBClient
+from aegis_ai.toolsets.tools.osidb.osidb_client import (
+    OSIDBClient,
+    OSIDBFlawNotFoundError,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -233,6 +236,8 @@ async def cve_retrieve(cve_id: CVEID) -> CVE:
             affects=affects,
             cvss_scores=cvss_scores,
         )
+    except OSIDBFlawNotFoundError:
+        raise
     except Exception as e:
         logger.error(
             f"We encountered an error during OSIDB retrieval of {validated_cve_id}: {e}"

--- a/src/aegis_ai/toolsets/tools/osidb/osidb_client.py
+++ b/src/aegis_ai/toolsets/tools/osidb/osidb_client.py
@@ -35,6 +35,27 @@ class OSIDBAuthError(Exception):
     pass
 
 
+class OSIDBFlawNotFoundError(Exception):
+    """Raised when OSIDB has no flaw record for the requested CVE ID (HTTP 404)."""
+
+    def __init__(self, cve_id: str) -> None:
+        self.cve_id = cve_id
+        super().__init__(f"No flaw in OSIDB for {cve_id}")
+
+
+def _is_osidb_flaw_not_found(exc: BaseException) -> bool:
+    """Return True if *exc* indicates OSIDB returned 404 for a flaw lookup."""
+    if isinstance(exc, httpx.HTTPStatusError):
+        return exc.response.status_code == 404
+    resp = getattr(exc, "response", None)
+    if resp is not None:
+        code = getattr(resp, "status_code", None)
+        if code == 404:
+            return True
+    text = str(exc).lower()
+    return "404" in text and ("not found" in text or "client error" in text)
+
+
 class OSIDBClient:
     """A client for interacting with OSIDB API."""
 
@@ -122,7 +143,12 @@ class OSIDBClient:
                     params=params,
                     headers={"Authorization": f"Bearer {token}"},
                 )
-                resp.raise_for_status()
+                try:
+                    resp.raise_for_status()
+                except httpx.HTTPStatusError as e:
+                    if e.response.status_code == 404:
+                        raise OSIDBFlawNotFoundError(cve_id) from e
+                    raise
                 data = resp.json()
             from osidb_bindings.bindings.python_client.models.osidb_api_v1_flaws_retrieve_response_200 import (
                 OsidbApiV1FlawsRetrieveResponse200,
@@ -131,10 +157,15 @@ class OSIDBClient:
             flaw_data = OsidbApiV1FlawsRetrieveResponse200.from_dict(data)
         else:
             session = cast(Any, session)  # token was None, so session is not None
-            flaw_data = session.flaws.retrieve(
-                id=cve_id,
-                include_fields=_FLAW_RETRIEVE_FIELDS,
-            )
+            try:
+                flaw_data = session.flaws.retrieve(
+                    id=cve_id,
+                    include_fields=_FLAW_RETRIEVE_FIELDS,
+                )
+            except Exception as e:
+                if _is_osidb_flaw_not_found(e):
+                    raise OSIDBFlawNotFoundError(cve_id) from e
+                raise
 
         if not include_embargoed and flaw_data.embargoed:
             logger.info(f"Flaw {cve_id} is embargoed and retrieval is disabled.")

--- a/src/aegis_ai/toolsets/tools/osidb/osidb_client.py
+++ b/src/aegis_ai/toolsets/tools/osidb/osidb_client.py
@@ -43,6 +43,30 @@ class OSIDBFlawNotFoundError(Exception):
         super().__init__(f"No flaw in OSIDB for {cve_id}")
 
 
+class OSIDBUnauthorizedError(Exception):
+    """Raised when OSIDB rejects authentication or authorization (HTTP 401)."""
+
+    def __init__(self, message: str | None = None) -> None:
+        self.message = message or (
+            "OSIDB authentication failed (HTTP 401). "
+            "Check Kerberos credentials, delegation, and OSIDB access."
+        )
+        super().__init__(self.message)
+
+
+def _is_osidb_unauthorized(exc: BaseException) -> bool:
+    """Return True if *exc* indicates OSIDB returned 401."""
+    if isinstance(exc, httpx.HTTPStatusError):
+        return exc.response.status_code == 401
+    resp = getattr(exc, "response", None)
+    if resp is not None:
+        code = getattr(resp, "status_code", None)
+        if code == 401:
+            return True
+    text = str(exc).lower()
+    return "401" in text and ("unauthorized" in text or "client error" in text)
+
+
 def _is_osidb_flaw_not_found(exc: BaseException) -> bool:
     """Return True if *exc* indicates OSIDB returned 404 for a flaw lookup."""
     if isinstance(exc, httpx.HTTPStatusError):
@@ -114,6 +138,8 @@ class OSIDBClient:
                     logger.warning(
                         f"Failed to connect OSIDB at {osidb_server_url}: {e.__class__.__name__}"
                     )
+                    if _is_osidb_unauthorized(e):
+                        raise OSIDBUnauthorizedError() from e
                     raise
         return (self._session, None)
 
@@ -148,6 +174,11 @@ class OSIDBClient:
                 except httpx.HTTPStatusError as e:
                     if e.response.status_code == 404:
                         raise OSIDBFlawNotFoundError(cve_id) from e
+                    if e.response.status_code == 401:
+                        raise OSIDBUnauthorizedError(
+                            "OSIDB returned HTTP 401 Unauthorized. "
+                            "Verify Kerberos credentials, delegation, and OSIDB access."
+                        ) from e
                     raise
                 data = resp.json()
             from osidb_bindings.bindings.python_client.models.osidb_api_v1_flaws_retrieve_response_200 import (
@@ -163,6 +194,8 @@ class OSIDBClient:
                     include_fields=_FLAW_RETRIEVE_FIELDS,
                 )
             except Exception as e:
+                if _is_osidb_unauthorized(e):
+                    raise OSIDBUnauthorizedError() from e
                 if _is_osidb_flaw_not_found(e):
                     raise OSIDBFlawNotFoundError(cve_id) from e
                 raise
@@ -177,9 +210,14 @@ class OSIDBClient:
         """Return the process-level bindings session (used when delegated token path doesn't apply)."""
         async with self._session_lock:
             if self._session is None:
-                self._session = osidb_bindings.new_session(
-                    osidb_server_uri=get_settings().osidb_server_url
-                )
+                try:
+                    self._session = osidb_bindings.new_session(
+                        osidb_server_uri=get_settings().osidb_server_url
+                    )
+                except Exception as e:
+                    if _is_osidb_unauthorized(e):
+                        raise OSIDBUnauthorizedError() from e
+                    raise
         return self._session
 
     async def _list_component_flaws_with_token(

--- a/src/aegis_ai_web/src/data_models.py
+++ b/src/aegis_ai_web/src/data_models.py
@@ -21,9 +21,9 @@ class Feedback(BaseModel):
     CSV escaping is handled automatically by the csv library during logging.
     """
 
-    feature: str = Field(..., max_length=100)
-    cve_id: Optional[CVEID] = Field("", max_length=50)
-    email: Optional[str] = Field("", max_length=100)
+    feature: str = Field(..., min_length=1, max_length=100)
+    cve_id: CVEID = Field(...)
+    email: str = Field(..., min_length=1, max_length=100)
     request_time: Optional[str] = Field("", max_length=50)
     actual: Optional[str] = Field("", max_length=5000)  # Increased for longer values
     expected: Optional[str] = Field("", max_length=5000)  # Increased for longer values
@@ -152,9 +152,9 @@ class ProgrammaticFeedback(BaseModel):
     # unspecified fields in the payload will result in a ValidationError
     model_config = {"extra": "forbid"}
 
-    feature: str = Field(..., max_length=100)
-    cve_id: Optional[CVEID] = Field("", max_length=50)
-    email: Optional[str] = Field("", max_length=100)
+    feature: str = Field(..., min_length=1, max_length=100)
+    cve_id: CVEID = Field(...)
+    email: str = Field(..., min_length=1, max_length=100)
     suggested_value: Optional[str] = Field("", max_length=5000)
     submitted_value: Optional[str] = Field("", max_length=5000)
 

--- a/src/aegis_ai_web/src/data_models.py
+++ b/src/aegis_ai_web/src/data_models.py
@@ -23,9 +23,6 @@ class Feedback(BaseModel):
 
     feature: str = Field(..., max_length=100)
     cve_id: Optional[CVEID] = Field("", max_length=50)
-    cveId: Optional[CVEID] = Field(
-        "", max_length=50
-    )  # FIXME: an interim compatibility fix for OSIM
     email: Optional[str] = Field("", max_length=100)
     request_time: Optional[str] = Field("", max_length=50)
     actual: Optional[str] = Field("", max_length=5000)  # Increased for longer values

--- a/src/aegis_ai_web/src/main.py
+++ b/src/aegis_ai_web/src/main.py
@@ -236,7 +236,7 @@ cve_feature_registry: Dict[str, Type] = {
     "cvss-diff-explainer": cve.CVSSDiffExplainer,
 }
 CVEFeatureName = Enum(
-    "ComponentFeatureName",
+    "CVEFeatureName",
     {name: name for name in cve_feature_registry.keys()},
     type=str,
 )

--- a/src/aegis_ai_web/src/main.py
+++ b/src/aegis_ai_web/src/main.py
@@ -555,8 +555,8 @@ async def save_feedback(request: Request, feedback: Feedback):
         accept_str = str(feedback.accept).lower()
         row_data = {
             "feature": feedback.feature,
-            "cve_id": feedback.cve_id or "",
-            "email": feedback.email or "",
+            "cve_id": feedback.cve_id,
+            "email": feedback.email,
             "actual": feedback.actual or "",
             "expected": feedback.expected or "",
             "request_time": feedback.request_time or "",
@@ -690,8 +690,8 @@ async def save_programmatic_feedback(request: Request, feedback: ProgrammaticFee
 
     try:
         feature = feedback.feature
-        cve_id = feedback.cve_id or ""
-        email = feedback.email or ""
+        cve_id = feedback.cve_id
+        email = feedback.email
         suggested = feedback.suggested_value or ""
         submitted = feedback.submitted_value or ""
 

--- a/src/aegis_ai_web/src/main.py
+++ b/src/aegis_ai_web/src/main.py
@@ -435,6 +435,15 @@ async def component_analysis(
         if detail:
             return result
         return result.output
+    except OSIDBFlawNotFoundError as e:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No flaw data found in OSIDB for {e.cve_id}.",
+        )
+    except OSIDBUnauthorizedError as e:
+        raise HTTPException(status_code=401, detail=str(e))
+    except OSIDBAuthError as e:
+        raise HTTPException(status_code=503, detail=str(e))
     except Exception as e:
         log_exception_safely(e, f"Error executing Component feature '{feature_name}'")
         raise HTTPException(

--- a/src/aegis_ai_web/src/main.py
+++ b/src/aegis_ai_web/src/main.py
@@ -555,9 +555,7 @@ async def save_feedback(request: Request, feedback: Feedback):
         accept_str = str(feedback.accept).lower()
         row_data = {
             "feature": feedback.feature,
-            "cve_id": feedback.cve_id
-            or feedback.cveId
-            or "",  # FIXME: an interim compatibility fix for OSIM
+            "cve_id": feedback.cve_id or "",
             "email": feedback.email or "",
             "actual": feedback.actual or "",
             "expected": feedback.expected or "",

--- a/src/aegis_ai_web/src/main.py
+++ b/src/aegis_ai_web/src/main.py
@@ -14,6 +14,8 @@ from typing import Dict, Optional, Type, Annotated, cast, Any
 
 import yaml
 from fastapi import FastAPI, Request, HTTPException, Form, Query
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import RequestValidationError
 from fastapi.responses import HTMLResponse, JSONResponse, FileResponse, Response
 
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -89,6 +91,37 @@ async def unicode_decode_exception_handler(request: Request, exc: UnicodeDecodeE
     return JSONResponse(
         status_code=400,
         content={"detail": "Invalid UTF-8 encoding in request body"},
+    )
+
+
+@app.exception_handler(RequestValidationError)
+async def request_validation_exception_handler(
+    request: Request, exc: RequestValidationError
+):
+    """
+    Log Pydantic/request validation failures and return the standard FastAPI 422 body.
+
+    WARNING logs include error type, location, and message only. Request payload
+    excerpts (Pydantic's ``input`` field) are logged at DEBUG only.
+    """
+    errors = jsonable_encoder(exc.errors())
+    summary_errors = [{k: v for k, v in err.items() if k != "input"} for err in errors]
+    logging.warning(
+        "Request validation failed: %s %s — %s",
+        request.method,
+        request.url.path,
+        json.dumps(summary_errors),
+    )
+    logging.debug(
+        "Request validation failed (full detail, includes body excerpts): %s %s — %s",
+        request.method,
+        request.url.path,
+        json.dumps(errors),
+    )
+    return JSONResponse(
+        status_code=422,
+        content={"detail": errors},
+        media_type="application/json",
     )
 
 

--- a/src/aegis_ai_web/src/main.py
+++ b/src/aegis_ai_web/src/main.py
@@ -28,6 +28,10 @@ from aegis_ai import config_logging, get_settings
 from aegis_ai.agents import public_feature_agent, rh_feature_agent
 
 from aegis_ai.data_models import CVEID, cveid_validator
+from aegis_ai.toolsets.tools.osidb.osidb_client import (
+    OSIDBAuthError,
+    OSIDBFlawNotFoundError,
+)
 from aegis_ai.features import cve, component
 from aegis_ai.features.data_models import AegisAnswer
 
@@ -280,15 +284,16 @@ CVEFeatureName = Enum(
     response_class=JSONResponse,
 )
 async def cve_analysis(feature: CVEFeatureName, cve_id: CVEID, detail: bool = False):
-    if feature not in cve_feature_registry:
-        raise HTTPException(404, detail=f"CVE feature '{feature}' not found.")
+    feature_name = feature.value
+    if feature_name not in cve_feature_registry:
+        raise HTTPException(404, detail=f"CVE feature '{feature_name}' not found.")
 
-    FeatureClass = cve_feature_registry[feature]
+    FeatureClass = cve_feature_registry[feature_name]
 
     try:
         validated_input = cveid_validator.validate_python(cve_id)
     except Exception as e:
-        msg = f"Invalid input for CVE feature '{feature}'"
+        msg = f"Invalid input for CVE feature '{feature_name}'"
         log_exception_safely(e, msg)
         raise HTTPException(status_code=422, detail=msg)
 
@@ -298,11 +303,18 @@ async def cve_analysis(feature: CVEFeatureName, cve_id: CVEID, detail: bool = Fa
         if detail:
             return result
         return result.output
+    except OSIDBFlawNotFoundError as e:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No flaw data found in OSIDB for {e.cve_id}.",
+        )
+    except OSIDBAuthError as e:
+        raise HTTPException(status_code=503, detail=str(e))
     except Exception as e:
-        log_exception_safely(e, f"Error executing CVE feature '{feature}'")
+        log_exception_safely(e, f"Error executing CVE feature '{feature_name}'")
         raise HTTPException(
             status_code=500,
-            detail=f"An internal error occurred while executing CVE feature '{feature}'.",
+            detail=f"An internal error occurred while executing CVE feature '{feature_name}'.",
         )
 
 
@@ -320,13 +332,14 @@ async def cve_analysis_with_body(
         log_exception_safely(e, "Missing required field: 'cve_id'")
         raise HTTPException(status_code=400, detail="Missing required field: 'cve_id'")
 
-    if feature.value not in cve_feature_registry:
-        raise HTTPException(404, detail=f"CVE feature '{feature.value}' not found.")
-    FeatureClass = cve_feature_registry[feature.value]
+    feature_name = feature.value
+    if feature_name not in cve_feature_registry:
+        raise HTTPException(404, detail=f"CVE feature '{feature_name}' not found.")
+    FeatureClass = cve_feature_registry[feature_name]
     try:
         validated_input = dict(cve_data)
     except Exception as e:
-        msg = f"Invalid input for CVE feature '{feature}'"
+        msg = f"Invalid input for CVE feature '{feature_name}'"
         log_exception_safely(e, msg)
         raise HTTPException(status_code=422, detail=msg)
 
@@ -338,7 +351,7 @@ async def cve_analysis_with_body(
         validated_input.get("comment_zero") or validated_input.get("cve_description")
     ) or ""
     if (
-        feature.value != "suggest-affected-components"
+        feature_name != "suggest-affected-components"
         and not existing_components
         and validated_input.get("title")
         and description_text
@@ -363,11 +376,18 @@ async def cve_analysis_with_body(
         if detail:
             return result
         return result.output
+    except OSIDBFlawNotFoundError as e:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No flaw data found in OSIDB for {e.cve_id}.",
+        )
+    except OSIDBAuthError as e:
+        raise HTTPException(status_code=503, detail=str(e))
     except Exception as e:
-        log_exception_safely(e, f"Error executing CVE feature '{feature}'")
+        log_exception_safely(e, f"Error executing CVE feature '{feature_name}'")
         raise HTTPException(
             status_code=500,
-            detail=f"An internal error occurred while executing CVE feature '{feature}'.",
+            detail=f"An internal error occurred while executing CVE feature '{feature_name}'.",
         )
 
 
@@ -388,16 +408,19 @@ ComponentFeatureName = Enum(
 async def component_analysis(
     feature: ComponentFeatureName, component_name: str, detail: bool = False
 ):
-    logging.info(feature)
-    if feature not in component_feature_registry:
-        raise HTTPException(404, detail=f"Component feature '{feature}' not found.")
+    feature_name = feature.value
+    logging.info(feature_name)
+    if feature_name not in component_feature_registry:
+        raise HTTPException(
+            404, detail=f"Component feature '{feature_name}' not found."
+        )
 
-    FeatureClass = component_feature_registry[feature]
+    FeatureClass = component_feature_registry[feature_name]
 
     try:
         validated_input = component_name
     except Exception as e:
-        msg = f"Invalid input for Component feature '{feature}'"
+        msg = f"Invalid input for Component feature '{feature_name}'"
         log_exception_safely(e, msg)
         raise HTTPException(status_code=422, detail=msg)
 
@@ -408,10 +431,10 @@ async def component_analysis(
             return result
         return result.output
     except Exception as e:
-        log_exception_safely(e, f"Error executing Component feature '{feature}'")
+        log_exception_safely(e, f"Error executing Component feature '{feature_name}'")
         raise HTTPException(
             status_code=500,
-            detail=f"An internal error occurred while executing Component feature '{feature}'.",
+            detail=f"An internal error occurred while executing Component feature '{feature_name}'.",
         )
 
 

--- a/src/aegis_ai_web/src/main.py
+++ b/src/aegis_ai_web/src/main.py
@@ -31,6 +31,7 @@ from aegis_ai.data_models import CVEID, cveid_validator
 from aegis_ai.toolsets.tools.osidb.osidb_client import (
     OSIDBAuthError,
     OSIDBFlawNotFoundError,
+    OSIDBUnauthorizedError,
 )
 from aegis_ai.features import cve, component
 from aegis_ai.features.data_models import AegisAnswer
@@ -308,6 +309,8 @@ async def cve_analysis(feature: CVEFeatureName, cve_id: CVEID, detail: bool = Fa
             status_code=404,
             detail=f"No flaw data found in OSIDB for {e.cve_id}.",
         )
+    except OSIDBUnauthorizedError as e:
+        raise HTTPException(status_code=401, detail=str(e))
     except OSIDBAuthError as e:
         raise HTTPException(status_code=503, detail=str(e))
     except Exception as e:
@@ -381,6 +384,8 @@ async def cve_analysis_with_body(
             status_code=404,
             detail=f"No flaw data found in OSIDB for {e.cve_id}.",
         )
+    except OSIDBUnauthorizedError as e:
+        raise HTTPException(status_code=401, detail=str(e))
     except OSIDBAuthError as e:
         raise HTTPException(status_code=503, detail=str(e))
     except Exception as e:

--- a/src/aegis_ai_web/src/main.py
+++ b/src/aegis_ai_web/src/main.py
@@ -423,15 +423,8 @@ async def component_analysis(
     FeatureClass = component_feature_registry[feature_name]
 
     try:
-        validated_input = component_name
-    except Exception as e:
-        msg = f"Invalid input for Component feature '{feature_name}'"
-        log_exception_safely(e, msg)
-        raise HTTPException(status_code=422, detail=msg)
-
-    try:
         feature_instance = FeatureClass(agent=llm_agent)
-        result = await feature_instance.exec(validated_input)
+        result = await feature_instance.exec(component_name)
         if detail:
             return result
         return result.output

--- a/src/aegis_ai_web/tests/test_delegated_auth.py
+++ b/src/aegis_ai_web/tests/test_delegated_auth.py
@@ -18,7 +18,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from aegis_ai.request_context import get_request_scope, set_request_scope
 from aegis_ai.toolsets.tools.osidb import osidb_client
-from aegis_ai.toolsets.tools.osidb.osidb_client import OSIDBAuthError
+from aegis_ai.toolsets.tools.osidb.osidb_client import (
+    OSIDBAuthError,
+    OSIDBUnauthorizedError,
+)
 
 # Must match OSIDBClient._OSIDB_DELEGATED_TOKEN_KEY (scope key for cached JWT)
 _OSIDB_DELEGATED_TOKEN_KEY = "_osidb_delegated_token"
@@ -141,6 +144,30 @@ class TestOSIDBClientDelegatedTokenPath:
 
         assert result.cve_id == "CVE-2024-5678"
         mock_session.flaws.retrieve.assert_called_once()
+
+    async def test_new_session_401_raises_osidb_unauthorized(self):
+        """
+        When new_session fails with HTTP 401 (e.g. OSIDB /auth/token), propagate
+        OSIDBUnauthorizedError so the API can return 401 instead of a wrapped 500.
+        """
+        from requests import HTTPError
+
+        set_request_scope(None)
+        resp = MagicMock()
+        resp.status_code = 401
+        err = HTTPError(
+            "401 Client Error: Unauthorized for url: https://osidb.example/auth/token"
+        )
+        err.response = resp
+
+        client = osidb_client.OSIDBClient()
+        with patch.object(
+            osidb_client.osidb_bindings,
+            "new_session",
+            side_effect=err,
+        ):
+            with pytest.raises(OSIDBUnauthorizedError):
+                await client.get_flaw_data("CVE-2026-4404", include_embargoed=False)
 
     async def test_list_component_flaws_uses_token_when_scope_has_token(self):
         """When scope has token, list_component_flaws uses Bearer token for list API."""

--- a/src/aegis_ai_web/tests/test_endpoints.py
+++ b/src/aegis_ai_web/tests/test_endpoints.py
@@ -3,6 +3,7 @@ import yaml
 from unittest.mock import AsyncMock, MagicMock, patch
 from fastapi.testclient import TestClient
 
+from aegis_ai.features import component as component_features
 from aegis_ai.features import cve as cve_features
 from aegis_ai.features.component.data_models import ComponentIntelligenceModel
 from aegis_ai.features.cve.data_models import SuggestAffectedComponentsModel
@@ -58,6 +59,26 @@ def test_cve_analysis_osidb_flaw_not_found_returns_404():
     detail = response.json()["detail"]
     assert "CVE-2025-59536" in detail
     assert "OSIDB" in detail
+
+
+def test_component_analysis_osidb_unauthorized_returns_401():
+    """Component analysis maps OSIDBUnauthorizedError to HTTP 401 like CVE analysis."""
+    with patch.object(
+        component_features.ComponentIntelligence,
+        "exec",
+        new_callable=AsyncMock,
+        side_effect=OSIDBUnauthorizedError(),
+    ):
+        response = client.get(
+            "/api/v1/analysis/component",
+            params={
+                "feature": "component-intelligence",
+                "component_name": "foo",
+            },
+        )
+    assert response.status_code == 401
+    detail = response.json()["detail"]
+    assert "401" in detail or "OSIDB" in detail
 
 
 def test_read_root():

--- a/src/aegis_ai_web/tests/test_endpoints.py
+++ b/src/aegis_ai_web/tests/test_endpoints.py
@@ -6,11 +6,35 @@ from fastapi.testclient import TestClient
 from aegis_ai.features import cve as cve_features
 from aegis_ai.features.component.data_models import ComponentIntelligenceModel
 from aegis_ai.features.cve.data_models import SuggestAffectedComponentsModel
-from aegis_ai.toolsets.tools.osidb.osidb_client import OSIDBFlawNotFoundError
+from aegis_ai.toolsets.tools.osidb.osidb_client import (
+    OSIDBFlawNotFoundError,
+    OSIDBUnauthorizedError,
+)
 from aegis_ai_web.src.main import app
 
 # Create a TestClient instance based on your FastAPI app
 client = TestClient(app)
+
+
+def test_cve_analysis_osidb_unauthorized_returns_401():
+    """
+    OSIDB HTTP 401 (e.g. /auth/token or flaw API) maps to API 401, not 500.
+    """
+    with patch.object(
+        cve_features.SuggestCWE,
+        "exec",
+        new_callable=AsyncMock,
+        side_effect=OSIDBUnauthorizedError(),
+    ):
+        response = client.get(
+            "/api/v1/analysis/cve",
+            params={
+                "feature": "suggest-cwe",
+                "cve_id": "CVE-2026-4404",
+            },
+        )
+    assert response.status_code == 401
+    assert "401" in response.json()["detail"] or "OSIDB" in response.json()["detail"]
 
 
 def test_cve_analysis_osidb_flaw_not_found_returns_404():

--- a/src/aegis_ai_web/tests/test_endpoints.py
+++ b/src/aegis_ai_web/tests/test_endpoints.py
@@ -3,12 +3,37 @@ import yaml
 from unittest.mock import AsyncMock, MagicMock, patch
 from fastapi.testclient import TestClient
 
+from aegis_ai.features import cve as cve_features
 from aegis_ai.features.component.data_models import ComponentIntelligenceModel
 from aegis_ai.features.cve.data_models import SuggestAffectedComponentsModel
+from aegis_ai.toolsets.tools.osidb.osidb_client import OSIDBFlawNotFoundError
 from aegis_ai_web.src.main import app
 
 # Create a TestClient instance based on your FastAPI app
 client = TestClient(app)
+
+
+def test_cve_analysis_osidb_flaw_not_found_returns_404():
+    """
+    Missing OSIDB flaw (HTTP 404) maps to API 404 with a clear message, not 500.
+    """
+    with patch.object(
+        cve_features.SuggestCWE,
+        "exec",
+        new_callable=AsyncMock,
+        side_effect=OSIDBFlawNotFoundError("CVE-2025-59536"),
+    ):
+        response = client.get(
+            "/api/v1/analysis/cve",
+            params={
+                "feature": "suggest-cwe",
+                "cve_id": "CVE-2025-59536",
+            },
+        )
+    assert response.status_code == 404
+    detail = response.json()["detail"]
+    assert "CVE-2025-59536" in detail
+    assert "OSIDB" in detail
 
 
 def test_read_root():

--- a/src/aegis_ai_web/tests/test_feedback.py
+++ b/src/aegis_ai_web/tests/test_feedback.py
@@ -150,6 +150,7 @@ async def test_submit_feedback_after_suggest_impact_analysis(feedback_log_setup)
     feedback_data = {
         "feature": "suggest-impact",
         "cve_id": cve_id,
+        "email": "user@example.com",
         "actual": actual_impact,
         "expected": expected_impact,
         "accept": False,
@@ -202,6 +203,7 @@ def test_save_feedback_exception_handling(feedback_log_setup, monkeypatch):
     feedback_data = {
         "feature": "suggest-impact",
         "cve_id": "CVE-2025-12345",
+        "email": "user@example.com",
         "accept": True,
     }
     response = client.post("/api/v1/feedback", json=feedback_data)

--- a/src/aegis_ai_web/tests/test_feedback.py
+++ b/src/aegis_ai_web/tests/test_feedback.py
@@ -86,6 +86,27 @@ def test_save_feedback_validation_error_missing_field():
     response = client.post("/api/v1/feedback", json=feedback_data)
 
     assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert isinstance(detail, list) and len(detail) >= 1
+    assert any("feature" in err.get("loc", []) for err in detail)
+
+
+def test_save_feedback_validation_error_missing_cve_id_includes_detail():
+    """Missing cve_id returns 422 with a JSON body describing the error."""
+    feedback_data = {
+        "feature": "suggest-cwe",
+        "email": "joey@redhat.com",
+        "accept": True,
+    }
+    response = client.post("/api/v1/feedback", json=feedback_data)
+
+    assert response.status_code == 422
+    body = response.json()
+    assert "detail" in body
+    assert any(
+        err.get("type") == "missing" and "cve_id" in (err.get("loc") or [])
+        for err in body["detail"]
+    )
 
 
 def test_save_feedback_validation_error_bad_accept():

--- a/src/aegis_ai_web/tests/test_programmatic_feedback.py
+++ b/src/aegis_ai_web/tests/test_programmatic_feedback.py
@@ -58,6 +58,7 @@ def test_save_programmatic_feedback_exact_match(programmatic_feedback_log_setup)
     feedback_data = {
         "feature": "suggest-impact",
         "cve_id": "CVE-2025-23395",
+        "email": "user@example.com",
         "suggested_value": "CRITICAL",
         "submitted_value": "CRITICAL",
     }
@@ -127,6 +128,7 @@ def test_save_programmatic_feedback_empty_submitted_value(
     feedback_data = {
         "feature": "suggest-cwe",
         "cve_id": "CVE-2025-12345",
+        "email": "user@example.com",
         "suggested_value": "CWE-79",
         "submitted_value": "",
     }
@@ -437,6 +439,7 @@ def test_non_semantic_feature_uses_exact_match(programmatic_feedback_log_setup):
     feedback_data = {
         "feature": "suggest-impact",
         "cve_id": "CVE-2025-23395",
+        "email": "user@example.com",
         "suggested_value": "CRITICAL",
         "submitted_value": "HIGH",
     }

--- a/tests/test_logging_suppress.py
+++ b/tests/test_logging_suppress.py
@@ -1,0 +1,60 @@
+"""Tests for logging filters in aegis_ai.config_logging."""
+
+import logging
+import sys
+
+import pytest
+
+from aegis_ai import SuppressThirdPartyTracebackFilter
+
+
+def _record_with_exc_info(name: str) -> logging.LogRecord:
+    try:
+        raise ValueError("expected")
+    except ValueError:
+        exc_info = sys.exc_info()
+    r = logging.LogRecord(
+        name=name,
+        level=logging.ERROR,
+        pathname="p",
+        lineno=1,
+        msg="m",
+        args=(),
+        exc_info=None,
+    )
+    r.exc_info = exc_info
+    return r
+
+
+def test_suppress_traceback_filter_clears_requests_gssapi_when_not_debug():
+    f = SuppressThirdPartyTracebackFilter(show_tracebacks=False)
+    r = _record_with_exc_info("requests_gssapi.gssapi_")
+    assert r.exc_info is not None
+    assert f.filter(r) is True
+    assert r.exc_info is None
+    assert getattr(r, "exc_text", None) is None
+
+
+def test_suppress_traceback_filter_keeps_exc_info_at_debug():
+    f = SuppressThirdPartyTracebackFilter(show_tracebacks=True)
+    r = _record_with_exc_info("requests_gssapi.gssapi_")
+    assert f.filter(r) is True
+    assert r.exc_info is not None
+
+
+def test_suppress_traceback_filter_does_not_touch_aegis_loggers():
+    f = SuppressThirdPartyTracebackFilter(show_tracebacks=False)
+    r = _record_with_exc_info("aegis_ai.toolsets")
+    assert f.filter(r) is True
+    assert r.exc_info is not None
+
+
+@pytest.mark.parametrize(
+    "name",
+    ("gssapi", "gssapi.sec_contexts"),
+)
+def test_suppress_traceback_filter_clears_gssapi_family(name: str):
+    f = SuppressThirdPartyTracebackFilter(show_tracebacks=False)
+    r = _record_with_exc_info(name)
+    assert f.filter(r) is True
+    assert r.exc_info is None


### PR DESCRIPTION
## What

This branch tightens validation and error handling across several web APIs and supporting code:

- **Type check:** Aligns the `Enum` name for `CVEFeatureName` with the assigned variable (`OFFSEC-250`).
- **Feedback / OSIM:** Removes the interim workaround for OSIM-submitted feedback now that OSIM is updated (`AEGIS-294`, [osim#718](https://github.com/RedHatProductSecurity/osim/pull/718)).
- **Feedback APIs:** Makes selected fields required on the feedback endpoints and improves how validation errors are returned (`OFFSEC-255`).
- **OSIDB:** Maps OSIDB lookup and authentication failures to appropriate responses instead of surfacing them as generic internal errors on analysis endpoints (`OFFSEC-251`).
- **Logging:** Stops logging full GSSAPI tracebacks when not in debug mode, while keeping the related PR context (`OFFSEC-251`, [aegis-ai#535](https://github.com/RedHatProductSecurity/aegis-ai/pull/535)).
- **Component intelligence:** Improves error handling for the `component-intelligence` feature so failures are not reported as a blanket internal error (`OFFSEC-254`).

## Why

These changes address findings and follow-up from penetration testing and related reviews: stricter contracts on feedback APIs, clearer client-visible errors for external dependency failures (OSIDB, component intelligence), reduced noise and sensitive detail in logs for GSSAPI, and removal of temporary OSIM-specific behavior that is no longer needed.

## How to Test

- Run **`uvx ty check`** (with your project’s usual excludes, e.g. `--exclude src/aegis_ai_ml`) and confirm a clean type check for the touched code.
- **Feedback endpoints:** Call the feedback APIs with missing required fields and with invalid payloads; confirm **400**-style validation responses with clear messages, not **500**s.
- **Analysis / CVE features (`suggest-cwe` and similar):** With OSIDB unavailable, misconfigured, or returning auth/lookup errors, confirm responses are **not** the generic internal error  
  `"An internal error occurred while executing CVE feature 'suggest-cwe'."`  
  unless the situation truly is an internal failure.
- **GSSAPI:** In non-debug mode, trigger an auth path that would previously log GSSAPI tracebacks; confirm logs no longer include full tracebacks (and that debug mode still behaves as intended if applicable).
- **Component intelligence:** Force or simulate a failure in the component-intelligence path; confirm the API does **not** return the generic internal error  
  `"An internal error occurred while executing Component feature 'component-intelligence'."`  
  for cases that should be classified as client or dependency errors.
- **OSIM integration:** Submit feedback via the current OSIM flow and confirm behavior matches expectations without the removed interim fix.

## Related Tickets

- [OFFSEC-250](https://redhat.atlassian.net/browse/OFFSEC-250) — `CVEFeatureName` / Enum type-name fix  
- [AEGIS-294](https://redhat.atlassian.net/browse/AEGIS-294) — drop interim OSIM feedback fix ([osim#718](https://github.com/RedHatProductSecurity/osim/pull/718))  
- [OFFSEC-255](https://redhat.atlassian.net/browse/OFFSEC-255) — feedback API required fields and validation errors  
- [OFFSEC-251](https://redhat.atlassian.net/browse/OFFSEC-251) — OSIDB lookup/auth handling and GSSAPI logging  
- [OFFSEC-254](https://redhat.atlassian.net/browse/OFFSEC-254) — `component-intelligence` error handling  
- [aegis-ai#535](https://github.com/RedHatProductSecurity/aegis-ai/pull/535) — related GSSAPI / logging context

[OFFSEC-250]: https://redhat.atlassian.net/browse/OFFSEC-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Harden API validation, error handling, and logging around feedback submission, OSIDB/component analysis integrations, and delegated authentication.

New Features:
- Introduce a centralized FastAPI request validation error handler that logs sanitized details and returns the standard 422 response body.
- Add explicit OSIDBFlawNotFoundError and OSIDBUnauthorizedError types to distinguish OSIDB 404 and 401 conditions in callers.
- Add a logging filter to suppress noisy Kerberos/GSSAPI tracebacks from third-party loggers outside of debug mode.

Bug Fixes:
- Correct the CVE feature Enum name so it aligns with CVEFeatureName and resolves the previous misnaming.
- Ensure CVE and component analysis endpoints map OSIDB 401/404/auth failures to appropriate HTTP responses instead of generic 500 errors.
- Tighten feedback and programmatic feedback schemas so feature, cve_id, and email are required fields, avoiding silently missing identifiers in stored feedback.
- Remove the temporary OSIM-specific feedback compatibility path that accepted alternate CVE ID fields and empty email values.

Enhancements:
- Improve CVE and component analysis error messages by using the feature name value consistently in logs and responses.
- Propagate OSIDB-specific errors from the OSIDB tool layer without wrapping them in generic internal error messages so callers can present clearer failures.

Tests:
- Extend endpoint, feedback, programmatic feedback, and delegated auth tests to cover OSIDB 401/404 mapping, required feedback fields, and the new error-handling paths.