### PR TITLE
chore: update `CHANGELOG.md` for the upcoming 0.6.3 release

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.3] - 2026-04-27
+
+### Changed
+- improved kernel CVE classifier training pipeline with better feature extraction
+- retrained kernel classifier with 83 additional IMPORTANT CVEs and expanded test set
+- penalize long lists in the output of `suggest-affected-components` evals
+- exclude `affects` from the input of `suggest-affected-components`
+
+### Added
+- added kernel impact classifier runtime module
+- added evaluation cases and annotations based on feedback from security analysts
+- CI can skip evals when the PR description contains `CI: skip-pr-evals`
+
+### Fixed
+- improved LLM prompt templates based on feedback
+- do not suggest fields unrelated to a specific feature
+- do not suggest `title` and `components` in `suggest-cwe`
+- do not mention exploit availability in suggestions
+- added a hint for CWE-617 to CWE tool
+- improved error handling in `component-intelligence` API endpoint
+- improved handling of OSIDB auth and lookup failures
+- improved handling of validation errors in feedback API endpoints
+- made certain fields required in feedback API endpoints
+- avoid logging of GSSAPI tracebacks in non-debug mode
+
+
 ## [0.6.2] - 2026-03-23
 
 ### Added

--- a/uv.lock
+++ b/uv.lock
@@ -2906,11 +2906,11 @@ wheels = [
 
 [[package]]
 name = "pathspec"
-version = "1.1.0"
+version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2e/17/9c3094b822982b9f1ea666d8580ce59000f61f87c1663556fb72031ad9ec/pathspec-1.1.0.tar.gz", hash = "sha256:f5d7c555da02fd8dde3e4a2354b6aba817a89112fa8f333f7917a2a4834dd080", size = 133918, upload-time = "2026-04-23T01:46:22.298Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/c9/8eed0486f074e9f1ca7f8ce5ad663e65f12fdab344028d658fa1b03d35e0/pathspec-1.1.0-py3-none-any.whl", hash = "sha256:574b128f7456bd899045ccd142dd446af7e6cfd0072d63ad73fbc55fbb4aaa42", size = 56264, upload-time = "2026-04-23T01:46:20.606Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
 ]
 
 [[package]]
@@ -3685,11 +3685,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.26"
+version = "0.0.27"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/9b/f23807317a113dc36e74e75eb265a02dd1a4d9082abc3c1064acd22997c4/python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602", size = 44043, upload-time = "2026-04-27T10:51:26.649Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+    { url = "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645", size = 29254, upload-time = "2026-04-27T10:51:24.997Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What
Update `CHANGELOG.md` for the 0.6.3 release.

## Why
So that `aegis-0.6.3` can be released, as described in [DEVELOP.md](https://github.com/RedHatProductSecurity/aegis-ai/blob/aa2bbaf9bf3b808f93db5528257a39ceb367e155/DEVELOP.md#publishing--releasing).

## How to Test
Check for typos, copy/paste errors, and similar mistakes in the change log.

## Related Tickets
Related: https://redhat.atlassian.net/browse/AEGIS-401

## Summary by Sourcery

Documentation:
- Add a 0.6.3 release entry to the changelog describing classifier improvements, new evaluation and runtime modules, CI eval-skip support, and multiple fixes to prompts, APIs, and error handling.