### PR TITLE
process feedback from Aegis API endpoints from 2026-03-16

### DIFF
--- a/evals/features/cve/test_suggest_cwe.py
+++ b/evals/features/cve/test_suggest_cwe.py
@@ -75,6 +75,11 @@ async def suggest_cwe(cve_id: CVEID) -> SuggestCWEModel:
 # TODO: gradually remove known_to_fail_evaluators annotations where possible
 cases = [
     SuggestCweCase(
+        cve_id="CVE-2019-25544",
+        cwe_list=["CWE-1284"],
+        metadata={"known_to_fail_evaluators": ["SuggestCweEvaluator"]},
+    ),
+    SuggestCweCase(
         cve_id="CVE-2022-48701",
         cwe_list=["CWE-125", "CWE-20"],
         metadata={"known_to_fail_evaluators": ["SuggestCweEvaluator"]},
@@ -270,11 +275,6 @@ cases = [
         metadata={"known_to_fail_evaluators": ["SuggestCweEvaluator"]},
     ),
     SuggestCweCase(
-        cve_id="CVE-2023-53843",
-        cwe_list=["CWE-1284", "CWE-1285", "CWE-681"],  # kdudka: added CWE-1285
-        metadata={"known_to_fail_evaluators": ["SuggestCweEvaluator"]},
-    ),
-    SuggestCweCase(
         cve_id="CVE-2023-53555",
         cwe_list=["CWE-824"],
     ),
@@ -300,6 +300,11 @@ cases = [
     SuggestCweCase(
         cve_id="CVE-2023-53764",
         cwe_list=["CWE-414", "CWE-413"],  # kdudka: added CWE-413
+    ),
+    SuggestCweCase(
+        cve_id="CVE-2023-53843",
+        cwe_list=["CWE-1284", "CWE-1285", "CWE-681"],  # kdudka: added CWE-1285
+        metadata={"known_to_fail_evaluators": ["SuggestCweEvaluator"]},
     ),
     SuggestCweCase(
         cve_id="CVE-2023-54201",
@@ -690,6 +695,16 @@ cases = [
         metadata={"known_to_fail_evaluators": ["SuggestCweEvaluator"]},
     ),
     SuggestCweCase(
+        cve_id="CVE-2025-59031",
+        cwe_list=["CWE-611", "CWE-22"],
+        metadata={"known_to_fail_evaluators": ["SuggestCweEvaluator"]},
+    ),
+    SuggestCweCase(
+        cve_id="CVE-2025-59032",
+        cwe_list=["CWE-229"],
+        metadata={"known_to_fail_evaluators": ["SuggestCweEvaluator"]},
+    ),
+    SuggestCweCase(
         cve_id="CVE-2025-59303",
         cwe_list=["CWE-497", "CWE-807"],
         metadata={"known_to_fail_evaluators": ["SuggestCweEvaluator"]},
@@ -752,6 +767,118 @@ cases = [
                 "CWEExplanationRootCause",
             ]
         },
+    ),
+    SuggestCweCase(
+        cve_id="CVE-2025-69196",
+        cwe_list=["CWE-1220"],
+        metadata={"known_to_fail_evaluators": ["SuggestCweEvaluator"]},
+    ),
+    SuggestCweCase(
+        cve_id="CVE-2026-3608",
+        cwe_list=["CWE-617"],
+        metadata={"known_to_fail_evaluators": ["SuggestCweEvaluator"]},
+    ),
+    SuggestCweCase(
+        cve_id="CVE-2026-3644",
+        cwe_list=["CWE-791"],
+        metadata={"known_to_fail_evaluators": ["SuggestCweEvaluator"]},
+    ),
+    SuggestCweCase(
+        cve_id="CVE-2026-25780",
+        cwe_list=["CWE-770"],
+    ),
+    SuggestCweCase(
+        cve_id="CVE-2026-26740",
+        cwe_list=["CWE-131", "CWE-787", "CWE-805"],
+    ),
+    SuggestCweCase(
+        cve_id="CVE-2026-26939",
+        cwe_list=["CWE-1220", "CWE-862", "CWE-266"],
+        metadata={"known_to_fail_evaluators": ["SuggestCweEvaluator"]},
+    ),
+    SuggestCweCase(
+        cve_id="CVE-2026-27651",
+        cwe_list=["CWE-476"],
+        metadata={"known_to_fail_evaluators": ["SuggestCweEvaluator"]},
+    ),
+    SuggestCweCase(
+        cve_id="CVE-2026-27784",
+        cwe_list=["CWE-190", "CWE-131", "CWE-805", "CWE-787", "CWE-120", "CWE-125"],
+    ),
+    SuggestCweCase(
+        cve_id="CVE-2026-27859",
+        cwe_list=["CWE-770"],
+    ),
+    SuggestCweCase(
+        cve_id="CVE-2026-28500",
+        cwe_list=["CWE-829"],
+        metadata={"known_to_fail_evaluators": ["SuggestCweEvaluator"]},
+    ),
+    SuggestCweCase(
+        cve_id="CVE-2026-29063",
+        cwe_list=["CWE-915"],
+    ),
+    SuggestCweCase(
+        cve_id="CVE-2026-31966",
+        cwe_list=["CWE-125"],
+        metadata={"known_to_fail_evaluators": ["SuggestCweEvaluator"]},
+    ),
+    SuggestCweCase(
+        cve_id="CVE-2026-31969",
+        cwe_list=["CWE-787"],
+    ),
+    SuggestCweCase(
+        cve_id="CVE-2026-31970",
+        cwe_list=["CWE-190"],
+    ),
+    SuggestCweCase(
+        cve_id="CVE-2026-31971",
+        cwe_list=["CWE-131"],
+    ),
+    SuggestCweCase(
+        cve_id="CVE-2026-31973",
+        cwe_list=["CWE-476"],
+    ),
+    SuggestCweCase(
+        cve_id="CVE-2026-32636",
+        cwe_list=["CWE-787"],
+    ),
+    SuggestCweCase(
+        cve_id="CVE-2026-33001",
+        cwe_list=["CWE-22", "CWE-59"],
+    ),
+    SuggestCweCase(
+        cve_id="CVE-2026-33002",
+        cwe_list=["CWE-346"],
+    ),
+    SuggestCweCase(
+        cve_id="CVE-2026-33551",
+        cwe_list=["CWE-266"],
+    ),
+    SuggestCweCase(
+        cve_id="CVE-2026-33995",
+        cwe_list=["CWE-1341", "CWE-415"],
+    ),
+    SuggestCweCase(
+        cve_id="CVE-2026-34785",
+        cwe_list=["CWE-552", "CWE-73", "CWE-22"],
+    ),
+    SuggestCweCase(
+        cve_id="CVE-2026-35535",
+        cwe_list=["CWE-272", "CWE-273"],
+    ),
+    SuggestCweCase(
+        cve_id="CVE-2026-35536",
+        cwe_list=["CWE-88", "CWE-140", "CWE-93"],
+        metadata={"known_to_fail_evaluators": ["SuggestCweEvaluator"]},
+    ),
+    SuggestCweCase(
+        cve_id="CVE-2026-35540",
+        cwe_list=["CWE-918"],
+    ),
+    SuggestCweCase(
+        cve_id="CVE-2026-40223",
+        cwe_list=["CWE-617"],
     ),
 ]
 

--- a/evals/features/cve/test_suggest_description.py
+++ b/evals/features/cve/test_suggest_description.py
@@ -118,18 +118,6 @@ async def suggest_description(cve_id: CVEID) -> SuggestDescriptionModel:
 # test cases
 cases = [
     SuggestDescriptionCase(
-        # not vetted by a PSIRT analyst
-        cve_id="CVE-2025-5399",
-        expected_title="WebSocket endless loop",
-        expected_description="A flaw was found in libcurl. This vulnerability allows a denial of service via a crafted WebSocket packet from a malicious server.",
-    ),
-    SuggestDescriptionCase(
-        # not vetted by a PSIRT analyst
-        cve_id="CVE-2025-23395",
-        expected_title="Local Root Exploit via `logfile_reopen()`",
-        expected_description="A flaw was found in Screen. When running with setuid-root privileged, the  logfile_reopen() function does not drop privileges while operating on a user-supplied path. This vulnerability allows an unprivileged user to create files in arbitrary locations with root ownership.",
-    ),
-    SuggestDescriptionCase(
         cve_id="CVE-2002-1001",
         expected_title="tokio-tar:  parses PAX extended headers incorrectly, allows file smuggling",
     ),
@@ -159,6 +147,12 @@ cases = [
         expected_description="A flaw was identified in the Bluetooth HIDP (Human Interface Device Protocol) implementation of the Linux kernel where a race condition in the hidp_session_thread handling can lead to a use-after-free vulnerability. Under certain timing conditions, the session object may be freed while a timer callback is still active, resulting in dereferencing freed memory and potential kernel panic or local escalation of privileges. The underlying cause is the use of hidp_del_timer without ensuring that the timer has fully stopped, which allows concurrent access to freed session resources",
     ),
     SuggestDescriptionCase(
+        # not vetted by a PSIRT analyst
+        cve_id="CVE-2025-5399",
+        expected_title="WebSocket endless loop",
+        expected_description="A flaw was found in libcurl. This vulnerability allows a denial of service via a crafted WebSocket packet from a malicious server.",
+    ),
+    SuggestDescriptionCase(
         cve_id="CVE-2025-12816",
         expected_title="node-forge: Interpretation conflict vulnerability allows bypassing cryptographic verifications",
         expected_description="A flaw was found in node-forge. This vulnerability allows unauthenticated attackers to bypass downstream cryptographic verifications and security decisions via crafting ASN.1 (Abstract Syntax Notation One) structures to desynchronize schema validations, yielding a semantic divergence.",
@@ -174,6 +168,12 @@ cases = [
     SuggestDescriptionCase(
         cve_id="CVE-2025-13609",
         expected_description="A vulnerability has been identified in keylime where an attacker can exploit this flaw by registering a new agent using a different Trusted Platform Module (TPM) device but claiming an existing agent's unique identifier (UUID). This action overwrites the legitimate agent's identity, enabling the attacker to impersonate the compromised agent and potentially bypass security controls.",
+    ),
+    SuggestDescriptionCase(
+        # not vetted by a PSIRT analyst
+        cve_id="CVE-2025-23395",
+        expected_title="Local Root Exploit via `logfile_reopen()`",
+        expected_description="A flaw was found in Screen. When running with setuid-root privileged, the  logfile_reopen() function does not drop privileges while operating on a user-supplied path. This vulnerability allows an unprivileged user to create files in arbitrary locations with root ownership.",
     ),
     # FIXME: `suggest-description` should not talk about `Denial of Service`
     # SuggestDescriptionCase(
@@ -235,6 +235,30 @@ cases = [
     SuggestDescriptionCase(
         cve_id="CVE-2025-91735",
         expected_description="A flaw was found in /driver/xyz.c in xyg sub component in the Linux kernel. This vulnerability allows a buffer overflow due to xyz leading to abc.",
+    ),
+    SuggestDescriptionCase(
+        cve_id="CVE-2026-31898",
+        expected_title="jsPDF: Arbitrary code execution via unsanitized input in createAnnotation method",
+    ),
+    SuggestDescriptionCase(
+        cve_id="CVE-2026-31966",
+        expected_title="htslib: Information disclosure and denial of service due to insufficient CRAM feature data validation",
+    ),
+    SuggestDescriptionCase(
+        cve_id="CVE-2026-31967",
+        expected_title="HTSlib: Information disclosure and Denial of Service via unvalidated CRAM mate reference ID",
+    ),
+    SuggestDescriptionCase(
+        cve_id="CVE-2026-32636",
+        expected_title="ImageMagick: Denial of Service via out-of-bounds write in NewXMLTree method",
+    ),
+    SuggestDescriptionCase(
+        cve_id="CVE-2026-33001",
+        expected_title="Jenkins: Arbitrary file write and potential code execution through crafted archives",
+    ),
+    SuggestDescriptionCase(
+        cve_id="CVE-2026-33002",
+        expected_title="Jenkins: Origin validation bypass via DNS rebinding in CLI WebSocket endpoint",
     ),
     SuggestDescriptionCase(
         cve_id="CVE-2099-99999",

--- a/evals/features/cve/test_suggest_description.py
+++ b/evals/features/cve/test_suggest_description.py
@@ -174,6 +174,7 @@ cases = [
         cve_id="CVE-2025-23395",
         expected_title="Local Root Exploit via `logfile_reopen()`",
         expected_description="A flaw was found in Screen. When running with setuid-root privileged, the  logfile_reopen() function does not drop privileges while operating on a user-supplied path. This vulnerability allows an unprivileged user to create files in arbitrary locations with root ownership.",
+        metadata={"known_to_fail_evaluators": ["NoVersionInfo"]},
     ),
     # FIXME: `suggest-description` should not talk about `Denial of Service`
     # SuggestDescriptionCase(

--- a/evals/features/cve/test_suggest_impact.py
+++ b/evals/features/cve/test_suggest_impact.py
@@ -303,13 +303,13 @@ cases = [
         expected_cvss3_vector="CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:N/I:L/A:H",
     ),
     SuggestImpactCase(
+        cve_id="CVE-2023-54201",
+        expected_cvss3_vector="CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:N/A:H",
+    ),
+    SuggestImpactCase(
         cve_id="CVE-2024-53232",
         expected_impact="MODERATE",
         expected_cvss3_score=4.4,
-    ),
-    SuggestImpactCase(
-        cve_id="CVE-2023-54201",
-        expected_cvss3_vector="CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:N/A:H",
     ),
     SuggestImpactCase(
         cve_id="CVE-2025-5399",
@@ -452,6 +452,42 @@ cases = [
         expected_cvss3_score="6.3",
         expected_cvss3_vector="CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
         metadata={"known_to_fail_evaluators": ["CVSSKernelScopeAndPrivileges"]},
+    ),
+    SuggestImpactCase(
+        cve_id="CVE-2026-21727",
+        expected_impact="LOW",
+    ),
+    SuggestImpactCase(
+        cve_id="CVE-2026-23361",
+        expected_cvss3_vector="CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+        metadata={"known_to_fail_evaluators": ["CVSSVectorEvaluator"]},
+    ),
+    SuggestImpactCase(
+        cve_id="CVE-2026-23376",
+        expected_impact="LOW",
+    ),
+    SuggestImpactCase(
+        cve_id="CVE-2026-28387",
+        expected_impact="LOW",
+    ),
+    SuggestImpactCase(
+        cve_id="CVE-2026-28388",
+        expected_impact="LOW",
+    ),
+    SuggestImpactCase(
+        cve_id="CVE-2026-34073",
+        expected_impact="LOW",
+    ),
+    SuggestImpactCase(
+        cve_id="CVE-2026-35386",
+        expected_impact="LOW",
+        expected_cvss3_vector="CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:L/I:L/A:N",
+    ),
+    SuggestImpactCase(
+        cve_id="CVE-2026-35537",
+        expected_impact="LOW",
+        expected_cvss3_vector="CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
+        metadata={"known_to_fail_evaluators": ["ImpactEvaluator"]},
     ),
 ]
 

--- a/evals/features/cve/test_suggest_statement.py
+++ b/evals/features/cve/test_suggest_statement.py
@@ -336,6 +336,10 @@ cases = [
         metadata={"known_to_fail_evaluators": ["MitigationWellFormedCommands"]},
     ),
     SuggestStatementCase(
+        cve_id="CVE-2025-53020",
+        expected_mitigation="The attack surface can be reduced by disabling HTTP/2 support in Apache.\nFollow the guidance in Red Hat KCS article to:\n- Remove h2 and h2c from the Protocols directive\n- Disable mod_http2 and mod_proxy_http2 modules (if not required)\n\nhttps://access.redhat.com/node/7056356",
+    ),
+    SuggestStatementCase(
         cve_id="CVE-2025-64503",
         expected_statement="This vulnerability is rated Moderate for Red Hat Enterprise Linux because a specially crafted PDF file, when processed by the `cups-filters` `pdftoraster` tool, can lead to an out-of-bounds write, potentially causing a denial of service. This affects Red Hat Enterprise Linux 7, 8, 9, and 10.",
     ),
@@ -377,9 +381,56 @@ cases = [
         },
     ),
     SuggestStatementCase(
+        cve_id="CVE-2026-3497",
+        expected_mitigation="To mitigate this issue, disable GSSAPI key exchange in the OpenSSH server configuration. This prevents the server from processing GSSAPI messages, eliminating the vulnerability's attack surface.\n\nEdit `/etc/ssh/sshd_config` and add or modify the line:\n```\nGSSAPIKeyExchange no\n```\n\nAfter saving the changes, restart the `sshd` service for the mitigation to take effect. This action will prevent users from authenticating via GSSAPI.\n\n```\n# systemctl restart sshd\n```",
+    ),
+    SuggestStatementCase(
+        cve_id="CVE-2026-4271",
+        expected_mitigation="Mitigation for this issue is either not available or the currently available options don't meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability.",
+        metadata={"known_to_fail_evaluators": ["MitigationEvaluator"]},
+    ),
+    SuggestStatementCase(
+        cve_id="CVE-2026-5483",
+        expected_statement="A flaw in the `odh-dashboard` component of Red Hat OpenShift AI allows for the disclosure of Kubernetes Service Account tokens through a NodeJS endpoint. This vulnerability could enable an attacker to gain unauthorized access to Kubernetes resources within the OpenShift AI environment.",
+        expected_mitigation="If applying the update is not immediately possible, the vulnerability can be mitigated by disabling or removing the NIM (NVIDIA Inference Microservice) integration from the Red Hat OpenShift AI (RHOAI) environment.",
+        metadata={"known_to_fail_evaluators": ["MitigationEvaluator"]},
+    ),
+    SuggestStatementCase(
         cve_id="CVE-2026-22822",
         expected_mitigation="To mitigate this issue, implement a policy engine such as Kubernetes, Kyverno, Kubewarden, or OPA. Configure the policy engine to prevent the usage of the `getSecretKey` function within any ExternalSecret resource. This will block the insecure cross-namespace secret retrieval capability.",
         metadata={"known_to_fail_evaluators": ["StatementNoDuplicatedInfo"]},
+    ),
+    SuggestStatementCase(
+        cve_id="CVE-2026-24450",
+        expected_statement="This flaw in the LibRaw library consists in an integer overflow in the `uncompressed_fp_dng_load_raw` function, a successfully performed attack may lead to a heap buffer overflow and potentially arbitrary code execution or denial of service. The vulnerability stems from the usage of a 32-bit arithmetic to calculate the pixel buffers when decoding the raw image file, which may end up overflowing when processing user controlled images as input.\n\nThis vulnerability is not exploitable when the application consuming LibRaw is using the default memory limit (`max_raw_memory_mb` parameter) to unpack the RAW image. To be considered vulnerable the application should be setting the limit to around or greater then 16GB.\n\nRed Hat Product Security has rated this vulnerability as having a Moderate impact, despite the possibility of arbitrary code execution due to the heap-based buffer overflow, as the user needs to be tricked to process a maliciously crafted image or LibRaw needs to be exposed to the network and accept untrusted data as input. Additionally the default `max_raw_memory_mb` value set with LibRaw is not enough to trigger the vulnerability.",
+        metadata={"known_to_fail_evaluators": ["StatementNoCodeLevelDetails"]},
+    ),
+    SuggestStatementCase(
+        cve_id="CVE-2026-27820",
+        expected_statement="A buffer overflow vulnerability exists in the Zlib::GzipReader component of the Ruby zlib interface. This flaw, caused by insufficient memory capacity during data manipulation, could lead to memory corruption and system instability. This vulnerability is considered of a Moderate severity this happens because the high complexity to exploit, additionally the attacker may have not full control over the data is being corrupted or exfiltrated.",
+        metadata={"known_to_fail_evaluators": ["StatementNoDuplicatedInfo"]},
+    ),
+    SuggestStatementCase(
+        cve_id="CVE-2026-27962",
+        expected_statement="This critical vulnerability in Authlib's JWS implementation allows unauthenticated attackers to forge JWTs by embedding their own cryptographic key in the token header. Impact is high to confidentiality and integrity as attackers can bypass authentication.\n\nRed Hat Quay is not affected, as it imports authlib solely as a JWK parsing utility and performs all JWT signature verification through PyJWT, so the vulnerable jws.deserialize_compact() code path is never called.\n\nRed Hat OpenShift AI is not affected, since authlib is only present as a transitive dependency in the dev dependency group and is not included in production image builds, so the vulnerable code is not present in the shipped product.\n\nRed Hat Satellite is not affected, as authlib is only present as a dependency of fastmcp. In Satellite, fastmcp only invokes authlib using jwt.decode() which isn't able to reach the vulnerability condition even with key=none.",
+    ),
+    SuggestStatementCase(
+        cve_id="CVE-2026-31402",
+        expected_statement="This Important flaw in the Linux kernel's NFSv4.0 server (nfsd) allows a heap overflow. In this flaw a local attacker can trigger this by orchestrating two NFSv4.0 clients to create a conflicting lock with an oversized owner string.",
+        metadata={"known_to_fail_evaluators": ["StatementEvaluator"]},
+    ),
+    SuggestStatementCase(
+        cve_id="CVE-2026-35091",
+        expected_statement="This vulnerability has a Moderate impact on Red Hat products. A flaw in Corosync's membership commit token sanity check, when running in the default totemudp/totemudpu mode, allows a remote unauthenticated attacker to send a crafted UDP packet. This can lead to an out-of-bounds read, resulting in a denial of service and potential limited memory content disclosure. This issue affects Corosync only when configured to use the legacy totemudp or totemudpu transport modes with unencrypted communication.\n\nThese modes are not the default in modern Corosync versions. The default transport is knet, which supports encryption and is the standard configuration in RHEL.",
+    ),
+    SuggestStatementCase(
+        cve_id="CVE-2026-40175",
+        expected_statement='Critical impact: The Axios library, a promise-based HTTP client, is susceptible to a prototype pollution vulnerability. This flaw, when combined with specific "Gadget" attack chains in third-party dependencies, can lead to remote code execution.',
+    ),
+    SuggestStatementCase(
+        cve_id="CVE-2026-40227",
+        expected_mitigation="This issue can be mitigated by changing the permission of the varsock file located at:\n~~~\n/run/systemd/io.systemd.Manager\n~~~\nto be accessible only by trusted or privileged users.",
+        metadata={"known_to_fail_evaluators": ["MitigationEvaluator"]},
     ),
 ]
 

--- a/evals/osidb_cache/CVE-2019-25544.json
+++ b/evals/osidb_cache/CVE-2019-25544.json
@@ -1,0 +1,49 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2019-25544",
+    "cwe_id": "CWE-1284",
+    "impact": "MODERATE",
+    "title": "Pidgin: Denial of Service via excessively long username",
+    "statement": "This Moderate impact denial of service flaw in Pidgin allows a local attacker to crash the application. By providing an excessively long username string during account creation, the application becomes unavailable when attempting to join a chat.",
+    "mitigation": "Red Hat is not aware of a practical temporary workaround that fully or partially mitigates this issue or meets Red Hat Product Security's standards for usability, deployment, applicability, or stability.",
+    "comment_zero": "Pidgin 2.13.0 contains a denial of service vulnerability that allows local attackers to crash the application by providing an excessively long username string during account creation. Attackers can input a buffer of 1000 characters in the username field and trigger a crash when joining a chat, causing the application to become unavailable.",
+    "comments": "",
+    "description": "A flaw was found in Pidgin. Local attackers can exploit this denial of service vulnerability by providing an excessively long username string during account creation. This can cause the application to crash when joining a chat, leading to the application becoming unavailable.",
+    "components": [
+        "Pidgin"
+    ],
+    "references": [
+        {
+            "url": "https://www.exploit-db.com/exploits/46930"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2019-25544"
+        },
+        {
+            "url": "https://pidgin.im/"
+        },
+        {
+            "url": "https://www.vulncheck.com/advisories/pidgin-denial-of-service-via-malformed-username"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:4.0/AV:L/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N"
+        },
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        },
+        {
+            "issuer": "NIST",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2025-53020.json
+++ b/evals/osidb_cache/CVE-2025-53020.json
@@ -1,0 +1,35 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2025-53020",
+    "cwe_id": "CWE-401",
+    "impact": "MODERATE",
+    "title": "Apache HTTP Server: HTTP/2 DoS by Memory Increase",
+    "statement": "",
+    "mitigation": "The attack surface can be reduced by disabling HTTP/2 support in Apache.\nFollow the guidance in Red Hat KCS article to:\n- Remove h2 and h2c from the Protocols directive\n- Disable mod_http2 and mod_proxy_http2 modules (if not required)\n\nhttps://access.redhat.com/node/7056356",
+    "comment_zero": "Late Release of Memory after Effective Lifetime vulnerability in Apache HTTP Server.\n\nThis issue affects Apache HTTP Server: from 2.4.17 up to 2.4.63.\n\nUsers are recommended to upgrade to version 2.4.64, which fixes the issue.",
+    "comments": "",
+    "description": "A flaw was found in Apache HTTP Server. This late release of memory after effective lifetime vulnerability allows a remote, unauthenticated attacker to cause a denial of service (DoS). The vulnerability can lead to resource exhaustion, making the server unavailable to legitimate users.",
+    "components": [
+        "httpd"
+    ],
+    "references": [
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2025-53020"
+        },
+        {
+            "url": "https://httpd.apache.org/security/vulnerabilities_24.html"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "CISA",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2025-59031.json
+++ b/evals/osidb_cache/CVE-2025-59031.json
@@ -1,0 +1,35 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2025-59031",
+    "cwe_id": "CWE-611",
+    "impact": "MODERATE",
+    "title": "Dovecot: Information disclosure via specially crafted OOXML documents",
+    "statement": "",
+    "mitigation": "",
+    "comment_zero": "Dovecot has provided a script to use for attachment to text conversion. This script unsafely handles zip-style attachments. Attacker can use specially crafted OOXML documents to cause unintended files on the system to be indexed and subsequently ending up in FTS indexes. Do not use the provided script, instead, use something else like FTS tika. No publicly available exploits are known.",
+    "comments": "",
+    "description": "A flaw was found in Dovecot. An attacker can exploit this by using specially crafted OOXML (Office Open XML) documents that are unsafely handled by a provided script designed for attachment to text conversion. This can lead to unintended files on the system being indexed and subsequently exposed in Full Text Search (FTS) indexes, resulting in information disclosure.",
+    "components": [
+        "dovecot"
+    ],
+    "references": [
+        {
+            "url": "https://documentation.open-xchange.com/dovecot/security/advisories/csaf/2026/oxdc-adv-2026-0001.json"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2025-59031"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2025-59032.json
+++ b/evals/osidb_cache/CVE-2025-59032.json
@@ -1,0 +1,35 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2025-59032",
+    "cwe_id": "CWE-229",
+    "impact": "IMPORTANT",
+    "title": "ManageSieve: Denial of Service via crafted SASL initial response in AUTHENTICATE command",
+    "statement": "",
+    "mitigation": "",
+    "comment_zero": "ManageSieve AUTHENTICATE command crashes when using literal as SASL initial response. This can be used to crash ManageSieve service repeatedly, making it unavailable for other users. Control access to ManageSieve port, or disable the service if it's not needed. Alternatively upgrade to a fixed version. No publicly available exploits are known.",
+    "comments": "",
+    "description": "A flaw was found in ManageSieve. A remote attacker can exploit this vulnerability by sending a crafted SASL (Simple Authentication and Security Layer) initial response during the AUTHENTICATE command. This can cause the ManageSieve service to crash repeatedly, leading to a Denial of Service (DoS) for other users.",
+    "components": [
+        "dovecot"
+    ],
+    "references": [
+        {
+            "url": "https://documentation.open-xchange.com/dovecot/security/advisories/csaf/2026/oxdc-adv-2026-0001.json"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2025-59032"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2025-69196.json
+++ b/evals/osidb_cache/CVE-2025-69196.json
@@ -1,0 +1,39 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2025-69196",
+    "cwe_id": "CWE-1220",
+    "impact": "IMPORTANT",
+    "title": "FastMCP: Improper token issuance due to incorrect resource parameter handling",
+    "statement": "Important: FastMCP, as utilized in several Red Hat products, contains a flaw where the server incorrectly processes the resource parameter during authorization and token requests. This can lead to security tokens being issued for an unintended base URL, potentially allowing unauthorized access or information disclosure. This affects Hosted OpenShift Clusters, Red Hat OpenShift AI, and Red Hat Satellite. Red Hat Developer Hub is not affected as the vulnerable code is not present.",
+    "mitigation": "",
+    "comment_zero": "FastMCP is the standard framework for building MCP applications. Prior to version 2.14.2, the server does not properly respect the resource parameter submitted by the client in the authorization and token request. Instead of issuing the token explicitly for the MCP server, the token is issued for the base_url passed to the OAuthProxy during initialization. This issue has been patched 2.14.2.",
+    "comments": "",
+    "description": "A flaw was found in FastMCP, a framework for building MCP applications. The server does not correctly process the resource parameter provided by the client during authorization and token requests. This can lead to security tokens being issued for an unintended base URL (Uniform Resource Locator) instead of the specific MCP server. Such improper token issuance could allow an attacker to gain unauthorized access or disclose sensitive information.",
+    "components": [
+        "fastmcp"
+    ],
+    "references": [
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2025-69196"
+        },
+        {
+            "url": "https://github.com/PrefectHQ/fastmcp/security/advisories/GHSA-5h2m-4q8j-pqpj"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:4.0/AV:N/AC:H/AT:N/PR:N/UI:A/VC:H/VI:H/VA:N/SC:N/SI:N/SA:N"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N"
+        },
+        {
+            "issuer": "NIST",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:N/A:N"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-21727.json
+++ b/evals/osidb_cache/CVE-2026-21727.json
@@ -1,0 +1,35 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-21727",
+    "cwe_id": "CWE-653",
+    "impact": "LOW",
+    "title": "Grafana: Cross-tenant data disclosure and deletion via legacy correlation records",
+    "statement": "This Low impact cross-tenant isolation vulnerability in Grafana affects legacy correlation records created prior to Grafana 10.2. A user with datasource management privileges could read and permanently delete correlation data from other organizations due to a backward compatibility condition. Red Hat products utilizing Grafana with such legacy records are affected. Red Hat Product Seurity team has rated this vulnerability as having a Low severity, this is due the fact the attacker needs to have high privileges within the targeted Grafana instance and additionally the system needs to be making using of legacy correlation records limiting the confidentiality and integrity impact for the related records.",
+    "mitigation": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base, or stability.",
+    "comment_zero": "---\ntitle: Cross-Tenant Legacy Correlation Disclosure and Deletion\ndraft: false\nhero:\n  image: /static/img/heros/hero-legal2.svg\n  content: \"# Cross-Tenant Legacy Correlation Disclosure and Deletion\"\ndate: 2026-01-29\nproduct: Grafana\nseverity: Low\ncve: CVE-2026-21727\ncvss_score: \"3.3\"\ncvss_vector: \"CVSS:3.3/AV:N/AC:H/PR:H/UI:N/S:U/C:L/I:L/A:N\"\nfixed_versions:\n  - \">=11.6.11 >=12.0.9 >=12.1.6 >=12.2.4\"\n---\nA cross-tenant isolation vulnerability was found in Grafana\u2019s Correlations feature affecting legacy correlation records. Due to a backward compatibility condition allowing org_id = 0 records to be returned across organizations, a user with datasource management privileges could read and permanently delete legacy correlation data belonging to another organization. This issue affects correlations created prior to Grafana 10.2 and is fixed in >=11.6.11, >=12.0.9, >=12.1.6, and >=12.2.4.\n\nThanks to Gyu-hyeok Lee (g2h) for reporting this vulnerability.",
+    "comments": "",
+    "description": "A flaw was found in Grafana. This cross-tenant isolation vulnerability affects legacy correlation records, specifically those created prior to Grafana 10.2. A user with datasource management privileges can exploit a backward compatibility condition, which allows records with an organization ID (org_id) of 0 to be returned across different organizations. This enables the user to read and permanently delete sensitive correlation data belonging to other organizations.",
+    "components": [
+        "Grafana"
+    ],
+    "references": [
+        {
+            "url": "https://grafana.com/security/security-advisories/cve-2026-21727"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-21727"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:L/I:L/A:N"
+        },
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:L/I:L/A:N"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-23361.json
+++ b/evals/osidb_cache/CVE-2026-23361.json
@@ -1,0 +1,28 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-23361",
+    "cwe_id": "CWE-367",
+    "impact": "MODERATE",
+    "title": "PCI: dwc: ep: Flush MSI-X write before unmapping its ATU entry",
+    "statement": "This flaw affects systems using DesignWare PCI endpoint controllers (dwc) with MSI-X. The race between the posted write and ATU unmap can cause the write to go to unmapped address space, corrupting host memory or triggering IOMMU faults. Primarily affects embedded systems using PCI endpoint functionality with NVMe target emulation.",
+    "mitigation": "",
+    "comment_zero": "In the Linux kernel, the following vulnerability has been resolved:\n\nPCI: dwc: ep: Flush MSI-X write before unmapping its ATU entry\n\nEndpoint drivers use dw_pcie_ep_raise_msix_irq() to raise an MSI-X\ninterrupt to the host using a writel(), which generates a PCI posted write\ntransaction.  There's no completion for posted writes, so the writel() may\nreturn before the PCI write completes.  dw_pcie_ep_raise_msix_irq() also\nunmaps the outbound ATU entry used for the PCI write, so the write races\nwith the unmap.\n\nIf the PCI write loses the race with the ATU unmap, the write may corrupt\nhost memory or cause IOMMU errors, e.g., these when running fio with a\nlarger queue depth against nvmet-pci-epf:\n\n  arm-smmu-v3 fc900000.iommu:      0x0000010000000010\n  arm-smmu-v3 fc900000.iommu:      0x0000020000000000\n  arm-smmu-v3 fc900000.iommu:      0x000000090000f040\n  arm-smmu-v3 fc900000.iommu:      0x0000000000000000\n  arm-smmu-v3 fc900000.iommu: event: F_TRANSLATION client: 0000:01:00.0 sid: 0x100 ssid: 0x0 iova: 0x90000f040 ipa: 0x0\n  arm-smmu-v3 fc900000.iommu: unpriv data write s1 \"Input address caused fault\" stag: 0x0\n\nFlush the write by performing a readl() of the same address to ensure that\nthe write has reached the destination before the ATU entry is unmapped.\n\nThe same problem was solved for dw_pcie_ep_raise_msi_irq() in commit\n8719c64e76bf (\"PCI: dwc: ep: Cache MSI outbound iATU mapping\"), but there\nit was solved by dedicating an outbound iATU only for MSI. We can't do the\nsame for MSI-X because each vector can have a different msg_addr and the\nmsg_addr may be changed while the vector is masked.\n\n[bhelgaas: commit log]",
+    "comments": "Upstream advisory:\nhttps://lore.kernel.org/linux-cve-announce/2026032539-CVE-2026-23361-bd5c@gregkh/T ",
+    "description": "A flaw was found in the Linux kernel. A race condition exists in the handling of Message Signaled Interrupts eXtended (MSI-X) within the PCI subsystem. When an MSI-X interrupt is raised, a PCI posted write transaction may not complete before its associated Address Translation Unit (ATU) entry is unmapped. This timing issue can lead to memory corruption or Input/Output Memory Management Unit (IOMMU) errors on the host system.",
+    "components": [
+        "kernel"
+    ],
+    "references": [
+        {
+            "url": "https://lore.kernel.org/linux-cve-announce/2026032539-CVE-2026-23361-bd5c@gregkh/T"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-23376.json
+++ b/evals/osidb_cache/CVE-2026-23376.json
@@ -1,0 +1,28 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-23376",
+    "cwe_id": "CWE-414",
+    "impact": "LOW",
+    "title": "nvmet-fcloop: Check remoteport port_state before calling done callback",
+    "statement": "This flaw affects systems using NVMe over Fibre Channel loopback (fcloop) for testing. The missing port_state check causes incorrect callback handling when the remote port is not online, leading to resource management issues. This is primarily a testing/development driver issue rather than a production deployment concern.",
+    "mitigation": "",
+    "comment_zero": "In the Linux kernel, the following vulnerability has been resolved:\n\nnvmet-fcloop: Check remoteport port_state before calling done callback\n\nIn nvme_fc_handle_ls_rqst_work, the lsrsp->done callback is only set when\nremoteport->port_state is FC_OBJSTATE_ONLINE.  Otherwise, the\nnvme_fc_xmt_ls_rsp's LLDD call to lport->ops->xmt_ls_rsp is expected to\nfail and the nvme-fc transport layer itself will directly call\nnvme_fc_xmt_ls_rsp_free instead of relying on LLDD's done callback to free\nthe lsrsp resources.\n\nUpdate the fcloop_t2h_xmt_ls_rsp routine to check remoteport->port_state.\nIf online, then lsrsp->done callback will free the lsrsp.  Else, return\n-ENODEV to signal the nvme-fc transport to handle freeing lsrsp.",
+    "comments": "Upstream advisory:\nhttps://lore.kernel.org/linux-cve-announce/2026032542-CVE-2026-23376-114a@gregkh/T ",
+    "description": "A flaw was found in the Linux kernel's nvmet-fcloop component. This vulnerability occurs due to incorrect handling of resource freeing when the remote port state is not online. Specifically, the `fcloop_t2h_xmt_ls_rsp` routine fails to check the `remoteport->port_state` before calling a done callback, which can lead to improper resource management. This could potentially result in system instability or resource leaks.",
+    "components": [
+        "kernel"
+    ],
+    "references": [
+        {
+            "url": "https://lore.kernel.org/linux-cve-announce/2026032542-CVE-2026-23376-114a@gregkh/T"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-24450.json
+++ b/evals/osidb_cache/CVE-2026-24450.json
@@ -1,0 +1,42 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-24450",
+    "cwe_id": "CWE-190",
+    "impact": "MODERATE",
+    "title": "LibRaw: Arbitrary code execution via a specially crafted malicious file",
+    "statement": "This flaw in the LibRaw library consists in an integer overflow in the `uncompressed_fp_dng_load_raw` function, a successfully performed attack may lead to a heap buffer overflow and potentially arbitrary code execution or denial of service. The vulnerability stems from the usage of a 32-bit arithmetic to calculate the pixel buffers when decoding the raw image file, which may end up overflowing when processing user controlled images as input. The calculation result is further used within 64-bit boundary checking however the proper cast is missing and the result value is used to allocate the buffer from memory, when the overflow happens the function may start writing outside of the expected memory boundary leading to data corruption.\n\nThis vulnerability is not exploitable when the application consuming LibRaw is using the default memory limit (`max_raw_memory_mb` parameter) to unpack the RAW image. To be considered vulnerable the application should be setting the limit to around or greater then 16GB.\n\nRed Hat Product Security has rated this vulnerability as having a Moderate impact, despite the possibility of arbitrary code execution due to the heap-based buffer overflow, as the user needs to be tricked to process a maliciously crafted image or LibRaw needs to be exposed to the network and accepting untrusted data as input. Additionally the default `max_raw_memory_mb` value set with LibRaw is not enough to trigger the vulnerability.",
+    "mitigation": "This vulnerability can be mitigated by limiting the amount of memory used to unpack untrusted RAW images. This needs to be set in the application using the LibRaw and can be achieved by setting the `max_raw_memory_mb` to a value smaller than 16GB.\nThis parameter can't be changed in runtime in the library, so developers needs to patch and rebuild their application to impose the new limit. It's important to notice the fact when reducing the memory limit for the decoding process may render the library unable to handle big images.",
+    "comment_zero": "An integer overflow vulnerability exists in the uncompressed_fp_dng_load_raw functionality of LibRaw Commit 8dc68e2. A specially crafted malicious file can lead to a heap buffer overflow. An attacker can provide a malicious file to trigger this vulnerability.",
+    "comments": "",
+    "description": "A flaw was found in LibRaw. A remote attacker could exploit an integer overflow vulnerability by providing a specially crafted malicious file. This flaw, located in the `uncompressed_fp_dng_load_raw` functionality, leads to a heap buffer overflow. Successful exploitation may result in arbitrary code execution or a denial of service.",
+    "components": [
+        "LibRaw"
+    ],
+    "references": [
+        {
+            "url": "https://talosintelligence.com/vulnerability_reports/TALOS-2026-2363"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-24450"
+        },
+        {
+            "url": "https://github.com/LibRaw/LibRaw/releases/tag/0.22.1"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H"
+        },
+        {
+            "issuer": "NIST",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-25780.json
+++ b/evals/osidb_cache/CVE-2026-25780.json
@@ -1,0 +1,35 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-25780",
+    "cwe_id": "CWE-770",
+    "impact": "MODERATE",
+    "title": "Memory Exhaustion via Malformed DOC File Upload",
+    "statement": "",
+    "mitigation": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability.",
+    "comment_zero": "Mattermost versions 11.3.x <= 11.3.0, 11.2.x <= 11.2.2, 10.11.x <= 10.11.10 fail to bound memory allocation when processing DOC files which allows an authenticated attacker to cause server memory exhaustion and denial of service via uploading a specially crafted DOC file.. Mattermost Advisory ID: MMSA-2026-00581",
+    "comments": "",
+    "description": "A memory exhaustion flaw has been discovered in the Mattermost server. Affected versions fail to bound memory allocation when processing DOC files which allows an authenticated attacker to cause server memory exhaustion and denial of service via uploading a specially crafted DOC file.",
+    "components": [
+        "github.com/mattermost/mattermost-server"
+    ],
+    "references": [
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-25780"
+        },
+        {
+            "url": "https://mattermost.com/security-updates"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-26740.json
+++ b/evals/osidb_cache/CVE-2026-26740.json
@@ -1,0 +1,35 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-26740",
+    "cwe_id": "CWE-787",
+    "impact": "IMPORTANT",
+    "title": "giflib: Denial of Service via buffer overflow in EGifGCBToExtension",
+    "statement": "",
+    "mitigation": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability.",
+    "comment_zero": "Buffer Overflow vulnerability in giflib v.5.2.2 allows a remote attacker to cause a denial of service via the EGifGCBToExtension overwriting an existing Graphic Control Extension block without validating its allocated size.",
+    "comments": "",
+    "description": "A flaw was found in giflib. A remote attacker can exploit a buffer overflow vulnerability in the EGifGCBToExtension function by providing a specially crafted Graphics Control Extension (GCE) block. This allows overwriting an existing GCE block without proper size validation, leading to a denial of service (DoS) on the system.",
+    "components": [
+        "giflib"
+    ],
+    "references": [
+        {
+            "url": "https://github.com/zakkanijia/POC/blob/main/giflib/giftool/giflib_giftool_gce_len_heap_oobwrite_disclosure.md"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-26740"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "CISA",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:H"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-26939.json
+++ b/evals/osidb_cache/CVE-2026-26939.json
@@ -1,0 +1,35 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-26939",
+    "cwe_id": "CWE-1220",
+    "impact": "MODERATE",
+    "title": "Kibana: Unauthorized system control via missing authorization",
+    "statement": "",
+    "mitigation": "",
+    "comment_zero": "Missing Authorization (CWE-862) in Kibana\u2019s server-side Detection Rule Management can lead to Unauthorized Endpoint Response Action Configuration (host isolation, process termination, and process suspension) via CAPEC-1 (Accessing Functionality Not Properly Constrained by ACLs). This requires an authenticated attacker with rule management privileges.",
+    "comments": "",
+    "description": "A flaw was found in Kibana. An authenticated attacker with rule management privileges could exploit a missing authorization vulnerability in the server-side Detection Rule Management. This allows the attacker to configure unauthorized endpoint response actions, such as host isolation, process termination, and process suspension. This could lead to a denial of service or impact on system integrity.",
+    "components": [
+        "Kibana"
+    ],
+    "references": [
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-26939"
+        },
+        {
+            "url": "https://discuss.elastic.co/t/kibana-8-19-12-9-2-6-9-3-1-security-update-esa-2026-19/385530"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:N"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:N"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-27651.json
+++ b/evals/osidb_cache/CVE-2026-27651.json
@@ -1,0 +1,39 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-27651",
+    "cwe_id": "CWE-476",
+    "impact": "IMPORTANT",
+    "title": "NGINX: Denial of Service via undisclosed requests when ngx_mail_auth_http_module is enabled",
+    "statement": "",
+    "mitigation": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability.",
+    "comment_zero": "When the ngx_mail_auth_http_module\u00a0module is enabled on NGINX Plus or NGINX Open Source, undisclosed requests can cause worker processes to terminate. This issue may occur when (1) CRAM-MD5 or APOP authentication is enabled, and (2) the authentication server permits retry by returning the Auth-Wait response header. Note: Software versions which have reached End of Technical Support (EoTS) are not evaluated.",
+    "comments": "",
+    "description": "A flaw was found in NGINX, specifically within the ngx_mail_auth_http_module. When this module is enabled, and CRAM-MD5 or APOP authentication is active with an authentication server that permits retries, undisclosed requests can cause NGINX worker processes to terminate. This can lead to a Denial of Service (DoS), making the affected NGINX instance unavailable to legitimate users.",
+    "components": [
+        "NGINX"
+    ],
+    "references": [
+        {
+            "url": "https://my.f5.com/manage/s/article/K000160383"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-27651"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N"
+        },
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-27784.json
+++ b/evals/osidb_cache/CVE-2026-27784.json
@@ -1,0 +1,43 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-27784",
+    "cwe_id": "CWE-190",
+    "impact": "IMPORTANT",
+    "title": "NGINX: Denial of Service due to memory corruption via crafted MP4 file",
+    "statement": "",
+    "mitigation": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability.",
+    "comment_zero": "The 32-bit implementation of NGINX Open Source has a vulnerability in the ngx_http_mp4_module module, which might allow an attacker to over-read or over-write NGINX worker memory resulting in its termination, using a specially crafted MP4 file. The issue only affects 32-bit NGINX Open Source if it is built with the ngx_http_mp4_module module and the mp4 directive is used in the configuration file. Additionally, the attack is possible only if an attacker can trigger the processing of a specially crafted MP4 file with the ngx_http_mp4_module module. \n\n\nNote: Software versions which have reached End of Technical Support (EoTS) are not evaluated.",
+    "comments": "",
+    "description": "A flaw was found in NGINX Open Source, specifically within the ngx_http_mp4_module. An attacker can exploit this memory corruption vulnerability by providing a specially crafted MP4 file. This can lead to an over-read or over-write of NGINX worker memory, causing the worker to terminate and resulting in a Denial of Service (DoS). This issue affects 32-bit NGINX Open Source when built with the ngx_http_mp4_module and the mp4 directive is used.",
+    "components": [
+        "NGINX"
+    ],
+    "references": [
+        {
+            "url": "https://my.f5.com/manage/s/article/K000160364"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-27784"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        },
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:4.0/AV:L/AC:L/AT:N/PR:L/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"
+        },
+        {
+            "issuer": "NIST",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-27820.json
+++ b/evals/osidb_cache/CVE-2026-27820.json
@@ -1,0 +1,38 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-27820",
+    "cwe_id": "CWE-131",
+    "impact": "MODERATE",
+    "title": "zlib: Memory corruption via buffer overflow in Zlib::GzipReader",
+    "statement": "A buffer overflow vulnerability exists in the Zlib::GzipReader component of the Ruby zlib interface. This flaw, caused by insufficient memory capacity during data manipulation, could lead to memory corruption and system instability. This vulnerability is considered of a Moderate severity this happens because the high complexity to exploit, additionally the attacker may have not full control over the data is being corrupted or exfiltrated.",
+    "mitigation": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base, or stability.",
+    "comment_zero": "zlib is a Ruby interface for the zlib compression/decompression library. Versions 3.0.0 and below, 3.1.0, 3.1.1, 3.2.0 and 3.2.1 contain a buffer overflow vulnerability in the Zlib::GzipReader. The zstream_buffer_ungets function prepends caller-provided bytes ahead of previously produced output but fails to guarantee the backing Ruby string has enough capacity before the memmove shifts the existing data. This can lead to memory corruption when the buffer length exceeds capacity. This issue has been fixed in versions 3.0.1, 3.1.2 and 3.2.3.",
+    "comments": "Upstream public commit for this issue:\nhttps://github.com/ruby/zlib/commit/608d2be66fcbcb759cbe26c82e95f4381b8dd140 ",
+    "description": "A flaw was found in zlib, a Ruby interface for the zlib compression/decompression library. The Zlib::GzipReader component contains a buffer overflow vulnerability. This occurs because the zstream_buffer_ungets function does not ensure sufficient memory capacity before moving existing data, which can lead to memory corruption. An attacker could potentially exploit this to cause unexpected behavior or system instability.",
+    "components": [
+        "zlib"
+    ],
+    "references": [
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-27820"
+        },
+        {
+            "url": "https://github.com/ruby/zlib/security/advisories/GHSA-g857-hhfv-j68w"
+        },
+        {
+            "url": "https://hackerone.com/reports/3467067"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N/E:U"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-27859.json
+++ b/evals/osidb_cache/CVE-2026-27859.json
@@ -1,0 +1,35 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-27859",
+    "cwe_id": "CWE-770",
+    "impact": "MODERATE",
+    "title": "Dovecot: Denial of Service via excessive RFC 2231 MIME parameters",
+    "statement": "",
+    "mitigation": "",
+    "comment_zero": "A mail message containing excessive amount of RFC 2231 MIME parameters causes LMTP to use too much CPU. A suitably formatted mail message causes mail delivery process to consume large amounts of CPU time. Use MTA capabilities to limit RFC 2231 MIME parameters in mail messages, or upgrade to fixed version where the processing is limited. No publicly available exploits are known.",
+    "comments": "",
+    "description": "A flaw was found in Dovecot. A remote attacker can exploit this vulnerability by sending a specially crafted mail message containing an excessive amount of RFC 2231 MIME parameters. This can cause the Local Mail Transfer Protocol (LMTP) process to consume large amounts of CPU time, leading to a Denial of Service (DoS).",
+    "components": [
+        "dovecot"
+    ],
+    "references": [
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-27859"
+        },
+        {
+            "url": "https://documentation.open-xchange.com/dovecot/security/advisories/csaf/2026/oxdc-adv-2026-0001.json"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+        },
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-27962.json
+++ b/evals/osidb_cache/CVE-2026-27962.json
@@ -1,0 +1,41 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-27962",
+    "cwe_id": "CWE-347",
+    "impact": "IMPORTANT",
+    "title": "Authlib: Authentication bypass due to JWK Header Injection vulnerability",
+    "statement": "This critical vulnerability in Authlib's JWS implementation allows unauthenticated attackers to forge JWTs by embedding their own cryptographic key in the token header. Impact is high to confidentiality and integrity as attackers can bypass authentication.\n\nThe impact for Red Hat Quay is rated as low because it imports authlib solely as a JWK parsing utility and performs all JWT signature verification through PyJWT, so the vulnerable jws.deserialize_compact() code path is never called.\n\nRed Hat OpenShift AI is not affected, since authlib is only present as a transitive dependency in the dev dependency group and is not included in production image builds, so the vulnerable code is not present in the shipped product.\n\nRed Hat Satellite is not affected, as authlib is only present as a dependency of fastmcp. In Satellite, fastmcp only invokes authlib using jwt.decode() which isn't able to reach the vulnerability condition even with key=none.",
+    "mitigation": "",
+    "comment_zero": "Authlib is a Python library which builds OAuth and OpenID Connect servers. Prior to version 1.6.9, a JWK Header Injection vulnerability in authlib's JWS implementation allows an unauthenticated attacker to forge arbitrary JWT tokens that pass signature verification. When key=None is passed to any JWS deserialization function, the library extracts and uses the cryptographic key embedded in the attacker-controlled JWT jwk header field. An attacker can sign a token with their own private key, embed the matching public key in the header, and have the server accept the forged token as cryptographically valid \u2014 bypassing authentication and authorization entirely. This issue has been patched in version 1.6.9.",
+    "comments": "",
+    "description": "A flaw was found in Authlib, a Python library used for creating secure authentication and authorization systems. This vulnerability, known as JWK (JSON Web Key) Header Injection, affects how Authlib verifies digital signatures in JWS (JSON Web Signature) tokens. An attacker can exploit this by creating a specially crafted token that includes their own cryptographic key in the header. When the system attempts to verify this token without a predefined key, it mistakenly uses the attacker's key, allowing them to bypass authentication and gain unauthorized access.",
+    "components": [
+        "authlib"
+    ],
+    "references": [
+        {
+            "url": "https://github.com/authlib/authlib/releases/tag/v1.6.9"
+        },
+        {
+            "url": "https://github.com/authlib/authlib/security/advisories/GHSA-wvwj-cvrp-7pv5"
+        },
+        {
+            "url": "https://github.com/authlib/authlib/commit/a5d4b2d4c9e46bfa11c82f85fdc2bcc0b50ae681"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-27962"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-28387.json
+++ b/evals/osidb_cache/CVE-2026-28387.json
@@ -1,0 +1,28 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-28387",
+    "cwe_id": "CWE-1341",
+    "impact": "LOW",
+    "title": "OpenSSL: Arbitrary code execution due to use-after-free in DANE TLSA authentication",
+    "statement": "This Low impact vulnerability affects clients performing DANE TLSA-based server authentication only when configured with an uncommon combination of PKIX-TA(0/PKIX-EE(1) and DANE-TA(2) certificate usages. Most common SMTP MTA deployments are not vulnerable as they are recommended to treat PKIX certificate usages as unusable. Exploitation also requires communication with a server publishing a TLSA RRset with both types of records.",
+    "mitigation": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base, or stability.",
+    "comment_zero": "Issue summary: An uncommon configuration of clients performing DANE TLSA-based\nserver authentication, when paired with uncommon server DANE TLSA records, may\nresult in a use-after-free and/or double-free on the client side.\n\nImpact summary: A use after free can have a range of potential consequences\nsuch as the corruption of valid data, crashes or execution of arbitrary code.\n\nHowever, the issue only affects clients that make use of TLSA records with both\nthe PKIX-TA(0/PKIX-EE(1) certificate usages and the DANE-TA(2) certificate\nusage.\n\nBy far the most common deployment of DANE is in SMTP MTAs for which RFC7672\nrecommends that clients treat as \"unusable\" any TLSA records that have the PKIX\ncertificate usages. These SMTP (or other similar) clients are not vulnerable\nto this issue. Conversely, any clients that support only the PKIX usages, and\nignore the DANE-TA(2) usage are also not vulnerable.\n\nThe client would also need to be communicating with a server that publishes a\nTLSA RRset with both types of TLSA records.\n\nNo FIPS modules are affected by this issue, the problem code is outside the\nFIPS module boundary.",
+    "comments": "",
+    "description": "A flaw was found in OpenSSL. An uncommon configuration of clients performing DANE TLSA-based server authentication, when paired with uncommon server DANE TLSA records, may result in a use-after-free and/or double-free on the client side. This vulnerability could lead to data corruption, application crashes, or, in severe cases, arbitrary code execution. This issue is highly specific and uncommon, as it only affects clients using both PKIX-TA(0)/PKIX-EE(1) and DANE-TA(2) certificate usages and communicating with a server publishing a TLSA record set with both types of records.",
+    "components": [
+        "openssl"
+    ],
+    "references": [
+        {
+            "url": "https://openssl-library.org/news/secadv/20260407.txt"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-28388.json
+++ b/evals/osidb_cache/CVE-2026-28388.json
@@ -1,0 +1,32 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-28388",
+    "cwe_id": "CWE-476",
+    "impact": "LOW",
+    "title": "OpenSSL: Denial of Service due to NULL pointer dereference in delta CRL processing",
+    "statement": "Low impact. This vulnerability in X.509 certificate verification can lead to a Denial of Service (DoS) due to a NULL pointer dereference when processing a malformed delta Certificate Revocation List (CRL). Exploitation requires the `X509_V_FLAG_USE_DELTAS` flag to be enabled in the verification context, a certificate with a `freshestCRL` extension or a base CRL with `EXFLAG_FRESHEST` set, and an attacker-provided malformed CRL. This flaw is limited to DoS and does not allow for code execution or memory disclosure.",
+    "mitigation": "To mitigate this issue, ensure that delta CRL processing is not enabled in applications that do not require it. This vulnerability is only exploitable when the `X509_V_FLAG_USE_DELTAS` flag is explicitly set within the X.509 verification context. Review application configurations to confirm that this flag is not enabled unless absolutely necessary for your security policy. Disabling this flag will prevent the vulnerable code path from being exercised. Specific implementation details will vary depending on the application utilizing X.509 certificate verification.",
+    "comment_zero": "Issue summary: When a delta CRL that contains a Delta CRL Indicator extension\nis processed a NULL pointer dereference might happen if the required CRL\nNumber extension is missing.\n\nImpact summary: A NULL pointer dereference can trigger a crash which\nleads to a Denial of Service for an application.\n\nWhen CRL processing and delta CRL processing is enabled during X.509\ncertificate verification, the delta CRL processing does not check\nwhether the CRL Number extension is NULL before dereferencing it.\nWhen a malformed delta CRL file is being processed, this parameter\ncan be NULL, causing a NULL pointer dereference.\n\nExploiting this issue requires the X509_V_FLAG_USE_DELTAS flag to be enabled in\nthe verification context, the certificate being verified to contain a\nfreshestCRL extension or the base CRL to have the EXFLAG_FRESHEST flag set, and\nan attacker to provide a malformed CRL to an application that processes it.\n\nThe vulnerability is limited to Denial of Service and cannot be escalated to\nachieve code execution or memory disclosure.",
+    "comments": "",
+    "description": "A flaw was found in OpenSSL. When processing a malformed delta Certificate Revocation List (CRL) that lacks a required CRL Number extension, a NULL pointer dereference can occur. This vulnerability can be exploited by a remote attacker who provides a specially crafted delta CRL to an application that has delta CRL processing enabled, leading to a Denial of Service (DoS) for the application.",
+    "components": [
+        "openssl"
+    ],
+    "references": [
+        {
+            "url": "https://openssl-library.org/news/secadv/20260407.txt"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        },
+        {
+            "issuer": "CISA",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-28500.json
+++ b/evals/osidb_cache/CVE-2026-28500.json
@@ -1,0 +1,42 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-28500",
+    "cwe_id": "CWE-829",
+    "impact": "IMPORTANT",
+    "title": "ONNX: Untrusted Model Repository Warnings Suppressed",
+    "statement": "",
+    "mitigation": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability.",
+    "comment_zero": "Open Neural Network Exchange (ONNX) is an open standard for machine learning interoperability. In versions up to and including 1.20.1, a security control bypass exists in onnx.hub.load() due to improper logic in the repository trust verification mechanism. While the function is designed to warn users when loading models from non-official sources, the use of the silent=True parameter completely suppresses all security warnings and confirmation prompts. This vulnerability transforms a standard model-loading function into a vector for Zero-Interaction Supply-Chain Attacks. When chained with file-system vulnerabilities, an attacker can silently exfiltrate sensitive files (SSH keys, cloud credentials) from the victim's machine the moment the model is loaded. As of time of publication, no known patched versions are available.",
+    "comments": "",
+    "description": "A flaw was found in Open Neural Network Exchange (ONNX), an open standard for machine learning interoperability. A security control bypass exists in the `onnx.hub.load()` function due to improper logic in its repository trust verification. An attacker can exploit this by providing a malicious model, which, when loaded with the `silent=True` parameter, suppresses all security warnings. This vulnerability transforms a standard model-loading function into a vector for Zero-Interaction Supply-Chain Attacks.",
+    "components": [
+        "onnx"
+    ],
+    "references": [
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-28500"
+        },
+        {
+            "url": "https://github.com/ZeroXJacks/CVEs/blob/main/2026/CVE-2026-28500.md"
+        },
+        {
+            "url": "https://github.com/onnx/onnx/security/advisories/GHSA-hqmj-h5c6-369m"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N"
+        },
+        {
+            "issuer": "NIST",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-29063.json
+++ b/evals/osidb_cache/CVE-2026-29063.json
@@ -1,0 +1,48 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-29063",
+    "cwe_id": "CWE-915",
+    "impact": "IMPORTANT",
+    "title": "Immutable.js: Arbitrary code execution via Prototype Pollution",
+    "statement": "Exploitation of this vulnerability requires that an attacker is able to provide arbitrary data to clients of this library in a way that calls the affected functions with data the attacker controls. In most deployments, the ability to provide data in this fashion requires that an attacker has some degree of privileges to access the affected applications.",
+    "mitigation": "",
+    "comment_zero": "Immutable.js provides many Persistent Immutable data structures. Prior to versions 3.8.3, 4.3.7, and 5.1.5, Prototype Pollution is possible in immutable via the mergeDeep(), mergeDeepWith(), merge(), Map.toJS(), and Map.toObject() APIs. This issue has been patched in versions 3.8.3, 4.3.7, and 5.1.5.",
+    "comments": "",
+    "description": "A flaw was found in Immutable.js, a library for persistent immutable data structures. This vulnerability, known as Prototype Pollution, allows an attacker with low privileges to inject unwanted properties into core JavaScript object prototypes without user interaction. By manipulating specific APIs such as mergeDeep(), mergeDeepWith(), merge(), Map.toJS(), and Map.toObject(), a remote attacker could potentially execute arbitrary code or cause a denial of service (DoS).",
+    "components": [
+        "immutable-js"
+    ],
+    "references": [
+        {
+            "url": "https://github.com/immutable-js/immutable-js/releases/tag/v5.1.5"
+        },
+        {
+            "url": "https://github.com/immutable-js/immutable-js/releases/tag/v3.8.3"
+        },
+        {
+            "url": "https://github.com/immutable-js/immutable-js/security/advisories/GHSA-wf6x-7x77-mvgw"
+        },
+        {
+            "url": "https://github.com/immutable-js/immutable-js/releases/tag/v4.3.8"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-29063"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+        },
+        {
+            "issuer": "NIST",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-31402.json
+++ b/evals/osidb_cache/CVE-2026-31402.json
@@ -1,0 +1,28 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-31402",
+    "cwe_id": "CWE-787",
+    "impact": "IMPORTANT",
+    "title": "nfsd: fix heap overflow in NFSv4.0 LOCK replay cache",
+    "statement": "This Important flaw in the Linux kernel's NFSv4.0 server (nfsd) allows a heap overflow. In this flaw a local attacker can trigger this by orchestrating two NFSv4.0 clients to create a conflicting lock with an oversized owner string.",
+    "mitigation": "Mitigation for this issue is either not available or the currently available options don't meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability.",
+    "comment_zero": "In the Linux kernel, the following vulnerability has been resolved:\n\nnfsd: fix heap overflow in NFSv4.0 LOCK replay cache\n\nThe NFSv4.0 replay cache uses a fixed 112-byte inline buffer\n(rp_ibuf[NFSD4_REPLAY_ISIZE]) to store encoded operation responses.\nThis size was calculated based on OPEN responses and does not account\nfor LOCK denied responses, which include the conflicting lock owner as\na variable-length field up to 1024 bytes (NFS4_OPAQUE_LIMIT).\n\nWhen a LOCK operation is denied due to a conflict with an existing lock\nthat has a large owner, nfsd4_encode_operation() copies the full encoded\nresponse into the undersized replay buffer via read_bytes_from_xdr_buf()\nwith no bounds check. This results in a slab-out-of-bounds write of up\nto 944 bytes past the end of the buffer, corrupting adjacent heap memory.\n\nThis can be triggered remotely by an unauthenticated attacker with two\ncooperating NFSv4.0 clients: one sets a lock with a large owner string,\nthen the other requests a conflicting lock to provoke the denial.\n\nWe could fix this by increasing NFSD4_REPLAY_ISIZE to allow for a full\nopaque, but that would increase the size of every stateowner, when most\nlockowners are not that large.\n\nInstead, fix this by checking the encoded response length against\nNFSD4_REPLAY_ISIZE before copying into the replay buffer. If the\nresponse is too large, set rp_buflen to 0 to skip caching the replay\npayload. The status is still cached, and the client already received the\ncorrect response on the original request.",
+    "comments": "Upstream advisory:\nhttps://lore.kernel.org/linux-cve-announce/2026040327-CVE-2026-31402-3e6a@gregkh/T ",
+    "description": "A flaw was found in the Linux kernel's NFSv4.0 server (nfsd). A remote, unauthenticated attacker can exploit this heap overflow vulnerability in the NFSv4.0 LOCK replay cache. By using two cooperating NFSv4.0 clients, where one sets a lock with a large owner string and another requests a conflicting lock, the attacker can trigger a slab-out-of-bounds write. This corruption of adjacent heap memory could lead to arbitrary code execution or a denial of service.",
+    "components": [
+        "kernel"
+    ],
+    "references": [
+        {
+            "url": "https://lore.kernel.org/linux-cve-announce/2026040327-CVE-2026-31402-3e6a@gregkh/T"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-31898.json
+++ b/evals/osidb_cache/CVE-2026-31898.json
@@ -1,0 +1,48 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-31898",
+    "cwe_id": "CWE-94",
+    "impact": "IMPORTANT",
+    "title": "jsPDF: Arbitrary code execution via unsanitized input in createAnnotation method",
+    "statement": "",
+    "mitigation": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability.",
+    "comment_zero": "jsPDF is a library to generate PDFs in JavaScript. Prior to version 4.2.1, user control of arguments of the `createAnnotation` method allows users to inject arbitrary PDF objects, such as JavaScript actions. If given the possibility to pass unsanitized input to the following method, a user can inject arbitrary PDF objects, such as JavaScript actions, which might trigger when the PDF is opened or interacted with the `createAnnotation`: `color` parameter. The vulnerability has been fixed in jsPDF@4.2.1. As a workaround, sanitize user input before passing it to the vulnerable API members.",
+    "comments": "",
+    "description": "A flaw was found in jsPDF, a JavaScript library used for generating PDF documents. This vulnerability allows a remote attacker to inject arbitrary PDF objects, including JavaScript actions, into a generated PDF. This can occur if unsanitized user input is provided to the `createAnnotation` method's `color` parameter. When a user opens or interacts with the specially crafted PDF, these injected actions may execute, potentially leading to arbitrary code execution or sensitive information disclosure.",
+    "components": [
+        "jspdf"
+    ],
+    "references": [
+        {
+            "url": "https://github.com/parallax/jsPDF/blob/b1607a9391d4cd65ea7ade25998aea8345ae1be3/src/modules/annotations.js#L193-L208"
+        },
+        {
+            "url": "https://github.com/parallax/jsPDF/security/advisories/GHSA-7x6v-j9x4-qf24"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-31898"
+        },
+        {
+            "url": "https://github.com/parallax/jsPDF/commit/4155c4819d5eca284168e51e0e1e81126b4f14b8"
+        },
+        {
+            "url": "https://github.com/parallax/jsPDF/releases/tag/v4.2.1"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:N"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:N"
+        },
+        {
+            "issuer": "NIST",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:H/A:N"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-31966.json
+++ b/evals/osidb_cache/CVE-2026-31966.json
@@ -1,0 +1,48 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-31966",
+    "cwe_id": "CWE-125",
+    "impact": "MODERATE",
+    "title": "htslib: Information disclosure and denial of service due to insufficient CRAM feature data validation",
+    "statement": "",
+    "mitigation": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability.",
+    "comment_zero": "HTSlib is a library for reading and writing bioinformatics file formats. CRAM is a compressed format which stores DNA sequence alignment data. As one method of removing redundant data, CRAM uses reference-based compression so that instead of storing the full sequence for each alignment record it stores a location in an external reference sequence along with a list of differences to the reference at that location as a sequence of \"features\". When decoding CRAM records, the reference data is stored in a char array, and parts matching the alignment record sequence are copied over as necessary. Due to insufficient validation of the feature data series, it was possible to make the `cram_decode_seq()` function copy data from either before the start, or after the end of the stored reference either into the buffer used to store the output sequence for the cram record, or into the buffer used to build the SAM `MD` tag.  This allowed arbitrary data to be leaked to the calling function. This bug may allow information about program state to be leaked.  It may also cause a program crash through an attempt to access invalid memory. Versions 1.23.1, 1.22.2 and 1.21.1 include fixes for this issue. There is no workaround for this issue.",
+    "comments": "",
+    "description": "A flaw was found in htslib, a library for reading and writing bioinformatics file formats. Specifically, within the CRAM (Compressed Reference-oriented Alignment Map) decoding process, insufficient validation of feature data series could allow a remote attacker to craft malicious CRAM records. This could lead to an out-of-bounds read, resulting in the disclosure of arbitrary program data or a program crash, causing a Denial of Service (DoS).",
+    "components": [
+        "htslib"
+    ],
+    "references": [
+        {
+            "url": "https://github.com/samtools/htslib/commit/22ec5230ef95769ab009420da69568c7e530af28"
+        },
+        {
+            "url": "https://github.com/samtools/htslib/commit/4a5ef25eb1fb3d64438103316fffe423b2c3f5f4"
+        },
+        {
+            "url": "https://github.com/samtools/htslib/security/advisories/GHSA-5cj8-mj52-8vp3"
+        },
+        {
+            "url": "https://github.com/samtools/htslib/commit/2a45eb129d703ad27f9fabc8169f0e94d3c69fa3"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-31966"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:N/VA:L/SC:N/SI:N/SA:N"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:R/S:U/C:L/I:N/A:H"
+        },
+        {
+            "issuer": "NIST",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:H"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-31967.json
+++ b/evals/osidb_cache/CVE-2026-31967.json
@@ -1,0 +1,42 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-31967",
+    "cwe_id": "CWE-125",
+    "impact": "MODERATE",
+    "title": "HTSlib: Information disclosure and Denial of Service via unvalidated CRAM mate reference ID",
+    "statement": "",
+    "mitigation": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability.",
+    "comment_zero": "HTSlib is a library for reading and writing bioinformatics file formats. CRAM is a compressed format which stores DNA sequence alignment data. In the `cram_decode_slice()` function called while reading CRAM records, the value of the mate reference id field was not validated. Later use of this value, for example when converting the data to SAM format, could result in the out of bounds array reads when looking up the corresponding reference name. If the array value obtained also happened to be a valid pointer, it would be interpreted as a string and an attempt would be made to write the data as part of the SAM record. This bug may allow information about program state to be leaked. It may also cause a program crash through an attempt to access invalid memory. Versions 1.23.1, 1.22.2 and 1.21.1 include fixes for this issue. There is no workaround for this issue.",
+    "comments": "",
+    "description": "A flaw was found in HTSlib, a library used for bioinformatics file formats. When processing CRAM (Compressed Reference-oriented Alignment Map) records, the `cram_decode_slice()` function fails to validate the mate reference ID field. This oversight allows an attacker to craft a malicious CRAM file, which can lead to an out-of-bounds read during data conversion to SAM (Sequence Alignment/Map) format. The primary consequence of this vulnerability is the potential disclosure of sensitive program state information, and it may also cause a Denial of Service (DoS) by crashing the program.",
+    "components": [
+        "htslib"
+    ],
+    "references": [
+        {
+            "url": "https://github.com/samtools/htslib/security/advisories/GHSA-33x5-c6vj-8f2w"
+        },
+        {
+            "url": "https://github.com/samtools/htslib/commit/9cefb46453ad471e933b8212d4f45920524d3357"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-31967"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:N/VA:L/SC:N/SI:N/SA:N"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:R/S:U/C:L/I:N/A:H"
+        },
+        {
+            "issuer": "NIST",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:H"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-31969.json
+++ b/evals/osidb_cache/CVE-2026-31969.json
@@ -1,0 +1,38 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-31969",
+    "cwe_id": "CWE-787",
+    "impact": "IMPORTANT",
+    "title": "HTSlib: CRAM decoder has a heap buffer overflow",
+    "statement": "",
+    "mitigation": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability.",
+    "comment_zero": "HTSlib is a library for reading and writing bioinformatics file formats. CRAM is a compressed format which stores DNA sequence alignment data using a variety of encodings and compression methods.  When reading data encoded using the `BYTE_ARRAY_STOP` method, an out-by-one error in the `cram_byte_array_stop_decode_char()` function check for a full output buffer could result in a single attacker-controlled byte being written beyond the end of a heap allocation. Exploiting this bug causes a heap buffer overflow. If a user opens a file crafted to exploit this issue, it could lead to the program crashing, or overwriting of data and heap structures in ways not expected by the program.  It may be possible to use this to obtain arbitrary code execution. Versions 1.23.1, 1.22.2 and 1.21.1 include fixes for this issue. There is no workaround for this issue.",
+    "comments": "",
+    "description": "A flaw was found in HTSlib, a library used for bioinformatics file formats. A remote attacker could exploit an out-by-one error when processing a specially crafted CRAM (Compressed Reference-oriented Alignment Map) file. This vulnerability can lead to a heap buffer overflow, potentially allowing for arbitrary code execution, data corruption, or causing the program to crash. This poses a significant risk to the integrity and availability of systems handling bioinformatics data.",
+    "components": [
+        "htslib"
+    ],
+    "references": [
+        {
+            "url": "https://github.com/samtools/htslib/commit/88cdf69e4b83bb550ab4f6f7134892c2ad1978f4"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-31969"
+        },
+        {
+            "url": "https://github.com/samtools/htslib/security/advisories/GHSA-q4cj-f4h5-fqgc"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:P/VC:N/VI:H/VA:L/SC:N/SI:N/SA:N"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:L"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-31970.json
+++ b/evals/osidb_cache/CVE-2026-31970.json
@@ -1,0 +1,42 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-31970",
+    "cwe_id": "CWE-190",
+    "impact": "IMPORTANT",
+    "title": "HTSlib: BGZF index file reader has a heap buffer overflow",
+    "statement": "",
+    "mitigation": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability.",
+    "comment_zero": "HTSlib is a library for reading and writing bioinformatics file formats. GZI files are used to index block-compressed GZIP [BGZF] files.  In the GZI loading function, `bgzf_index_load_hfile()`, it was possible to trigger an integer overflow, leading to an under- or zero-sized buffer being allocated to store the index.  Sixteen zero bytes would then be written to this buffer, and, depending on the result of the overflow the rest of the file may also be loaded into the buffer as well.  If the function did attempt to load the data, it would eventually fail due to not reading the expected number of records, and then try to free the overflowed heap buffer. Exploiting this bug causes a heap buffer overflow. If a user opens a file crafted to exploit this issue, it could lead to the program crashing, or overwriting of data and heap structures in ways not expected by the program.  It may be possible to use this to obtain arbitrary code execution. Versions 1.23.1, 1.22.2 and 1.21.1 include fixes for this issue. The easiest work-around is to discard any `.gzi` index files from untrusted sources, and use the `bgzip -r` option to recreate them.",
+    "comments": "",
+    "description": "A flaw was found in HTSlib, a library used for handling bioinformatics file formats. A remote attacker could exploit an integer overflow vulnerability when a user opens a specially crafted GZI (GZIP Index) file. Exploiting this bug causes a heap buffer overflow. If a user opens a file crafted to exploit this issue, it could lead to the program crashing, or overwriting of data and heap structures in ways not expected by the program. It may be possible to use this to obtain arbitrary code execution.",
+    "components": [
+        "htslib"
+    ],
+    "references": [
+        {
+            "url": "https://github.com/samtools/htslib/commit/6dd0d7d0e9e7e2e173a28969e624db8bc8bb5828"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-31970"
+        },
+        {
+            "url": "https://github.com/samtools/htslib/security/advisories/GHSA-p345-84hx-fq6q"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:P/VC:N/VI:H/VA:L/SC:N/SI:N/SA:N"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H"
+        },
+        {
+            "issuer": "NIST",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:H/A:H"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-31971.json
+++ b/evals/osidb_cache/CVE-2026-31971.json
@@ -1,0 +1,42 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-31971",
+    "cwe_id": "CWE-131",
+    "impact": "IMPORTANT",
+    "title": "HTSlib: CRAM decoder vulnerable to buffer overflow",
+    "statement": "",
+    "mitigation": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability.",
+    "comment_zero": "HTSlib is a library for reading and writing bioinformatics file formats. CRAM is a compressed format which stores DNA sequence alignment data using a variety of encodings and compression methods. When reading data encoded using the `BYTE_ARRAY_LEN` method, the `cram_byte_array_len_decode()` failed to validate that the amount of data being unpacked matched the size of the output buffer where it was to be stored. Depending on the data series being read, this could result either in a heap or a stack overflow with attacker-controlled bytes. Depending on the data stream this could result either in a heap buffer overflow or a stack overflow. If a user opens a file crafted to exploit this issue it could lead to the program crashing, overwriting of data structures on the heap or stack in ways not expected by the program, or changing the control flow of the program. It may be possible to use this to obtain arbitrary code execution. Versions 1.23.1, 1.22.2 and 1.21.1 include fixes for this issue. There is no workaround for this issue.",
+    "comments": "",
+    "description": "A flaw was found in HTSlib, a library used for bioinformatics file formats. When reading CRAM (Compressed Reference-oriented Alignment Map) files, the `cram_byte_array_len_decode()` function did not properly validate the size of incoming data against the allocated buffer. This memory corruption vulnerability allows a remote attacker to cause a heap or stack overflow by tricking a user into opening a specially crafted CRAM file. Successful exploitation could lead to arbitrary code execution, program crashes, or data corruption.",
+    "components": [
+        "htslib"
+    ],
+    "references": [
+        {
+            "url": "https://github.com/samtools/htslib/security/advisories/GHSA-jvx4-4wq7-6fmh"
+        },
+        {
+            "url": "https://github.com/samtools/htslib/commit/01cd003b46fa2ebea4d9be5475b11217eb4c11be"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-31971"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:P/VC:N/VI:H/VA:L/SC:N/SI:N/SA:N"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:N/I:H/A:H"
+        },
+        {
+            "issuer": "NIST",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:H/A:H"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-31973.json
+++ b/evals/osidb_cache/CVE-2026-31973.json
@@ -1,0 +1,42 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-31973",
+    "cwe_id": "CWE-476",
+    "impact": "MODERATE",
+    "title": "SAMtools: Denial of Service due to NULL pointer dereference in cram-size command",
+    "statement": "",
+    "mitigation": "",
+    "comment_zero": "SAMtools is a program for reading, manipulating and writing bioinformatics file formats. Starting in version 1.17, in the cram-size command, used to write information about how well CRAM files are compressed, a check to see if the `cram_decode_compression_header()` was missing. If the function returned an error, this could lead to a NULL pointer dereference. Exploiting this bug causes a NULL pointer dereference. Typically this will cause the program to crash. Versions 1.23.1, 1.22.2 and 1.21.1 include fixes for this issue. There is no workaround for this issue.",
+    "comments": "",
+    "description": "A flaw was found in SAMtools. In the `cram-size` command, a missing check for the return value of the `cram_decode_compression_header()` function can lead to a NULL pointer dereference. An attacker could exploit this by providing a specially crafted CRAM file. This vulnerability typically causes the program to crash, resulting in a Denial of Service (DoS).",
+    "components": [
+        "samtools"
+    ],
+    "references": [
+        {
+            "url": "https://github.com/samtools/samtools/commit/06fc2a219b3d7c94d3f412c09f6d1efd51199f2f"
+        },
+        {
+            "url": "https://github.com/samtools/samtools/security/advisories/GHSA-x86f-q6fj-cm43"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-31973"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:L/VA:L/SC:N/SI:N/SA:N"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        },
+        {
+            "issuer": "NIST",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-32636.json
+++ b/evals/osidb_cache/CVE-2026-32636.json
@@ -1,0 +1,45 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-32636",
+    "cwe_id": "CWE-787",
+    "impact": "MODERATE",
+    "title": "ImageMagick: Denial of Service via out-of-bounds write in NewXMLTree method",
+    "statement": "",
+    "mitigation": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability.",
+    "comment_zero": "ImageMagick is free and open-source software used for editing and manipulating digital images. Prior to 7.1.2-17 and 6.9.13-42, the NewXMLTree method contains a bug that could result in a crash due to an out of write bounds of a single zero byte. Versions 7.1.2-17 and 6.9.13-42 fix the issue.",
+    "comments": "",
+    "description": "A flaw was found in ImageMagick. The NewXMLTree method contains a bug that could result in a crash due to an out of write bounds of a single zero byte. This vulnerability could allow a remote attacker to cause a Denial of Service (DoS) by providing a specially crafted image, leading to system instability or unavailability.",
+    "components": [
+        "ImageMagick"
+    ],
+    "references": [
+        {
+            "url": "https://github.com/ImageMagick/ImageMagick/security/advisories/GHSA-gc62-2v5p-qpmp"
+        },
+        {
+            "url": "https://github.com/dlemstra/Magick.NET/releases/tag/14.11.0"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-32636"
+        },
+        {
+            "url": "https://github.com/ImageMagick/ImageMagick/releases/tag/7.1.2-17"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        },
+        {
+            "issuer": "NIST",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-33001.json
+++ b/evals/osidb_cache/CVE-2026-33001.json
@@ -1,0 +1,35 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-33001",
+    "cwe_id": "CWE-22",
+    "impact": "IMPORTANT",
+    "title": "Jenkins: Arbitrary file write and potential code execution through crafted archives",
+    "statement": "",
+    "mitigation": "",
+    "comment_zero": "Jenkins 2.554 and earlier, LTS 2.541.2 and earlier does not safely handle symbolic links during the extraction of .tar and .tar.gz archives, allowing crafted archives to write files to arbitrary locations on the filesystem, restricted only by file system access permissions of the user running Jenkins.\nThis can be exploited to deploy malicious scripts or plugins on the controller by attackers with Item/Configure permission, or able to control agent processes.",
+    "comments": "",
+    "description": "A flaw was found in Jenkins. This vulnerability allows attackers with Item/Configure permission, or those who can control agent processes, to exploit unsafe handling of symbolic links during the extraction of .tar and .tar.gz archives. By crafting malicious archives, an attacker can write files to arbitrary locations on the filesystem. This could enable the deployment of malicious scripts or plugins on the Jenkins controller, potentially leading to unauthorized code execution.",
+    "components": [
+        "jenkins"
+    ],
+    "references": [
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-33001"
+        },
+        {
+            "url": "https://www.jenkins.io/security/advisory/2026-03-18/#SECURITY-3657"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H"
+        },
+        {
+            "issuer": "CISA",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-33002.json
+++ b/evals/osidb_cache/CVE-2026-33002.json
@@ -1,0 +1,35 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-33002",
+    "cwe_id": "CWE-346",
+    "impact": "MODERATE",
+    "title": "Jenkins: Origin validation bypass via DNS rebinding in CLI WebSocket endpoint",
+    "statement": "This vulnerability is rated as Moderate by Red Hat, as the possible impacts of successful exploitation are tied to the permissions assigned to the anonymous user.",
+    "mitigation": "",
+    "comment_zero": "Jenkins 2.442 through 2.554 (both inclusive), LTS 2.426.3 through LTS 2.541.2 (both inclusive) performs origin validation of requests made through the CLI WebSocket endpoint by computing the expected origin for comparison using the Host or X-Forwarded-Host HTTP request headers, making it vulnerable to DNS rebinding attacks that allow bypassing origin validation.",
+    "comments": "",
+    "description": "A flaw was found in Jenkins. A remote attacker could exploit a vulnerability in the origin validation of requests made through the Command Line Interface (CLI) WebSocket endpoint. By manipulating the Host or X-Forwarded-Host HTTP headers, an attacker can perform Domain Name System (DNS) rebinding attacks. This allows bypassing the origin validation, potentially leading to unauthorized actions within the Jenkins environment.",
+    "components": [
+        "jenkins"
+    ],
+    "references": [
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-33002"
+        },
+        {
+            "url": "https://www.jenkins.io/security/advisory/2026-03-18/#SECURITY-3674"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:L/A:N"
+        },
+        {
+            "issuer": "CISA",
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-33551.json
+++ b/evals/osidb_cache/CVE-2026-33551.json
@@ -1,0 +1,38 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-33551",
+    "cwe_id": "CWE-266",
+    "impact": "LOW",
+    "title": "OpenStack Keystone: Privilege escalation through EC2 credential creation",
+    "statement": "",
+    "mitigation": "",
+    "comment_zero": "Maxence Bornecque from Orange Cyberdefense CERT Vulnerability Intelligence Watch Team reported a vulnerability in Keystone's EC2 credential creation endpoint. By using a restricted application credential to call the EC2 credential creation API, an authenticated user with only a reader role may obtain an EC2/S3 credential that carries the full set of the parent user's S3 permissions, effectively bypassing the role restrictions imposed on the application credential. Only deployments that use restricted application credentials in combination with the EC2/S3 compatibility API (swift3 / s3api) are affected.",
+    "comments": "",
+    "description": "A flaw was found in OpenStack Keystone. An authenticated user with a reader role can exploit a vulnerability in the EC2 credential creation endpoint. By using a restricted application credential to call the EC2 credential creation API, the user may obtain EC2/S3 credentials that carry the full set of the parent user's S3 permissions. This effectively bypasses the role restrictions imposed on the application credential, leading to unauthorized access and privilege escalation. This issue affects deployments that use restricted application credentials in combination with the EC2/S3 compatibility API.",
+    "components": [
+        "openstack-keystone"
+    ],
+    "references": [
+        {
+            "url": "https://www.openwall.com/lists/oss-security/2026/04/07/12"
+        },
+        {
+            "url": "http://www.openwall.com/lists/oss-security/2026/04/07/12"
+        },
+        {
+            "url": "https://security.openstack.org/ossa/OSSA-2026-005.html"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:C/C:N/I:L/A:N"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:C/C:N/I:L/A:N"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-33995.json
+++ b/evals/osidb_cache/CVE-2026-33995.json
@@ -1,0 +1,38 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-33995",
+    "cwe_id": "CWE-825",
+    "impact": "MODERATE",
+    "title": "FreeRDP: Denial of Service via double-free vulnerability during NLA connection teardown",
+    "statement": "",
+    "mitigation": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability.",
+    "comment_zero": "FreeRDP is a free implementation of the Remote Desktop Protocol. Prior to version 3.24.2, a double-free vulnerability in kerberos_AcceptSecurityContext() and kerberos_InitializeSecurityContextA() (WinPR, winpr/libwinpr/sspi/Kerberos/kerberos.c) can cause a crash in any FreeRDP clients on systems where Kerberos and/or Kerberos U2U is configured (Samba AD member, or krb5 for NFS). The crash is triggered during NLA connection teardown and requires a failed authentication attempt. This issue has been patched in version 3.24.2.",
+    "comments": "",
+    "description": "A flaw was found in FreeRDP, a free implementation of the Remote Desktop Protocol. A remote attacker could exploit a double-free vulnerability in the Kerberos security context functions, specifically `kerberos_AcceptSecurityContext()` and `kerberos_InitializeSecurityContextA()`, within the WinPR library. This vulnerability is triggered during the Network Level Authentication (NLA) connection teardown process after a failed authentication attempt. Successful exploitation can lead to a client crash, resulting in a Denial of Service (DoS) for affected FreeRDP clients configured with Kerberos.",
+    "components": [
+        "FreeRDP"
+    ],
+    "references": [
+        {
+            "url": "https://github.com/FreeRDP/FreeRDP/security/advisories/GHSA-mv25-f4p2-5mxx"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-33995"
+        },
+        {
+            "url": "https://github.com/FreeRDP/FreeRDP/commit/8078b8af1359055972e4fb2f509f543b69169391"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-34073.json
+++ b/evals/osidb_cache/CVE-2026-34073.json
@@ -1,0 +1,39 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-34073",
+    "cwe_id": "CWE-295",
+    "impact": "LOW",
+    "title": "Cryptography: Security bypass due to improper DNS name constraint validation",
+    "statement": "Red Hat products and services do not employ certificate chains of the form required for this vulnerability. A Red Hat customer may construct such a certificate chain, however these would be non-default configurations.",
+    "mitigation": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability.",
+    "comment_zero": "cryptography is a package designed to expose cryptographic primitives and recipes to Python developers. Prior to version 46.0.6, DNS name constraints were only validated against SANs within child certificates, and not the \"peer name\" presented during each validation. Consequently, cryptography would allow a peer named bar.example.com to validate against a wildcard leaf certificate for *.example.com, even if the leaf's parent certificate (or upwards) contained an excluded subtree constraint for bar.example.com. This issue has been patched in version 46.0.6.",
+    "comments": "",
+    "description": "A flaw was found in the `cryptography` library. This vulnerability occurs because DNS (Domain Name System) name constraints were not properly validated against the \"peer name\" during certificate validation, only against Subject Alternative Names (SANs) within child certificates. This oversight could allow a malicious actor to bypass security restrictions, enabling a certificate for a specific domain to be validated against a broader wildcard certificate, even when an exclusion for that specific domain exists. This could lead to an attacker impersonating a legitimate server or service.",
+    "components": [
+        "python-cryptography"
+    ],
+    "references": [
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-34073"
+        },
+        {
+            "url": "https://github.com/pyca/cryptography/security/advisories/GHSA-m959-cc7f-wv43"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "NIST",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N"
+        },
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:4.0/AV:N/AC:H/AT:P/PR:N/UI:N/VC:N/VI:L/VA:N/SC:N/SI:N/SA:N/E:U"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-34785.json
+++ b/evals/osidb_cache/CVE-2026-34785.json
@@ -1,0 +1,35 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-34785",
+    "cwe_id": "CWE-552",
+    "impact": "IMPORTANT",
+    "title": "Rack: Information disclosure via incorrect static file serving prefix check",
+    "statement": "",
+    "mitigation": "",
+    "comment_zero": "Rack is a modular Ruby web server interface. Prior to versions 2.2.23, 3.1.21, and 3.2.6, Rack::Static determines whether a request should be served as a static file using a simple string prefix check. When configured with URL prefixes such as \"/css\", it matches any request path that begins with that string, including unrelated paths such as \"/css-config.env\" or \"/css-backup.sql\". As a result, files under the static root whose names merely share the configured prefix may be served unintentionally, leading to information disclosure. This issue has been patched in versions 2.2.23, 3.1.21, and 3.2.6.",
+    "comments": "",
+    "description": "A flaw was found in Rack. The `Rack::Static` component, which serves static files for web applications, uses a simple string prefix check to determine if a request should be served as a static file. This can lead to unintended information disclosure, as files with names that merely share a configured URL prefix (e.g., \"/css\" matching \"/css-config.env\") may be served unintentionally to a remote attacker.",
+    "components": [
+        "github.com/rack/rack"
+    ],
+    "references": [
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-34785"
+        },
+        {
+            "url": "https://github.com/rack/rack/security/advisories/GHSA-h2jq-g4cq-5ppq"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+        },
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-3497.json
+++ b/evals/osidb_cache/CVE-2026-3497.json
@@ -1,0 +1,38 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-3497",
+    "cwe_id": "CWE-824",
+    "impact": "IMPORTANT",
+    "title": "OpenSSH GSSAPI: Information disclosure or denial of service due to uninitialized variables",
+    "statement": "IMPORTANT: This vulnerability affects the OpenSSH GSSAPI delta as implemented in Red Hat Enterprise Linux and OpenShift Container Platform. An unauthenticated attacker could send a specially crafted GSSAPI message during key exchange, leading to the use of uninitialized variables and potentially undefined behavior. The severity of the impact is dependent on compiler hardening configurations.",
+    "mitigation": "To mitigate this issue, disable GSSAPI key exchange in the OpenSSH server configuration. This prevents the server from processing GSSAPI messages, eliminating the vulnerability's attack surface.\n\nEdit `/etc/ssh/sshd_config` and add or modify the line:\n```\nGSSAPIKeyExchange no\n```\n\nAfter saving the changes, restart the `sshd` service for the mitigation to take effect. This action will prevent users from authenticating via GSSAPI.\n\n```\n# systemctl restart sshd\n```",
+    "comment_zero": "Vulnerability in the OpenSSH GSSAPI delta included in various Linux distributions. This vulnerability affects the GSSAPI patches added by various Linux distributions and does not affect the OpenSSH upstream project itself. The usage of sshpkt_disconnect() on an error, which does not terminate the process, allows an attacker to send an unexpected GSSAPI message type during the GSSAPI key exchange to the server, which will call the underlying function and continue the execution of the program without setting the related connection variables. As the variables are not initialized to NULL the code later accesses those uninitialized variables, accessing random memory, which could lead to undefined behavior. The recommended workaround is to use ssh_packet_disconnect() instead, which does terminate the process. The impact of the vulnerability depends heavily on the compiler flag hardening configuration.",
+    "comments": "",
+    "description": "A flaw was found in the OpenSSH GSSAPI (Generic Security Service Application Program Interface) delta patches, as included in various Linux distributions. A remote attacker could exploit this by sending an unexpected GSSAPI message type during the key exchange process. This occurs because the `sshpkt_disconnect()` function, when called on an error, does not properly terminate the process, leading to the continued execution of the program with uninitialized connection variables. Accessing these uninitialized variables can lead to undefined behavior, potentially resulting in information disclosure or a denial of service.",
+    "components": [
+        "openssh"
+    ],
+    "references": [
+        {
+            "url": "https://ubuntu.com/security/CVE-2026-3497"
+        },
+        {
+            "url": "https://www.openwall.com/lists/oss-security/2026/03/12/3"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-3497"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:L/VA:L/SC:N/SI:N/SA:N"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:H"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-35091.json
+++ b/evals/osidb_cache/CVE-2026-35091.json
@@ -1,0 +1,32 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-35091",
+    "cwe_id": "CWE-253",
+    "impact": "MODERATE",
+    "title": "Corosync: Denial of Service and information disclosure via crafted UDP packet",
+    "statement": "This vulnerability has a Moderate impact on Red Hat products. A flaw in Corosync's membership commit token sanity check, when running in the default totemudp/totemudpu mode, allows a remote unauthenticated attacker to send a crafted UDP packet. This can lead to an out-of-bounds read, resulting in a denial of service and potential limited memory content disclosure. This issue affects Corosync only when configured to use the legacy totemudp or totemudpu transport modes with unencrypted communication.\n\nThese modes are not the default in modern Corosync versions. The default transport is knet, which supports encryption and is the standard configuration in RHEL.Additionally, totemudp and totemudpu are unsupported in RHEL, and their use requires explicit manual configuration.",
+    "mitigation": "Systems using totemudp or totemudpu should migrate to the supported knet transport and enable encryption.\n\nDisabling the Corosync service is a valid workaround if clustering is not required, but for active clusters, enabling encryption via knet is the preferred and recommended approach.",
+    "comment_zero": "Wrong return value vulnerability in the Corosync membership commit token sanity check in exec/totemsrp.c. The flaw occurs in check_memb_commit_token_sanity() where truncated messages (msg_len < sizeof(struct memb_commit_token)) incorrectly return 0 (success) instead of -1 (failure). As a result, message_handler_memb_commit_token() continues processing attacker-controlled, undersized input, performs an allocation based on the short length, and then accesses struct memb_commit_token fields beyond the allocated region, triggering an out-of-bounds read (ASAN-confirmed). This can be exploited remotely without authentication in totemudp/totemudpu mode by sending a single crafted UDP packet to the Corosync port (default 5405), causing a denial of service and potentially leaking limited memory contents.",
+    "comments": "",
+    "description": "A flaw was found in Corosync. A remote unauthenticated attacker can exploit a wrong return value vulnerability in the Corosync membership commit token sanity check by sending a specially crafted User Datagram Protocol (UDP) packet. This can lead to an out-of-bounds read, causing a denial of service (DoS) and potentially disclosing limited memory contents. This vulnerability affects Corosync when running in totemudp/totemudpu mode, which is the default configuration.",
+    "components": [
+        "corosync"
+    ],
+    "references": [
+        {
+            "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2453169"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:H"
+        },
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:H"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-35386.json
+++ b/evals/osidb_cache/CVE-2026-35386.json
@@ -1,0 +1,41 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-35386",
+    "cwe_id": "CWE-78",
+    "impact": "LOW",
+    "title": "OpenSSH: Arbitrary command execution via shell metacharacters in username",
+    "statement": "",
+    "mitigation": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability.",
+    "comment_zero": "In OpenSSH before 10.3, command execution can occur via shell metacharacters in a username within a command line. This requires a scenario where the username on the command line is untrusted, and also requires a non-default configurations of % in ssh_config.",
+    "comments": "",
+    "description": "A flaw was found in OpenSSH. This vulnerability allows a remote attacker to achieve arbitrary command execution by injecting shell metacharacters into a username provided on the command line. Exploitation requires an untrusted username and a non-default configuration of the '%' character in `ssh_config`.",
+    "components": [
+        "OpenSSH"
+    ],
+    "references": [
+        {
+            "url": "https://www.openssh.org/releasenotes.html#10.3p1"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-35386"
+        },
+        {
+            "url": "https://www.openwall.com/lists/oss-security/2026/04/02/3"
+        },
+        {
+            "url": "https://marc.info/?l=openssh-unix-dev&m=177513443901484&w=2"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:L/I:L/A:N"
+        },
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:L/I:L/A:N"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-35535.json
+++ b/evals/osidb_cache/CVE-2026-35535.json
@@ -1,0 +1,44 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-35535",
+    "cwe_id": "CWE-272",
+    "impact": "IMPORTANT",
+    "title": "Sudo: Privilege escalation due to failure in privilege drop calls",
+    "statement": "",
+    "mitigation": "",
+    "comment_zero": "In Sudo through 1.9.17p2 before 3e474c2, a failure of a setuid, setgid, or setgroups call, during a privilege drop before running the mailer, is not a fatal error and can lead to privilege escalation.",
+    "comments": "",
+    "description": "A flaw was found in Sudo. A local user could exploit a failure in the setuid, setgid, or setgroups calls, which are used to drop privileges before running the mailer. This oversight allows for privilege escalation, enabling the user to gain elevated access on the system.",
+    "components": [
+        "sudo"
+    ],
+    "references": [
+        {
+            "url": "https://github.com/sudo-project/sudo/commit/3e474c2f201484be83d994ae10a4e20e8c81bb69"
+        },
+        {
+            "url": "https://bugs.launchpad.net/ubuntu/+source/sudo/+bug/2143042"
+        },
+        {
+            "url": "https://www.qualys.com/2026/03/10/crack-armor.txt"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-35535"
+        },
+        {
+            "url": "https://bugs.debian.org/1130593"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-35536.json
+++ b/evals/osidb_cache/CVE-2026-35536.json
@@ -1,0 +1,42 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-35536",
+    "cwe_id": "CWE-88",
+    "impact": "MODERATE",
+    "title": "Tornado: Cookie attribute injection due to improper handling of cookie arguments",
+    "statement": "",
+    "mitigation": "",
+    "comment_zero": "In Tornado before 6.5.5, cookie attribute injection could occur because the domain, path, and samesite arguments to .RequestHandler.set_cookie were not checked for crafted characters.",
+    "comments": "",
+    "description": "A flaw was found in Tornado. A remote attacker could exploit this vulnerability by injecting specially crafted characters into the `domain`, `path`, and `samesite` arguments when setting cookies. This could lead to cookie attribute injection, potentially allowing for information disclosure or manipulation of client-side data.",
+    "components": [
+        "tornado"
+    ],
+    "references": [
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-35536"
+        },
+        {
+            "url": "https://github.com/tornadoweb/tornado/releases/tag/v6.5.5"
+        },
+        {
+            "url": "https://github.com/tornadoweb/tornado/security/advisories/GHSA-78cv-mqj4-43f7"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N"
+        },
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N"
+        },
+        {
+            "issuer": "NIST",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-35537.json
+++ b/evals/osidb_cache/CVE-2026-35537.json
@@ -1,0 +1,57 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-35537",
+    "cwe_id": "CWE-502",
+    "impact": "LOW",
+    "title": "Roundcube Webmail: Arbitrary file write via unsafe deserialization in session handler",
+    "statement": "",
+    "mitigation": "",
+    "comment_zero": "An issue was discovered in Roundcube Webmail before 1.5.14 and 1.6.14. Unsafe deserialization in the redis/memcache session handler may lead to arbitrary file write operations by unauthenticated attackers via crafted session data.",
+    "comments": "",
+    "description": "A flaw was found in Roundcube Webmail. Unauthenticated attackers can exploit an unsafe deserialization vulnerability in the redis/memcache session handler. This allows for arbitrary file write operations by crafting malicious session data. The primary impact is the ability to write files to the system.",
+    "components": [
+        "roundcubemail"
+    ],
+    "references": [
+        {
+            "url": "https://github.com/roundcube/roundcubemail/commit/a4ead994d2f0ea92e4a1603196a197e0d5df1620"
+        },
+        {
+            "url": "https://github.com/roundcube/roundcubemail/releases/tag/1.5.14"
+        },
+        {
+            "url": "https://github.com/roundcube/roundcubemail/releases/tag/1.7-rc5"
+        },
+        {
+            "url": "https://github.com/roundcube/roundcubemail/commit/6d586cfa4d8a31f7957f7a445aaedd52592a0e74"
+        },
+        {
+            "url": "https://roundcube.net/news/2026/03/18/security-updates-1.7-rc5-1.6.14-1.5.14"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-35537"
+        },
+        {
+            "url": "https://github.com/roundcube/roundcubemail/commit/618c5428edc69fb088e7ac6c89e506dd39df3"
+        },
+        {
+            "url": "https://github.com/roundcube/roundcubemail/releases/tag/1.6.14"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N"
+        },
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N"
+        },
+        {
+            "issuer": "NIST",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-35540.json
+++ b/evals/osidb_cache/CVE-2026-35540.json
@@ -1,0 +1,51 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-35540",
+    "cwe_id": "CWE-918",
+    "impact": "MODERATE",
+    "title": "Roundcube Webmail: SSRF via insufficient CSS sanitization",
+    "statement": "",
+    "mitigation": "",
+    "comment_zero": "An issue was discovered in Roundcube Webmail 1.6.0 before 1.6.14. Insufficient Cascading Style Sheets (CSS) sanitization in HTML e-mail messages may lead to SSRF or Information Disclosure, e.g., if stylesheet links point to local network hosts.",
+    "comments": "",
+    "description": "A flaw was found in Roundcube Webmail. Insufficient sanitization of Cascading Style Sheets (CSS) in HTML e-mail messages may allow a remote attacker to perform Server-Side Request Forgery (SSRF) or disclose sensitive information. This can occur if malicious stylesheet links within an e-mail point to internal network hosts, potentially allowing an attacker to make requests from the server or gain unauthorized access to data.",
+    "components": [
+        "roundcubemail"
+    ],
+    "references": [
+        {
+            "url": "https://github.com/roundcube/roundcubemail/commit/579b68eff90650a5c782e153debd66c765648942"
+        },
+        {
+            "url": "https://github.com/roundcube/roundcubemail/releases/tag/1.6.14"
+        },
+        {
+            "url": "https://github.com/roundcube/roundcubemail/releases/tag/1.7-rc5"
+        },
+        {
+            "url": "https://github.com/roundcube/roundcubemail/commit/27ec6cc9cb25e1ef8b4d4ef39ce76d619caa6870"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-35540"
+        },
+        {
+            "url": "https://roundcube.net/news/2026/03/18/security-updates-1.7-rc5-1.6.14-1.5.14"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:L/I:L/A:N"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
+        },
+        {
+            "issuer": "NIST",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-3608.json
+++ b/evals/osidb_cache/CVE-2026-3608.json
@@ -1,0 +1,41 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-3608",
+    "cwe_id": "CWE-617",
+    "impact": "IMPORTANT",
+    "title": "Kea: Denial of Service via maliciously crafted message",
+    "statement": "",
+    "mitigation": "",
+    "comment_zero": "Sending a maliciously crafted message to the kea-ctrl-agent, kea-dhcp-ddns, kea-dhcp4, or kea-dhcp6 daemons over any configured API socket or HA listener can cause the receiving daemon to exit with a stack overflow error.\nThis issue affects Kea versions 2.6.0 through 2.6.4 and 3.0.0 through 3.0.2.",
+    "comments": "",
+    "description": "A flaw was found in Kea. A remote attacker can send a maliciously crafted message to the kea-ctrl-agent, kea-dhcp-ddns, kea-dhcp4, or kea-dhcp6 daemons over any configured API socket or HA listener. This can cause a stack overflow error, leading to the daemon exiting and resulting in a Denial of Service (DoS).",
+    "components": [
+        "Kea"
+    ],
+    "references": [
+        {
+            "url": "https://downloads.isc.org/isc/kea/2.6.5"
+        },
+        {
+            "url": "https://downloads.isc.org/isc/kea/3.0.3"
+        },
+        {
+            "url": "https://kb.isc.org/docs/cve-2026-3608"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-3608"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        },
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-3644.json
+++ b/evals/osidb_cache/CVE-2026-3644.json
@@ -1,0 +1,44 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-3644",
+    "cwe_id": "CWE-791",
+    "impact": "MODERATE",
+    "title": "Incomplete control character validation in http.cookies",
+    "statement": "",
+    "mitigation": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability.",
+    "comment_zero": "The fix for CVE-2026-0672, which rejected control characters in http.cookies.Morsel, was incomplete. The Morsel.update(), |= operator, and unpickling paths were not patched, allowing control characters to bypass input validation. Additionally, BaseCookie.js_output() lacked the output validation applied to BaseCookie.output().",
+    "comments": "",
+    "description": "A control character validation flaw has been discovered in the Python http.cookie module. The Morsel.update(), |= operator, and unpickling paths were not patched to resolve  CVE-2026-0672, allowing control characters to bypass input validation. Additionally, BaseCookie.js_output() lacked the output validation applied to BaseCookie.output().",
+    "components": [
+        "cpython"
+    ],
+    "references": [
+        {
+            "url": "https://github.com/python/cpython/commit/57e88c1cf95e1481b94ae57abe1010469d47a6b4"
+        },
+        {
+            "url": "https://mail.python.org/archives/list/security-announce@python.org/thread/H6CADMBCDRFGWCMOXWUIHFJNV43GABJ7/"
+        },
+        {
+            "url": "https://github.com/python/cpython/pull/145600"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-3644"
+        },
+        {
+            "url": "https://github.com/python/cpython/issues/145599"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:L/UI:N/VC:L/VI:H/VA:N/SC:N/SI:N/SA:N"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:N"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-40175.json
+++ b/evals/osidb_cache/CVE-2026-40175.json
@@ -1,0 +1,44 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-40175",
+    "cwe_id": "CWE-915",
+    "impact": "CRITICAL",
+    "title": "Axios: Remote Code Execution via Prototype Pollution escalation",
+    "statement": "Critical impact: The Axios library, a promise-based HTTP client, is susceptible to a prototype pollution vulnerability. This flaw, when combined with specific \"Gadget\" attack chains in third-party dependencies, can lead to remote code execution or full cloud compromise, including bypassing AWS IMDSv2.\n \nWith pollution check patch available in Axios gives an advantage, it remains vulnerable due to HTTP Header Sanitation and Server-Side Request Forgery threat.\n\nRed Hat products that incorporate the vulnerable Axios library are affected.\n\nThe openshift4/ose-monitoring-plugin-rhel9 container image is not vulnerable to this flaw. The affected component is used as a build-time dependency but it's not shipped in the final product, meaning the flaw is not present thus cannot be exploited in the container deployments.",
+    "mitigation": "",
+    "comment_zero": "Axios is a promise based HTTP client for the browser and Node.js. Prior to 1.15.0, the Axios library is vulnerable to a specific \"Gadget\" attack chain that allows Prototype Pollution in any third-party dependency to be escalated into Remote Code Execution (RCE) or Full Cloud Compromise (via AWS IMDSv2 bypass). This vulnerability is fixed in 1.15.0.",
+    "comments": "",
+    "description": "A flaw was found in Axios, a promise-based HTTP client. This vulnerability, known as Prototype Pollution, can be exploited through a specific \"Gadget\" attack chain. This allows an attacker to escalate a Prototype Pollution vulnerability in a third-party dependency, potentially leading to remote code execution or a full cloud compromise, such as bypassing AWS IMDSv2.",
+    "components": [
+        "axios"
+    ],
+    "references": [
+        {
+            "url": "https://github.com/axios/axios/pull/10660"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-40175"
+        },
+        {
+            "url": "https://github.com/axios/axios/security/advisories/GHSA-fvcv-3m26-pcqx"
+        },
+        {
+            "url": "https://github.com/axios/axios/commit/363185461b90b1b78845dc8a99a1f103d9b122a1"
+        },
+        {
+            "url": "https://github.com/axios/axios/releases/tag/v1.15.0"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H"
+        },
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-40223.json
+++ b/evals/osidb_cache/CVE-2026-40223.json
@@ -1,0 +1,35 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-40223",
+    "cwe_id": "CWE-617",
+    "impact": "MODERATE",
+    "title": "systemd: Local unprivileged user can cause Denial of Service",
+    "statement": "",
+    "mitigation": "",
+    "comment_zero": "In systemd 258 before 260, a local unprivileged user can trigger an assert when a Delegate=yes and User=<unset> unit exists and is running.",
+    "comments": "",
+    "description": "A flaw was found in systemd, a core component of Linux operating systems. A local user, without special privileges, can exploit this vulnerability. By manipulating a specific systemd unit configuration where delegation is enabled and the user is not set, the user can trigger an internal error, leading to a Denial of Service (DoS). This means the affected system may become unresponsive or crash, impacting its availability.",
+    "components": [
+        "systemd"
+    ],
+    "references": [
+        {
+            "url": "https://github.com/systemd/systemd/security/advisories/GHSA-x4h8-rrrg-q78f"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-40223"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:N/A:H"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:N/A:H"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-40227.json
+++ b/evals/osidb_cache/CVE-2026-40227.json
@@ -1,0 +1,39 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-40227",
+    "cwe_id": "CWE-476",
+    "impact": "MODERATE",
+    "title": "systemd: Denial of Service via malicious IPC API call with null element",
+    "statement": "A flaw in systemd allows a local unprivileged user to cause a Denial of Service by making a crafted Inter-Process Communication (IPC) API call. The issue is restricted to systemd v260 only, the systemd versions as shipped as with Red Hat products are not affected by this vulnerability as it doesn't ship the commit which introduced the vulnerability.",
+    "mitigation": "This issue can be mitigated by changing the permission of the varsock file located at:\n~~~\n/run/systemd/io.systemd.Manager\n~~~\nto be accessible only by trusted or privileged users.",
+    "comment_zero": "In systemd 260 before 261, a local unprivileged user can trigger an assert via an IPC API call with an array or map that has a null element.",
+    "comments": "",
+    "description": "A flaw was found in systemd. A local unprivileged user can exploit this vulnerability by making an Inter-Process Communication (IPC) API call with a specially crafted array or map containing a null element. This can trigger an assert, leading to a Denial of Service (DoS) condition, which makes the system unavailable.",
+    "components": [
+        "systemd"
+    ],
+    "references": [
+        {
+            "url": "https://github.com/systemd/systemd/security/advisories/GHSA-848h-497j-8vjq"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-40227"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
+        },
+        {
+            "issuer": "NIST",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-4271.json
+++ b/evals/osidb_cache/CVE-2026-4271.json
@@ -1,0 +1,36 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-4271",
+    "cwe_id": "CWE-416",
+    "impact": "MODERATE",
+    "title": "libsoup: Denial of Service via Use-After-Free in HTTP/2 server",
+    "statement": "This MODERATE impact use-after-free flaw in libsoup's HTTP/2 server implementation affects applications that use libsoup to handle HTTP/2 server callbacks. An attacker can trigger this by sending HTTP/2 requests that cause authentication validation failures, potentially leading to application instability or crashes. Red Hat products are affected if they leverage libsoup as an HTTP/2 server and disconnect client connections during header processing.",
+    "mitigation": "Mitigation for this issue is either not available or the currently available options don't meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability.",
+    "comment_zero": "Use-After-Free vulnerability in the HTTP/2 server implementation of the libsoup HTTP library. The issue occurs in the on_frame_recv_callback() function when processing HTTP/2 frames. During header handling, the function increments an internal callback counter and emits signals such as soup_server_message_got_headers(). If a user-defined signal handler disconnects the client connection during this callback (for example due to authentication failure), the associated SoupServerMessageIOHTTP2 object may be destroyed and freed while still referenced by the callback. When execution returns to the callback, it continues to access the freed io object and attempts to update internal state, resulting in a heap use-after-free condition. An attacker can trigger this issue by sending HTTP/2 requests that cause authentication validation failures, potentially leading to application instability or crashes.",
+    "comments": "",
+    "description": "A flaw was found in libsoup, a library for handling HTTP requests. This vulnerability, known as a Use-After-Free, occurs in the HTTP/2 server implementation. A remote attacker can exploit this by sending specially crafted HTTP/2 requests that cause authentication failures. This can lead to the application attempting to access memory that has already been freed, potentially causing application instability or crashes, resulting in a Denial of Service (DoS).",
+    "components": [
+        "libsoup"
+    ],
+    "references": [
+        {
+            "url": "https://gitlab.gnome.org/GNOME/libsoup/-/issues/496"
+        }
+    ],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+        },
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+        },
+        {
+            "issuer": "NIST",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-5483.json
+++ b/evals/osidb_cache/CVE-2026-5483.json
@@ -1,0 +1,28 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-5483",
+    "cwe_id": "CWE-201",
+    "impact": "IMPORTANT",
+    "title": "ODH Dashboard Kubernetes Service Account Exposure",
+    "statement": "A flaw in the `odh-dashboard` component of Red Hat OpenShift AI allows for the disclosure of Kubernetes Service Account tokens through a NodeJS endpoint. This vulnerability could enable an attacker to gain unauthorized access to Kubernetes resources within the OpenShift AI environment.\n\nThe NIM serving API endpoint (`/api/nim-serving/:nimResource`) returns the full K8 client response including the dashboard's service account token. \n\nRequirements to exploit:\n- Authenticated access to the dashboard\n- The NIM account CR must exist on the cluster for 2.25+ \n- The target secret must exist and if the secret referenced by the Account CR hasn't been created yet, the endpoint returns a 404 and no token is leaked",
+    "mitigation": "If applying the update is not immediately possible, the vulnerability can be mitigated by disabling or removing the NIM (NVIDIA Inference Microservice) integration from the Red Hat OpenShift AI (RHOAI) environment.",
+    "comment_zero": "A flaw was found in odh-dashboard in Red Hat Openshift AI. This vulnerability in the `odh-dashboard` component of Red Hat OpenShift AI (RHOAI) allows for the disclosure of Kubernetes Service Account tokens through a NodeJS endpoint. This could enable an attacker to gain unauthorized access to Kubernetes resources.",
+    "comments": "",
+    "description": "A flaw was found in odh-dashboard in Red Hat Openshift AI. This vulnerability in the `odh-dashboard` component of Red Hat OpenShift AI (RHOAI) allows for the disclosure of Kubernetes Service Account tokens through a NodeJS endpoint. This could enable an attacker to gain unauthorized access to Kubernetes resources.",
+    "components": [
+        "odh-dashboard"
+    ],
+    "references": [],
+    "affects": [],
+    "cvss_scores": [
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:C/C:H/I:H/A:H"
+        },
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:C/C:H/I:H/A:H"
+        }
+    ]
+}

--- a/src/aegis_ai/toolsets/tools/cwe/__init__.py
+++ b/src/aegis_ai/toolsets/tools/cwe/__init__.py
@@ -61,6 +61,7 @@ KEYWORD_BOOSTS: List[Tuple[re.Pattern[str], str, float]] = [
     (re.compile(r"\brace (condition)?\b"), "CWE-366", 0.2),
     # CWE-825: Expired/Dangling Pointer Dereference
     (re.compile(r"\b(dangling|stale|expired) pointer\b"), "CWE-825", 0.25),
+    (re.compile(r"\b(assert\w*|abort)\b.*\b(fail|reach|trigger|hit)\b|\breachable assert"), "CWE-617", 0.2),
     # CWE-459: Incomplete Cleanup (temp files, leftover artifacts)
     (re.compile(r"\b(incomplete|missing) cleanup\b|\bnot (deleted|removed)\b|\btemporary file\b|\bleft in (/tmp|tmp|temp)\b"), "CWE-459", 0.25),
     # CWE-772: Missing Release of Resource after Effective Lifetime (resource leak)


### PR DESCRIPTION
## What

Process feedback from Aegis API endpoints collected since 2026-03-16. This adds 50+ new evaluation cases across all four CVE features (`suggest-cwe`, `suggest-impact`, `suggest-statement`, `suggest-description`), adds a keyword boost for `CWE-617` (Reachable Assertion) in the CWE search tool, and caches 50 new OSIDB fixtures.

## Why
Resolves [AEGIS-377](https://redhat.atlassian.net/browse/AEGIS-377). Integrating production feedback into the eval suite improves regression coverage and surfaces areas where Aegis suggestions diverge from analyst expectations. The `CWE-617` keyword boost was added because the TF-IDF search was failing to rank "reachable assertion" CVEs correctly.

## How to Test
See the CI results.

## Related Tickets
Related: https://redhat.atlassian.net/browse/AEGIS-377

[AEGIS-377]: https://redhat.atlassian.net/browse/AEGIS-377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Integrate recent Aegis API production feedback into the CVE evaluation suite and improve CWE suggestion coverage for reachable assertions.

Enhancements:
- Add a keyword-based boost for CWE-617 (reachable assertion) in the CWE search tool to better recognize assertion-related vulnerabilities.

Tests:
- Expand suggest-cwe, suggest-impact, suggest-statement, and suggest-description evaluation cases with newly collected CVEs, including marking known evaluator failure cases for future improvement.
- Reintroduce and reorganize certain existing description and impact cases to align with updated evaluator expectations.

Chores:
- Add OSIDB cache fixtures for the new CVE cases used in the evaluation suite to stabilize tests.