### PR TITLE
do not mention publicly available exploits in the suggested description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,6 +166,9 @@ cython_debug/
 # PyPI configuration file
 .pypirc
 
+# Claude
+/.claude
+
 # Aegis specific
 .attic
 Makefile

--- a/evals/features/cve/test_suggest_description.py
+++ b/evals/features/cve/test_suggest_description.py
@@ -254,6 +254,10 @@ evals = common_feature_evals + [
         rubric="suggested_title and suggested_description do not contain versions of affected components, except in acronyms explanation and in acronyms themselves.  Do not confuse API endpoint versions with component versions.",
     ),
     create_llm_judge(
+        assertion_name="NoExploitDisclosure",
+        rubric="suggested_description does not mention exploit availability or public disclosure status (e.g., 'The exploit has been publicly disclosed', 'A public exploit exists'). The description should focus on the vulnerability itself, not on whether exploits are available.",
+    ),
+    create_llm_judge(
         assertion_name="TitleSummarizesDescription",
         rubric="suggested_title briefly summarizes what is described in suggested_description",
     ),

--- a/evals/features/cve/test_suggest_statement.py
+++ b/evals/features/cve/test_suggest_statement.py
@@ -188,6 +188,7 @@ cases = [
             To mitigate this vulnerability, consider removing these packages. Note that some of these packages are required by GNOME, removing them will also remove GNOME and other packages, breaking functionality. However, the server can still be used via the terminal interface.
             Additionally, WebKitGTK3 is not required by any package. Therefore, it can be removed without consequences or break of functionality.
             """,
+        metadata={"known_to_fail_evaluators": ["MitigationWellFormedCommands"]},
     ),
     SuggestStatementCase(
         cve_id="CVE-2024-53197",

--- a/src/aegis_ai/features/cve/__init__.py
+++ b/src/aegis_ai/features/cve/__init__.py
@@ -244,6 +244,7 @@ class SuggestDescriptionText(Feature):
                 - Use plain English; avoid deep implementation jargon. If a function or symbol name is central to exploitation, you may mention a single example and explain it briefly.
                 - If a term or acronym is needed, briefly define it and expand the acronym in parentheses on first use.
                 - Do not include product/version lists, package names, or mitigation/update guidance.
+                - Do not mention exploit availability or public disclosure status (e.g., "The exploit has been publicly disclosed").
                 - Avoid generic CIA boilerplate; name the concrete impact (e.g., data disclosure, code execution, denial of service).
                 - When upstream or reference text in the CVE is well written, prefer clarity and professional advisory tone over adding redundant phrasing.
                 - Ambiguity and uncertainty:


### PR DESCRIPTION
## What

- Add a prompt rule to `suggest-description` preventing Aegis from mentioning exploit availability or public disclosure status in suggested CVE descriptions.
- Add a `NoExploitDisclosure` LLM judge evaluator to catch regressions.
- Mark `MitigationWellFormedCommands` as a known-to-fail evaluator for CVE-2024-44308 in `suggest-statement` evals.
- Add `.claude` to `.gitignore`.

## Why

- Aegis was sometimes appending phrases like "The exploit has been publicly disclosed" to suggested descriptions, which is not appropriate for flaw descriptions (AEGIS-392).
- The `MitigationWellFormedCommands` LLM judge occasionally misidentifies `JavaScriptCoreUseJIT` as an incorrect environment variable, even though it is the one used in Red Hat's official mitigation for CVE-2024-44308.

## How to Test

- Run `suggest-description` evals and verify the new `NoExploitDisclosure` evaluator passes.
- Run `suggest-statement` evals and verify CVE-2024-44308 no longer causes spurious failures.

## Related Tickets
Related: https://redhat.atlassian.net/browse/AEGIS-392

## Summary by Sourcery

Tighten CVE description generation rules around exploit disclosure and adjust related evaluations and test metadata.

Enhancements:
- Add a prompt guideline to CVE description generation to avoid mentioning exploit availability or public disclosure status.

Tests:
- Add a NoExploitDisclosure LLM judge evaluator to the suggest-description eval suite.
- Mark the MitigationWellFormedCommands evaluator as known-to-fail for the CVE-2024-44308 suggest-statement case to avoid spurious test failures.

Chores:
- Ignore .claude files in version control.