### PR TITLE
Improve `suggest-affected-components` component naming accuracy

### DIFF
--- a/evals/features/cve/test_suggest_affected_components.py
+++ b/evals/features/cve/test_suggest_affected_components.py
@@ -43,6 +43,7 @@ SAMPLE_SEED = int(
 # Excludes CVEs with cpython as expected (model tends to suggest 'python' instead).
 # Excludes CVE-2025-23083 (nodejs): model often returns 'Node.js', causing flaky evals.
 DEFAULT_CVE_IDS: tuple[str, ...] = (
+    "CVE-2006-10002",
     "CVE-2025-3416",
     "CVE-2025-5991",
     "CVE-2025-6052",
@@ -66,6 +67,8 @@ DEFAULT_CVE_IDS: tuple[str, ...] = (
     "CVE-2025-62718",
     "CVE-2025-64329",
     "CVE-2025-65637",
+    "CVE-2025-66442",
+    "CVE-2026-0396",
     "CVE-2026-0900",
     "CVE-2026-0988",
     "CVE-2026-0989",
@@ -73,6 +76,7 @@ DEFAULT_CVE_IDS: tuple[str, ...] = (
     "CVE-2026-0992",
     "CVE-2026-1484",
     "CVE-2026-1485",
+    "CVE-2026-1502",
     "CVE-2026-1757",
     "CVE-2026-2319",
     "CVE-2026-2320",
@@ -82,6 +86,7 @@ DEFAULT_CVE_IDS: tuple[str, ...] = (
     "CVE-2026-4447",
     "CVE-2026-4449",
     "CVE-2026-4452",
+    "CVE-2026-4455",
     "CVE-2026-5290",
     "CVE-2026-5291",
     "CVE-2026-5868",
@@ -93,9 +98,33 @@ DEFAULT_CVE_IDS: tuple[str, ...] = (
     "CVE-2026-6316",
     "CVE-2026-7335",
     "CVE-2026-7347",
+    "CVE-2026-21998",
+    "CVE-2026-22004",
     "CVE-2026-22815",
+    "CVE-2026-23272",
+    "CVE-2026-23275",
+    "CVE-2026-23666",
     "CVE-2026-23950",
     "CVE-2026-24842",
+    "CVE-2026-26962",
+    "CVE-2026-27140",
+    "CVE-2026-27447",
+    "CVE-2026-28684",
+    "CVE-2026-32178",
+    "CVE-2026-32285",
+    "CVE-2026-32289",
+    "CVE-2026-32748",
+    "CVE-2026-32935",
+    "CVE-2026-33056",
+    "CVE-2026-33256",
+    "CVE-2026-33414",
+    "CVE-2026-33416",
+    "CVE-2026-33891",
+    "CVE-2026-34073",
+    "CVE-2026-35339",
+    "CVE-2026-35342",
+    "CVE-2026-35537",
+    "CVE-2026-40200",
 )
 
 
@@ -103,6 +132,11 @@ DEFAULT_CVE_IDS: tuple[str, ...] = (
 # assertion failures if the individual score is low
 KNOWN_TO_FAIL_CVE_IDS: tuple[str, ...] = (
     "CVE-2025-64329",  # Aegis occasionally suggests 'containerd' while 'github.com/containerd/containerd' is expected
+    "CVE-2025-6052",  # got ['glib2'], expected ['glib']
+    "CVE-2026-22815",  # got ['python-aiohttp'], expected ['aiohttp']
+    "CVE-2026-26962",  # got ['rubygem-rack'], expected ['rack']
+    "CVE-2026-34073",  # got ['cryptography'], expected ['python-cryptography']
+    "CVE-2026-40200",  # got ['musl libc'], expected ['musl']
 )
 
 

--- a/evals/features/cve/test_suggest_affected_components.py
+++ b/evals/features/cve/test_suggest_affected_components.py
@@ -134,6 +134,7 @@ DEFAULT_CVE_IDS: tuple[str, ...] = (
 KNOWN_TO_FAIL_CVE_IDS: tuple[str, ...] = (
     "CVE-2025-64329",  # Aegis occasionally suggests 'containerd' while 'github.com/containerd/containerd' is expected
     "CVE-2025-6052",  # got ['glib2'], expected ['glib']
+    "CVE-2026-1484",  # got ['glib2'], expected ['Glib']
     "CVE-2026-22815",  # got ['python-aiohttp'], expected ['aiohttp']
     "CVE-2026-26962",  # got ['rubygem-rack'], expected ['rack']
     "CVE-2026-34073",  # got ['cryptography'], expected ['python-cryptography']

--- a/evals/features/cve/test_suggest_affected_components.py
+++ b/evals/features/cve/test_suggest_affected_components.py
@@ -45,6 +45,7 @@ SAMPLE_SEED = int(
 DEFAULT_CVE_IDS: tuple[str, ...] = (
     "CVE-2006-10002",
     "CVE-2025-3416",
+    "CVE-2025-42611",
     "CVE-2025-5991",
     "CVE-2025-6052",
     "CVE-2025-11233",

--- a/evals/osidb_cache/CVE-2006-10002.json
+++ b/evals/osidb_cache/CVE-2006-10002.json
@@ -1,0 +1,44 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2006-10002",
+    "cwe_id": "CWE-131",
+    "impact": "MODERATE",
+    "title": "XML::Parser for Perl: Heap corruption and denial of service from crafted XML input",
+    "statement": "",
+    "mitigation": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability.",
+    "comment_zero": "XML::Parser versions through 2.47 for Perl could overflow the pre-allocated buffer size cause a heap corruption (double free or corruption) and crashes.\n\nA :utf8 PerlIO layer, parse_stream() in Expat.xs could overflow the XML input buffer because Perl's read() returns decoded characters while SvPV() gives back multi-byte UTF-8 bytes that can exceed the pre-allocated buffer size. This can cause heap corruption (double free or corruption) and crashes.",
+    "comments": "",
+    "description": "A flaw was found in XML::Parser for Perl. This vulnerability allows an attacker to cause a heap corruption, which can lead to a denial of service (DoS) by crashing the application. The issue occurs when the software processes specially crafted XML input, causing an internal buffer to overflow. This overflow can corrupt memory, leading to instability and application termination.",
+    "components": [
+        "perl-xml-parser"
+    ],
+    "references": [
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2006-10002"
+        },
+        {
+            "url": "https://github.com/cpan-authors/XML-Parser/commit/6b291f4d260fc124a6ec80382b87a918f372bc6b.patch"
+        },
+        {
+            "url": "https://rt.cpan.org/Ticket/Display.html?id=19859"
+        },
+        {
+            "url": "https://github.com/cpan-authors/XML-Parser/issues/64"
+        }
+    ],
+    "cvss_scores": [
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H"
+        },
+        {
+            "issuer": "CISA",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+        },
+        {
+            "issuer": "NIST",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2025-42611.json
+++ b/evals/osidb_cache/CVE-2025-42611.json
@@ -1,0 +1,34 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2025-42611",
+    "cwe_id": "CWE-295",
+    "impact": "MODERATE",
+    "title": "RouterOS: Authentication bypass vulnerability in certificate validation",
+    "statement": "",
+    "mitigation": "",
+    "comment_zero": "RouterOS provides various services that rely on correct\nverification of client and server certificates to secure confidentiality and\nintegrity of communications. This includes OpenVPN, CAPsMAN, Dot1x (802.1X),\namong others.\n\n\n\nThe vulnerability lies in shared certificate validation\nlogic which uses the system certificate store that is shared and equally\ntrusted by all system services. This causes confusion of scope, allowing any\ncertificate authority present in the system-wide trust store to be trusted in\nany context (with some exceptions), allowing partial or full authentication\nbypass in CAPsMAN, OpenVPN, Dot1X and potentially others.",
+    "comments": "",
+    "description": "A flaw was found in RouterOS, impacting services like OpenVPN, CAPsMAN, and Dot1x. The system's shared certificate validation logic incorrectly trusts any certificate authority within the system-wide trust store across all services. This scope confusion can lead to a partial or full authentication bypass, potentially compromising the confidentiality and integrity of communications.",
+    "components": [
+        "RouterOS"
+    ],
+    "references": [
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2025-42611"
+        },
+        {
+            "url": "https://www.cert.si/en/cve-2025-42611/"
+        }
+    ],
+    "cvss_scores": [
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2025-66442.json
+++ b/evals/osidb_cache/CVE-2025-66442.json
@@ -1,0 +1,43 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2025-66442",
+    "cwe_id": "CWE-733",
+    "impact": "MODERATE",
+    "title": "Mbed TLS and TF-PSA-Crypto: Information disclosure via compiler-induced timing side channel",
+    "statement": "This Moderate impact flaw in Mbed TLS and TF-PSA-Crypto is a compiler-induced timing side channel. When the LLVM compiler's select-optimize feature is enabled, a remote attacker could potentially exploit timing differences during RSA and CBC/ECB decryption operations to infer sensitive information, such as cryptographic keys. This affects Red Hat community projects such as Fedora and EPEL.",
+    "mitigation": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base, or stability.",
+    "comment_zero": "In Mbed TLS through 4.0.0, there is a compiler-induced timing side channel (in RSA and CBC/ECB decryption) that only occurs with LLVM's select-optimize feature. TF-PSA-Crypto through 1.0.0 is also affected.",
+    "comments": "",
+    "description": "A flaw was found in Mbed TLS and TF-PSA-Crypto. This vulnerability is a compiler-induced timing side channel that occurs when the LLVM compiler's select-optimize feature is enabled. A remote attacker could potentially exploit this timing difference during RSA and CBC/ECB decryption operations to infer sensitive information, such as cryptographic keys.",
+    "components": [
+        "mbedtls"
+    ],
+    "references": [
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2025-66442"
+        },
+        {
+            "url": "https://mbed-tls.readthedocs.io/en/latest/security-advisories/"
+        },
+        {
+            "url": "https://github.com/Mbed-TLS/mbedtls/releases"
+        },
+        {
+            "url": "https://mbed-tls.readthedocs.io/en/latest/security-advisories/mbedtls-security-advisory-2026-03-compiler-induced-constant-time-violations/"
+        },
+        {
+            "url": "https://github.com/Mbed-TLS/TF-PSA-Crypto/releases"
+        }
+    ],
+    "cvss_scores": [
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N"
+        },
+        {
+            "issuer": "CISA",
+            "vector": "CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-0396.json
+++ b/evals/osidb_cache/CVE-2026-0396.json
@@ -1,0 +1,38 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-0396",
+    "cwe_id": "CWE-79",
+    "impact": "MODERATE",
+    "title": "dnsdist: HTML injection via crafted DNS queries",
+    "statement": "",
+    "mitigation": "",
+    "comment_zero": "An attacker might be able to inject HTML content into the internal web dashboard by sending crafted DNS queries to a DNSdist instance where domain-based dynamic rules have been enabled via either DynBlockRulesGroup:setSuffixMatchRule or DynBlockRulesGroup:setSuffixMatchRuleFFI.",
+    "comments": "",
+    "description": "A flaw was found in dnsdist. A remote attacker could exploit this vulnerability by sending specially crafted DNS queries to a dnsdist instance where domain-based dynamic rules have been enabled. This could allow the attacker to inject malicious HTML content into the internal web dashboard, potentially leading to information disclosure or defacement.",
+    "components": [
+        "dnsdist"
+    ],
+    "references": [
+        {
+            "url": "https://www.dnsdist.org/security-advisories/powerdns-advisory-for-dnsdist-2026-02.html"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-0396"
+        }
+    ],
+    "cvss_scores": [
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:N"
+        },
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:N"
+        },
+        {
+            "issuer": "NIST",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-1502.json
+++ b/evals/osidb_cache/CVE-2026-1502.json
@@ -1,0 +1,43 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-1502",
+    "cwe_id": "CWE-93",
+    "impact": "MODERATE",
+    "title": "Python: HTTP header injection via CR/LF in proxy tunnel headers",
+    "statement": "",
+    "mitigation": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability.",
+    "comment_zero": "CR/LF bytes were not rejected by HTTP client proxy tunnel headers or host.",
+    "comments": "",
+    "description": "A flaw was found in Python. This vulnerability allows for the injection of extra information into HTTP communication. Specifically, the system does not properly prevent special characters (carriage return and line feed) from being included in HTTP client proxy tunnel headers or host fields.",
+    "components": [
+        "python"
+    ],
+    "references": [
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-1502"
+        },
+        {
+            "url": "https://github.com/python/cpython/pull/146212"
+        },
+        {
+            "url": "https://github.com/python/cpython/issues/146211"
+        },
+        {
+            "url": "https://mail.python.org/archives/list/security-announce@python.org/thread/2IVPAEQWUJBCTQZEJEVTYCIKSMQPGRZ3/"
+        },
+        {
+            "url": "https://github.com/python/cpython/commit/05ed7ce7ae9e17c23a04085b2539fe6d6d3cef69"
+        }
+    ],
+    "cvss_scores": [
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:H/UI:R/S:U/C:N/I:H/A:N"
+        },
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:H/UI:P/VC:N/VI:H/VA:N/SC:N/SI:N/SA:N"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-21998.json
+++ b/evals/osidb_cache/CVE-2026-21998.json
@@ -1,0 +1,37 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-21998",
+    "cwe_id": "CWE-770",
+    "impact": "MODERATE",
+    "title": "Optimizer unspecified vulnerability (CPU Apr 2026)",
+    "statement": "Red Hat Product Security rates the severity of this flaw as determined by the Oracle MySQL Critical Patch Update.",
+    "mitigation": "",
+    "comment_zero": "Vulnerability in the MySQL Server product of Oracle MySQL (component: Server: Optimizer).  Supported versions that are affected are 8.0.0-8.0.45, 8.4.0-8.4.8 and  9.0.0-9.6.0. Easily exploitable vulnerability allows high privileged attacker with network access via multiple protocols to compromise MySQL Server.  Successful attacks of this vulnerability can result in unauthorized ability to cause a hang or frequently repeatable crash (complete DOS) of MySQL Server. CVSS 3.1 Base Score 4.9 (Availability impacts).  CVSS Vector: (CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:N/I:N/A:H).",
+    "comments": "",
+    "description": "Oracle CPU describes the issue as following: Vulnerability in the MySQL Server product of Oracle MySQL (component: Server: Optimizer). Supported versions that are affected are 8.0.0-8.0.45, 8.4.0-8.4.8 and 9.0.0-9.6.0. Easily exploitable vulnerability allows high privileged attacker with network access via multiple protocols to compromise MySQL Server. Successful attacks of this vulnerability can result in unauthorized ability to cause a hang or frequently repeatable crash (complete DOS) of MySQL Server.",
+    "components": [
+        "mysql"
+    ],
+    "references": [
+        {
+            "url": "https://www.oracle.com/security-alerts/cpuapr2026.html#AppendixMSQL"
+        },
+        {
+            "url": "https://www.oracle.com/security-alerts/cpuapr2026.html"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-21998"
+        }
+    ],
+    "cvss_scores": [
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:N/I:N/A:H"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:N/I:N/A:H"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-22004.json
+++ b/evals/osidb_cache/CVE-2026-22004.json
@@ -1,0 +1,37 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-22004",
+    "cwe_id": "CWE-770",
+    "impact": "MODERATE",
+    "title": "InnoDB unspecified vulnerability (CPU Apr 2026)",
+    "statement": "Red Hat Product Security rates the severity of this flaw as determined by the Oracle MySQL Critical Patch Update.",
+    "mitigation": "",
+    "comment_zero": "Vulnerability in the MySQL Server product of Oracle MySQL (component: InnoDB).  Supported versions that are affected are 8.0.0-8.0.45, 8.4.0-8.4.8 and  9.0.0-9.6.0. Easily exploitable vulnerability allows high privileged attacker with network access via multiple protocols to compromise MySQL Server.  Successful attacks of this vulnerability can result in unauthorized ability to cause a hang or frequently repeatable crash (complete DOS) of MySQL Server. CVSS 3.1 Base Score 4.9 (Availability impacts).  CVSS Vector: (CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:N/I:N/A:H).",
+    "comments": "",
+    "description": "Oracle CPU describes the issue as following: Vulnerability in the MySQL Server product of Oracle MySQL (component: InnoDB). Supported versions that are affected are 8.0.0-8.0.45, 8.4.0-8.4.8 and 9.0.0-9.6.0. Easily exploitable vulnerability allows high privileged attacker with network access via multiple protocols to compromise MySQL Server. Successful attacks of this vulnerability can result in unauthorized ability to cause a hang or frequently repeatable crash (complete DOS) of MySQL Server.",
+    "components": [
+        "mysql"
+    ],
+    "references": [
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-22004"
+        },
+        {
+            "url": "https://www.oracle.com/security-alerts/cpuapr2026.html"
+        },
+        {
+            "url": "https://www.oracle.com/security-alerts/cpuapr2026.html#AppendixMSQL"
+        }
+    ],
+    "cvss_scores": [
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:N/I:N/A:H"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:N/I:N/A:H"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-23272.json
+++ b/evals/osidb_cache/CVE-2026-23272.json
@@ -1,0 +1,31 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-23272",
+    "cwe_id": "CWE-367",
+    "impact": "MODERATE",
+    "title": "netfilter: nf_tables: unconditionally bump set->nelems before insertion",
+    "statement": "This vulnerability affects systems using nf_tables for packet filtering with sets that have size limits. When a set reaches capacity, the race between element insertion/removal and RCU readers creates a window for use-after-free. Exploitation requires the ability to configure nf_tables rules, which typically requires CAP_NET_ADMIN privileges or root access.",
+    "mitigation": "",
+    "comment_zero": "In the Linux kernel, the following vulnerability has been resolved:\n\nnetfilter: nf_tables: unconditionally bump set->nelems before insertion\n\nIn case that the set is full, a new element gets published then removed\nwithout waiting for the RCU grace period, while RCU reader can be\nwalking over it already.\n\nTo address this issue, add the element transaction even if set is full,\nbut toggle the set_full flag to report -ENFILE so the abort path safely\nunwinds the set to its previous state.\n\nAs for element updates, decrement set->nelems to restore it.\n\nA simpler fix is to call synchronize_rcu() in the error path.\nHowever, with a large batch adding elements to already maxed-out set,\nthis could cause noticeable slowdown of such batches.",
+    "comments": "Upstream advisory:\nhttps://lore.kernel.org/linux-cve-announce/2026032034-CVE-2026-23272-8ad1@gregkh/T ",
+    "description": "A flaw was found in the Linux kernel's netfilter nf_tables component. A race condition occurs when elements are inserted into a full set, causing an element to be removed without proper synchronization with Read-Copy-Update (RCU) readers. This can allow a local attacker to trigger a use-after-free vulnerability, potentially leading to a denial of service or other unspecified impacts.",
+    "components": [
+        "kernel"
+    ],
+    "references": [
+        {
+            "url": "https://lore.kernel.org/linux-cve-announce/2026032034-CVE-2026-23272-8ad1@gregkh/T"
+        }
+    ],
+    "cvss_scores": [
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-23275.json
+++ b/evals/osidb_cache/CVE-2026-23275.json
@@ -1,0 +1,31 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-23275",
+    "cwe_id": "CWE-366",
+    "impact": "LOW",
+    "title": "io_uring: ensure ctx->rings is stable for task work flags manipulation",
+    "statement": "This flaw affects io_uring applications using DEFER_TASKRUN mode with ring resizing. The race window exists between swapping to a new rings structure and freeing the old one, where task work can manipulate flags in freed memory. Exploiting this requires an application using the specific io_uring configuration and triggering ring resize operations concurrently with task work additions.",
+    "mitigation": "",
+    "comment_zero": "In the Linux kernel, the following vulnerability has been resolved:\n\nio_uring: ensure ctx->rings is stable for task work flags manipulation\n\nIf DEFER_TASKRUN | SETUP_TASKRUN is used and task work is added while\nthe ring is being resized, it's possible for the OR'ing of\nIORING_SQ_TASKRUN to happen in the small window of swapping into the\nnew rings and the old rings being freed.\n\nPrevent this by adding a 2nd ->rings pointer, ->rings_rcu, which is\nprotected by RCU. The task work flags manipulation is inside RCU\nalready, and if the resize ring freeing is done post an RCU synchronize,\nthen there's no need to add locking to the fast path of task work\nadditions.\n\nNote: this is only done for DEFER_TASKRUN, as that's the only setup mode\nthat supports ring resizing. If this ever changes, then they too need to\nuse the io_ctx_mark_taskrun() helper.",
+    "comments": "Upstream advisory:\nhttps://lore.kernel.org/linux-cve-announce/2026032035-CVE-2026-23275-33fe@gregkh/T ",
+    "description": "A flaw was found in the Linux kernel's io_uring subsystem. This vulnerability occurs during the resizing of an io_uring ring when task work is added with specific flags (DEFER_TASKRUN or SETUP_TASKRUN). A race condition allows the IORING_SQ_TASKRUN flag to be set in an unstable memory region, which can lead to unpredictable system behavior or system instability.",
+    "components": [
+        "kernel"
+    ],
+    "references": [
+        {
+            "url": "https://lore.kernel.org/linux-cve-announce/2026032035-CVE-2026-23275-33fe@gregkh/T"
+        }
+    ],
+    "cvss_scores": [
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:N/A:H"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-23666.json
+++ b/evals/osidb_cache/CVE-2026-23666.json
@@ -1,0 +1,34 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-23666",
+    "cwe_id": "CWE-366",
+    "impact": "IMPORTANT",
+    "title": ".NET Framework: Denial of Service via Race Condition",
+    "statement": "Important: A race condition in .NET Framework can lead to a Denial of Service. This flaw allows an unauthenticated attacker to exploit improper synchronization when using shared resources, causing affected systems to become unavailable. This impacts Red Hat Enterprise Linux 8, 9, and 10, as well as Fedora, where .NET is deployed.",
+    "mitigation": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base, or stability.",
+    "comment_zero": "Concurrent execution using shared resource with improper synchronization ('race condition') in .NET Framework allows an unauthorized attacker to deny service over a network.",
+    "comments": "",
+    "description": "A flaw was found in .NET Framework. An unauthorized attacker can exploit a race condition, which is a concurrent execution using shared resources with improper synchronization, to deny service over a network. This vulnerability can lead to a Denial of Service (DoS) for affected systems.",
+    "components": [
+        "dotnet"
+    ],
+    "references": [
+        {
+            "url": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2026-23666"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-23666"
+        }
+    ],
+    "cvss_scores": [
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        },
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:P/RL:O/RC:C"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-26962.json
+++ b/evals/osidb_cache/CVE-2026-26962.json
@@ -1,0 +1,38 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-26962",
+    "cwe_id": "CWE-93",
+    "impact": "MODERATE",
+    "title": "Rack: Header injection and response splitting via incorrect multipart header parsing",
+    "statement": "",
+    "mitigation": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability.",
+    "comment_zero": "Rack is a modular Ruby web server interface. From version 3.2.0 to before version 3.2.6, Rack::Multipart::Parser unfolds folded multipart part headers incorrectly. When a multipart header contains an obs-fold sequence, Rack preserves the embedded CRLF in parsed parameter values such as filename or name instead of removing the folded line break during unfolding. As a result, applications that later reuse those parsed values in HTTP response headers may be vulnerable to downstream header injection or response splitting. This issue has been patched in version 3.2.6.",
+    "comments": "",
+    "description": "A flaw was found in Rack, a modular Ruby web server interface. Rack::Multipart::Parser incorrectly processes folded multipart part headers, failing to remove embedded carriage return and line feed (CRLF) characters. This can lead to applications that reuse these parsed values in HTTP response headers becoming vulnerable to header injection or response splitting, potentially allowing an attacker to manipulate HTTP responses.",
+    "components": [
+        "rack"
+    ],
+    "references": [
+        {
+            "url": "https://github.com/rack/rack/security/advisories/GHSA-rx22-g9mx-qrhv"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-26962"
+        }
+    ],
+    "cvss_scores": [
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N"
+        },
+        {
+            "issuer": "NIST",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-27140.json
+++ b/evals/osidb_cache/CVE-2026-27140.json
@@ -1,0 +1,48 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-27140",
+    "cwe_id": "CWE-641",
+    "impact": "IMPORTANT",
+    "title": "Go (golang) and cmd/go: Arbitrary Code Execution via malicious SWIG file names",
+    "statement": "",
+    "mitigation": "",
+    "comment_zero": "SWIG file names containing 'cgo' and well-crafted payloads could lead to code smuggling and arbitrary code execution at build time due to trust layer bypass.",
+    "comments": "",
+    "description": "A flaw was found in the Go programming language (golang) and its command-line tool (cmd/go). A remote attacker could exploit this during the build process by crafting malicious SWIG (Simplified Wrapper and Interface Generator) file names that contain \"cgo\" and specific payloads. This could lead to code smuggling and arbitrary code execution, bypassing trust mechanisms and allowing the attacker to run unauthorized code.",
+    "components": [
+        "cmd/go",
+        "golang"
+    ],
+    "references": [
+        {
+            "url": "https://groups.google.com/g/golang-announce/c/0uYbvbPZRWU"
+        },
+        {
+            "url": "https://pkg.go.dev/vuln/GO-2026-4871"
+        },
+        {
+            "url": "https://go.dev/cl/763768"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-27140"
+        },
+        {
+            "url": "https://go.dev/issue/78335"
+        }
+    ],
+    "cvss_scores": [
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:H/A:H"
+        },
+        {
+            "issuer": "CISA",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+        },
+        {
+            "issuer": "NIST",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-27447.json
+++ b/evals/osidb_cache/CVE-2026-27447.json
@@ -1,0 +1,41 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-27447",
+    "cwe_id": "CWE-178",
+    "impact": "MODERATE",
+    "title": "OpenPrinting CUPS: Authorization bypass via case-insensitive username comparison",
+    "statement": "",
+    "mitigation": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability.",
+    "comment_zero": "OpenPrinting CUPS is an open source printing system for Linux and other Unix-like operating systems. In versions 2.4.16 and prior, CUPS daemon (cupsd) contains an authorization bypass vulnerability due to case-insensitive username comparison during authorization checks. The vulnerability allows an unprivileged user to gain unauthorized access to restricted operations by using a user with a username that differs only in case from an authorized user. At time of publication, there are no publicly available patches.",
+    "comments": "",
+    "description": "A flaw was found in OpenPrinting CUPS. This authorization bypass vulnerability allows an unprivileged user to gain unauthorized access to restricted operations. This can be exploited by using a username that differs only in case from an authorized user during authorization checks.",
+    "components": [
+        "cups"
+    ],
+    "references": [
+        {
+            "url": "https://github.com/OpenPrinting/cups/security/advisories/GHSA-v987-m8hp-phj9"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-27447"
+        },
+        {
+            "url": "https://github.com/OpenPrinting/cups/commit/88516bf6d9e34cef7a64a704b856b837f70cd220"
+        }
+    ],
+    "cvss_scores": [
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:H/UI:R/S:U/C:H/I:L/A:N"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:L/I:L/A:N"
+        },
+        {
+            "issuer": "NIST",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:L/A:N"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-28684.json
+++ b/evals/osidb_cache/CVE-2026-28684.json
@@ -1,0 +1,40 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-28684",
+    "cwe_id": "CWE-59",
+    "impact": "MODERATE",
+    "title": "python-dotenv: Arbitrary file overwrite via symbolic link following",
+    "statement": "",
+    "mitigation": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base, or stability.",
+    "comment_zero": "python-dotenv reads key-value pairs from a .env file and can set them as environment variables. Prior to version 1.2.2, `set_key()` and `unset_key()` in python-dotenv follow symbolic links when rewriting `.env` files, allowing a local attacker to overwrite arbitrary files via a crafted symlink when a cross-device rename fallback is triggered. Users should upgrade to v.1.2.2 or, as a workaround, apply the patch manually.",
+    "comments": "",
+    "description": "A flaw was found in python-dotenv. A local attacker can exploit this by crafting a symbolic link, which the `set_key()` and `unset_key()` functions in python-dotenv follow when rewriting `.env` files. This can lead to the overwriting of arbitrary files on the system.",
+    "components": [
+        "python-dotenv"
+    ],
+    "references": [
+        {
+            "url": "https://github.com/theskumar/python-dotenv/commit/790c5c02991100aa1bf41ee5330aca75edc51311"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-28684"
+        },
+        {
+            "url": "https://github.com/theskumar/python-dotenv/releases/tag/v1.2.2"
+        },
+        {
+            "url": "https://github.com/theskumar/python-dotenv/security/advisories/GHSA-mf9w-mj56-hr94"
+        }
+    ],
+    "cvss_scores": [
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:R/S:U/C:N/I:H/A:H"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:H"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-32178.json
+++ b/evals/osidb_cache/CVE-2026-32178.json
@@ -1,0 +1,27 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-32178",
+    "cwe_id": "CWE-138",
+    "impact": "IMPORTANT",
+    "title": "Dotnet: SMTP Command Injection and Header Injection via MailAddress parsing flaw",
+    "statement": "This Important flaw in the .NET runtime's System.Net.Mail component affects Red Hat Enterprise Linux and Red Hat Hardened Images. Improper neutralization of carriage return and line feed sequences during email address parsing can lead to SMTP command or header injection, enabling email spoofing in applications utilizing the affected .NET versions for SMTP operations.\n\nThe impact is primarily related to how email data is handled and interpreted. By injecting crafted header content, an attacker may influence the structure of email messages and potentially expose sensitive information included in those messages to unintended recipients.",
+    "mitigation": "Red Hat is not aware of a practical temporary workaround that fully mitigates this issue or meets Red Hat Product Security's standards for usability, deployment, applicability, or stability. Customers are advised to apply the relevant security updates when they become available.",
+    "comment_zero": "Dotnet: SMTP Command Injection and Header Injection via MailAddress Parsing Flaw in System.Net.Mail\n\nAffected .NET versions: 6.0, 8.0, 9.0, 10.0",
+    "comments": "",
+    "description": "A flaw was found in the .NET runtime (System.Net.Mail) in how email address data is parsed. Improper neutralization of special characters, specifically carriage return and line feed (CR/LF) sequences, may allow specially crafted email address input to be interpreted incorrectly. An attacker could exploit this issue to perform email spoofing by injecting additional headers or altering how the email address is processed during SMTP operations",
+    "components": [
+        "dotnet"
+    ],
+    "references": [],
+    "cvss_scores": [
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+        },
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N/E:U/RL:O/RC:C"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-32285.json
+++ b/evals/osidb_cache/CVE-2026-32285.json
@@ -1,0 +1,40 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-32285",
+    "cwe_id": "CWE-1285",
+    "impact": "IMPORTANT",
+    "title": "github.com/buger/jsonparser: Denial of Service via malformed JSON input",
+    "statement": "",
+    "mitigation": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability.",
+    "comment_zero": "The Delete function fails to properly validate offsets when processing malformed JSON input. This can lead to a negative slice index and a runtime panic, allowing a denial of service attack.",
+    "comments": "",
+    "description": "A flaw was found in github.com/buger/jsonparser. The Delete function, when processing malformed JSON input, fails to properly validate offsets. This vulnerability can lead to a negative slice index and a runtime panic, allowing a remote attacker to cause a denial of service (DoS) by providing specially crafted JSON data.",
+    "components": [
+        "github.com/buger/jsonparser"
+    ],
+    "references": [
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-32285"
+        },
+        {
+            "url": "https://pkg.go.dev/vuln/GO-2026-4514"
+        },
+        {
+            "url": "https://github.com/buger/jsonparser/issues/275"
+        },
+        {
+            "url": "https://github.com/golang/vulndb/issues/4514"
+        }
+    ],
+    "cvss_scores": [
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        },
+        {
+            "issuer": "CISA",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-32289.json
+++ b/evals/osidb_cache/CVE-2026-32289.json
@@ -1,0 +1,48 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-32289",
+    "cwe_id": "CWE-79",
+    "impact": "MODERATE",
+    "title": "html/template: Cross-Site Scripting (XSS) via improper context and brace depth tracking in JS template literals",
+    "statement": "",
+    "mitigation": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability.",
+    "comment_zero": "Context was not properly tracked across template branches for JS template literals, leading to possibly incorrect escaping of content when branches were used. Additionally template actions within JS template literals did not properly track the brace depth, leading to incorrect escaping being applied. These issues could cause actions within JS template literals to be incorrectly or improperly escaped, leading to XSS vulnerabilities.",
+    "comments": "",
+    "description": "A flaw was found in the `html/template` package. This vulnerability arises from improper tracking of context and brace depth within JavaScript (JS) template literals. A remote attacker could exploit these issues to cause content to be incorrectly or improperly escaped, leading to Cross-Site Scripting (XSS) vulnerabilities. This could allow an attacker to inject malicious scripts into web pages viewed by other users.",
+    "components": [
+        "html/template",
+        "golang"
+    ],
+    "references": [
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-32289"
+        },
+        {
+            "url": "https://groups.google.com/g/golang-announce/c/0uYbvbPZRWU"
+        },
+        {
+            "url": "https://go.dev/cl/763762"
+        },
+        {
+            "url": "https://go.dev/issue/78331"
+        },
+        {
+            "url": "https://pkg.go.dev/vuln/GO-2026-4865"
+        }
+    ],
+    "cvss_scores": [
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N"
+        },
+        {
+            "issuer": "CISA",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
+        },
+        {
+            "issuer": "NIST",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-32748.json
+++ b/evals/osidb_cache/CVE-2026-32748.json
@@ -1,0 +1,44 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-32748",
+    "cwe_id": "CWE-826",
+    "impact": "IMPORTANT",
+    "title": "Squid: Denial of Service via crafted ICP traffic",
+    "statement": "This Important flaw in Squid can lead to a Denial of Service when processing specially crafted Internet Cache Protocol (ICP) traffic. This vulnerability affects Red Hat products running Squid if ICP support is explicitly enabled by configuring a non-zero `icp_port`. Deployments where ICP is not enabled by default are not affected.",
+    "mitigation": "To mitigate this issue, ensure that ICP support is not explicitly enabled in the Squid configuration. This can be achieved by commenting out or setting `icp_port` to `0` in the `squid.conf` file. After modifying the configuration, the Squid service must be reloaded or restarted for the changes to take effect.\n\nExample:\n```\n# icp_port 3130\n```\nor\n```\nicp_port 0\n```\nWarning: Reloading or restarting the Squid service may temporarily interrupt proxy services.",
+    "comment_zero": "Squid is a caching proxy for the Web. Prior to version 7.5, due to premature release of resource during expected lifetime and heap Use-After-Free bugs, Squid is vulnerable to Denial of Service when handling ICP traffic. This problem allows a remote attacker to perform a reliable and repeatable Denial of Service attack against the Squid service using ICP protocol. This attack is limited to Squid deployments that explicitly enable ICP support (i.e. configure non-zero `icp_port`). This problem _cannot_ be mitigated by denying ICP queries using `icp_access` rules. This bug is fixed in Squid version 7.5.",
+    "comments": "",
+    "description": "A flaw was found in Squid. A remote attacker can exploit this vulnerability by sending specially crafted ICP (Internet Cache Protocol) traffic. This can lead to a Denial of Service (DoS) due to premature resource release and use-after-free vulnerabilities. This attack is possible in Squid deployments with explicitly enabled ICP support.",
+    "components": [
+        "Squid"
+    ],
+    "references": [
+        {
+            "url": "https://github.com/squid-cache/squid/commit/703e07d25ca6fa11f52d20bf0bb879e22ab7481b"
+        },
+        {
+            "url": "http://www.openwall.com/lists/oss-security/2026/03/25/3"
+        },
+        {
+            "url": "https://github.com/squid-cache/squid/security/advisories/GHSA-f9p7-3jqg-hhvq"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-32748"
+        }
+    ],
+    "cvss_scores": [
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        },
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:L"
+        },
+        {
+            "issuer": "NIST",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-32935.json
+++ b/evals/osidb_cache/CVE-2026-32935.json
@@ -1,0 +1,41 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-32935",
+    "cwe_id": "CWE-208",
+    "impact": "MODERATE",
+    "title": "phpseclib: Information disclosure via padding oracle timing attack when using AES in CBC mode",
+    "statement": "",
+    "mitigation": "",
+    "comment_zero": "phpseclib is a PHP secure communications library. Projects using versions 1.0.26 and below, 2.0.0 through 2.0.51, and 3.0.0 through 3.0.49 are vulnerable to a to padding oracle timing attack when using AES in CBC mode. This issue has been fixed in versions 1.0.27, 2.0.52 and 3.0.50.",
+    "comments": "",
+    "description": "A flaw was found in phpseclib, a PHP secure communications library. When using Advanced Encryption Standard (AES) in Cipher Block Chaining (CBC) mode, a remote attacker can exploit a padding oracle timing attack. This vulnerability may allow the attacker to decrypt sensitive information by observing the time differences in processing malformed ciphertexts.",
+    "components": [
+        "phpseclib"
+    ],
+    "references": [
+        {
+            "url": "https://github.com/phpseclib/phpseclib/security/advisories/GHSA-94g3-g5v7-q4jg"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-32935"
+        },
+        {
+            "url": "https://github.com/phpseclib/phpseclib/commit/ccc21aef71eb170e9bf819b167e67d1fd9e6e788"
+        }
+    ],
+    "cvss_scores": [
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N"
+        },
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:4.0/AV:N/AC:H/AT:N/PR:N/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N"
+        },
+        {
+            "issuer": "NIST",
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-33056.json
+++ b/evals/osidb_cache/CVE-2026-33056.json
@@ -1,0 +1,41 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-33056",
+    "cwe_id": "CWE-59",
+    "impact": "MODERATE",
+    "title": "tar-rs: Arbitrary directory permission modification via crafted tar archive",
+    "statement": "",
+    "mitigation": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability.",
+    "comment_zero": "tar-rs is a tar archive reading/writing library for Rust. In versions 0.4.44 and below, when unpacking a tar archive, the tar crate's unpack_dir function uses fs::metadata() to check whether a path that already exists is a directory. Because fs::metadata() follows symbolic links, a crafted tarball containing a symlink entry followed by a directory entry with the same name causes the crate to treat the symlink target as a valid existing directory \u2014 and subsequently apply chmod to it. This allows an attacker to modify the permissions of arbitrary directories outside the extraction root. This issue has been fixed in version 0.4.45.",
+    "comments": "",
+    "description": "A flaw was found in tar-rs, a Rust library for reading and writing tar archives. When unpacking a crafted tar archive, an attacker can exploit a symbolic link vulnerability. By including a symlink followed by a directory with the same name, the library incorrectly applies file permissions to the symlink's target. This allows an attacker to modify the permissions of arbitrary directories outside the intended extraction location.",
+    "components": [
+        "tar-rs"
+    ],
+    "references": [
+        {
+            "url": "https://github.com/alexcrichton/tar-rs/commit/17b1fd84e632071cb8eef9d3709bf347bd266446"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-33056"
+        },
+        {
+            "url": "https://github.com/alexcrichton/tar-rs/security/advisories/GHSA-j4xf-2g29-59ph"
+        }
+    ],
+    "cvss_scores": [
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N"
+        },
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:A/VC:N/VI:L/VA:N/SC:N/SI:N/SA:N"
+        },
+        {
+            "issuer": "NIST",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:H/A:N"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-33256.json
+++ b/evals/osidb_cache/CVE-2026-33256.json
@@ -1,0 +1,34 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-33256",
+    "cwe_id": "CWE-770",
+    "impact": "MODERATE",
+    "title": "unbounded memory allocation by internal web server",
+    "statement": "",
+    "mitigation": "",
+    "comment_zero": "An attacker can send a web request that causes unlimited memory allocation in the internal web server, leading to a denial of service. The internal web server is disabled by default.",
+    "comments": "",
+    "description": "",
+    "components": [
+        "pdns-recursor"
+    ],
+    "references": [
+        {
+            "url": "https://docs.powerdns.com/recursor/security-advisories/powerdns-advisory-2026-03.html"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-33256"
+        }
+    ],
+    "cvss_scores": [
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+        },
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-33414.json
+++ b/evals/osidb_cache/CVE-2026-33414.json
@@ -1,0 +1,42 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-33414",
+    "cwe_id": "CWE-94",
+    "impact": "IMPORTANT",
+    "title": "Podman: Arbitrary code execution via command injection in HyperV backend",
+    "statement": "This flaw in Podman's HyperV backend does not affect Red Hat products. The vulnerable code path is exclusive to Windows installations, and the HyperV backend is not utilized on Red Hat Enterprise Linux or OpenShift Container Platform.",
+    "mitigation": "",
+    "comment_zero": "Podman is a tool for managing OCI containers and pods. Versions 4.8.0 through 5.8.1 contain a command injection vulnerability in the HyperV machine backend in pkg/machine/hyperv/stubber.go, where the VM image path is inserted into a PowerShell double-quoted string without sanitization, allowing $() subexpression injection. Because PowerShell evaluates subexpressions inside double-quoted strings before executing the outer command, an attacker who can control the VM image path through a crafted machine name or image directory can execute arbitrary PowerShell commands with the privileges of the Podman process. On typical Windows installations this means SYSTEM-level code execution, and only Windows is affected as the code is exclusive to the HyperV backend. This issue has been patched in version 5.8.2.",
+    "comments": "",
+    "description": "A flaw was found in Podman, a tool for managing containers. This vulnerability, located in the HyperV machine backend, allows for command injection. An attacker who can manipulate the virtual machine (VM) image path can inject and execute arbitrary PowerShell commands. This could lead to unauthorized system-level code execution on Windows installations where Podman is running.",
+    "components": [
+        "podman",
+        "github.com/containers/podman"
+    ],
+    "references": [
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-33414"
+        },
+        {
+            "url": "https://github.com/containers/podman/commit/571c842bd357ee626019ea97d030fb772fc654ed"
+        },
+        {
+            "url": "https://github.com/containers/podman/security/advisories/GHSA-hc8w-h2mf-hp59"
+        }
+    ],
+    "cvss_scores": [
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H"
+        },
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:4.0/AV:L/AC:H/AT:N/PR:H/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N/E:U"
+        },
+        {
+            "issuer": "NIST",
+            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:C/C:H/I:H/A:H"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-33416.json
+++ b/evals/osidb_cache/CVE-2026-33416.json
@@ -1,0 +1,49 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-33416",
+    "cwe_id": "CWE-825",
+    "impact": "MODERATE",
+    "title": "libpng: Arbitrary code execution due to use-after-free vulnerability",
+    "statement": "",
+    "mitigation": "To reduce exposure, avoid processing untrusted PNG image files with applications that utilize libpng. Restricting the source of PNG images to trusted origins can limit the attack surface.",
+    "comment_zero": "LIBPNG is a reference library for use in applications that read, create, and manipulate PNG (Portable Network Graphics) raster image files. In versions 1.2.1 through 1.6.55, `png_set_tRNS` and `png_set_PLTE` each alias a heap-allocated buffer between `png_struct` and `png_info`, sharing a single allocation across two structs with independent lifetimes. The `trans_alpha` aliasing has been present since at least libpng 1.0, and the `palette` aliasing since at least 1.2.1. Both affect all prior release lines `png_set_tRNS` sets `png_ptr->trans_alpha = info_ptr->trans_alpha` (256-byte buffer) and `png_set_PLTE` sets `info_ptr->palette = png_ptr->palette` (768-byte buffer). In both cases, calling `png_free_data` (with `PNG_FREE_TRNS` or `PNG_FREE_PLTE`) frees the buffer through `info_ptr` while the corresponding `png_ptr` pointer remains dangling. Subsequent row-transform functions dereference and, in some code paths, write to the freed memory. A second call to `png_set_tRNS` or `png_set_PLTE` has the same effect, because both functions call `png_free_data` internally before reallocating the `info_ptr` buffer. Version 1.6.56 fixes the issue.",
+    "comments": "",
+    "description": "A flaw was found in libpng, a library used for processing PNG (Portable Network Graphics) image files. This vulnerability arises from improper memory management where a heap-allocated buffer is aliased between internal data structures. When specific functions are called, a freed memory region can still be referenced, leading to a use-after-free condition. An attacker could potentially exploit this to achieve arbitrary code execution or cause a denial of service.",
+    "components": [
+        "libpng"
+    ],
+    "references": [
+        {
+            "url": "https://github.com/pnggroup/libpng/commit/c1b0318b393c90679e6fa5bc1d329fd5d5012ec1"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-33416"
+        },
+        {
+            "url": "https://github.com/pnggroup/libpng/commit/23019269764e35ed8458e517f1897bd3c54820eb"
+        },
+        {
+            "url": "https://github.com/pnggroup/libpng/security/advisories/GHSA-m4pc-p4q3-4c7j"
+        },
+        {
+            "url": "https://github.com/pnggroup/libpng/commit/a3a21443ed12bfa1ef46fa0d4fb2b74a0fa34a25"
+        },
+        {
+            "url": "https://github.com/pnggroup/libpng/commit/7ea9eea884a2328cc7fdcb3c0c00246a50d90667"
+        },
+        {
+            "url": "https://github.com/pnggroup/libpng/pull/824"
+        }
+    ],
+    "cvss_scores": [
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-33891.json
+++ b/evals/osidb_cache/CVE-2026-33891.json
@@ -1,0 +1,37 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-33891",
+    "cwe_id": "CWE-606",
+    "impact": "IMPORTANT",
+    "title": "node-forge: Denial of Service via infinite loop in BigInteger.modInverse()",
+    "statement": "",
+    "mitigation": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability.",
+    "comment_zero": "Forge (also called `node-forge`) is a native implementation of Transport Layer Security in JavaScript. Prior to version 1.4.0, a Denial of Service (DoS) vulnerability exists in the node-forge library due to an infinite loop in the BigInteger.modInverse() function (inherited from the bundled jsbn library). When modInverse() is called with a zero value as input, the internal Extended Euclidean Algorithm enters an unreachable exit condition, causing the process to hang indefinitely and consume 100% CPU. Version 1.4.0 patches the issue.",
+    "comments": "",
+    "description": "A flaw was found in the node-forge library, a JavaScript implementation of Transport Layer Security. This vulnerability, inherited from the bundled jsbn library, allows a remote attacker to cause a Denial of Service (DoS). When the BigInteger.modInverse() function is called with a zero value, it enters an infinite loop, causing the process to hang indefinitely and consume 100% of the CPU resources.",
+    "components": [
+        "node-forge"
+    ],
+    "references": [
+        {
+            "url": "https://github.com/digitalbazaar/forge/commit/9bb8d67b99d17e4ebb5fd7596cd699e11f25d023"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-33891"
+        },
+        {
+            "url": "https://github.com/digitalbazaar/forge/security/advisories/GHSA-5m6q-g25r-mvwx"
+        }
+    ],
+    "cvss_scores": [
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-35339.json
+++ b/evals/osidb_cache/CVE-2026-35339.json
@@ -1,0 +1,37 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-35339",
+    "cwe_id": "CWE-393",
+    "impact": "MODERATE",
+    "title": "uutils coreutils chmod: Incorrect exit code handling in recursive mode can lead to incorrect file permissions.",
+    "statement": "",
+    "mitigation": "",
+    "comment_zero": "The recursive mode (-R) of the chmod utility in uutils coreutils incorrectly handles exit codes when processing multiple files. The final return value is determined solely by the success or failure of the last file processed. This allows the command to return an exit code of 0 (success) even if errors were encountered on previous files, such as 'Operation not permitted'. Scripts relying on these exit codes may proceed under a false sense of success while sensitive files remain with restrictive or incorrect permissions.",
+    "comments": "",
+    "description": "A flaw was found in uutils coreutils. Specifically, the `chmod` utility, when used in recursive mode (`-R`), incorrectly handles exit codes. This can lead to a situation where a command reports success even if errors occurred on previous files, such as 'Operation not permitted'. Consequently, scripts that rely on these exit codes may proceed under a false sense of success, potentially leaving sensitive files with unintended or incorrect permissions. Such misconfigurations could result in unauthorized access or other security policy violations.",
+    "components": [
+        "rust-coreutils"
+    ],
+    "references": [
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-35339"
+        },
+        {
+            "url": "https://github.com/uutils/coreutils/releases/tag/0.6.0"
+        },
+        {
+            "url": "https://github.com/uutils/coreutils/pull/9793"
+        }
+    ],
+    "cvss_scores": [
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:N"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:H/A:N"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-35342.json
+++ b/evals/osidb_cache/CVE-2026-35342.json
@@ -1,0 +1,38 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-35342",
+    "cwe_id": "CWE-377",
+    "impact": "LOW",
+    "title": "insecure temporary file placement via empty TMPDIR",
+    "statement": "",
+    "mitigation": "",
+    "comment_zero": "The mktemp utility in uutils coreutils fails to properly handle an empty TMPDIR environment variable. Unlike GNU mktemp, which falls back to /tmp when TMPDIR is an empty string, the uutils implementation treats the empty string as a valid path. This causes temporary files to be created in the current working directory (CWD) instead of the intended secure temporary directory. If the CWD is more permissive or accessible to other users than /tmp, it may lead to unintended information disclosure or unauthorized access to temporary data.",
+    "comments": "",
+    "description": "",
+    "components": [
+        "rust-coreutils",
+        "mktemp"
+    ],
+    "references": [
+        {
+            "url": "https://github.com/uutils/coreutils/releases/tag/0.6.0"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-35342"
+        },
+        {
+            "url": "https://github.com/uutils/coreutils/pull/10566"
+        }
+    ],
+    "cvss_scores": [
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
+        },
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-40200.json
+++ b/evals/osidb_cache/CVE-2026-40200.json
@@ -1,0 +1,37 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-40200",
+    "cwe_id": "CWE-190",
+    "impact": "IMPORTANT",
+    "title": "musl libc: Arbitrary code execution and denial of service via stack-based memory corruption in qsort",
+    "statement": "AN IMPORTANT stack-based memory corruption flaw in musl libc's `qsort` function could lead to arbitrary code execution or denial of service. This vulnerability requires a local attacker to provide an extremely large, specially crafted array, exceeding millions of elements, making practical exploitation highly improbable in typical Red Hat environments.",
+    "mitigation": "",
+    "comment_zero": "An issue was discovered in musl libc 0.7.10 through 1.2.6. Stack-based memory corruption can occur during qsort of very large arrays, due to incorrectly implemented double-word primitives. The number of elements must exceed about seven million, i.e., the 32nd Leonardo number on 32-bit platforms (or the 64th Leonardo number on 64-bit platforms, which is not practical).",
+    "comments": "",
+    "description": "A flaw was found in musl libc. This stack-based memory corruption vulnerability occurs when the `qsort` function processes extremely large arrays due to incorrectly implemented double-word primitives. A local attacker could exploit this by providing a specially crafted, very large array, potentially leading to arbitrary code execution or a denial of service.",
+    "components": [
+        "musl"
+    ],
+    "references": [
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-40200"
+        },
+        {
+            "url": "https://musl.libc.org/releases.html"
+        },
+        {
+            "url": "https://www.openwall.com/lists/oss-security/2026/04/10/13"
+        }
+    ],
+    "cvss_scores": [
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:C/C:H/I:H/A:H"
+        },
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-4455.json
+++ b/evals/osidb_cache/CVE-2026-4455.json
@@ -1,0 +1,37 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-4455",
+    "cwe_id": "CWE-787",
+    "impact": "IMPORTANT",
+    "title": "Heap buffer overflow in PDFium",
+    "statement": "Red Hat Product Security rates the severity of this flaw as determined by the Google Chrome Security Advisory.",
+    "mitigation": "",
+    "comment_zero": "Heap buffer overflow in PDFium in Google Chrome prior to 146.0.7680.153 allowed a remote attacker to potentially exploit heap corruption via a crafted PDF file. (Chromium security severity: High)",
+    "comments": "",
+    "description": "A heap buffer overflow flaw was found in the PDFium component of the Chromium browser.\n\nUpstream bug(s):\n\nhttps://code.google.com/p/chromium/issues/detail?id=488585504",
+    "components": [
+        "chromium-browser"
+    ],
+    "references": [
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-4455"
+        },
+        {
+            "url": "https://chromereleases.googleblog.com/2026/03/stable-channel-update-for-desktop_18.html"
+        },
+        {
+            "url": "https://issues.chromium.org/issues/488585504"
+        }
+    ],
+    "cvss_scores": [
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+        },
+        {
+            "issuer": "CISA",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+        }
+    ]
+}

--- a/src/aegis_ai/features/cve/__init__.py
+++ b/src/aegis_ai/features/cve/__init__.py
@@ -765,7 +765,7 @@ class SuggestAffectedComponents(Feature):
                 - If the component is from the Python standard library, use 'python' as the component name.
                 - If the component is from the Go ecosystem and not in the standard library, include the namespace (e.g. github.com/containerd/containerd).
                 - If the component is from the Go standard library, use a specific package name and return it first in the components array in addition to the component 'golang'.
-                - For vulnerabilities in Google Chrome, Chromium, or any Chromium sub-component (V8, Blink, ANGLE, PDFium, Skia, DevTools, WebGL, WebML, Compositing, etc.), use 'chromium-browser' as the single component name.
+                - Use Red Hat distribution package names, not upstream project or product names. Examples: Linux kernel → 'kernel', Google Chrome/Chromium (including sub-components like V8, Blink, ANGLE, PDFium, Skia, DevTools, WebGL, WebML, Compositing) → 'chromium-browser', MySQL Server → 'mysql', uutils/coreutils → 'rust-coreutils', Mbed TLS → 'mbedtls', PowerDNS Recursor → 'pdns-recursor', Roundcube Webmail → 'roundcubemail', OpenPrinting CUPS → 'cups', .NET Framework → 'dotnet'.
                 - Provide a concise explanation of the rationale.
             """,
             rules="""

--- a/src/aegis_ai/features/cve/__init__.py
+++ b/src/aegis_ai/features/cve/__init__.py
@@ -766,6 +766,7 @@ class SuggestAffectedComponents(Feature):
                 - If the component is from the Go ecosystem and not in the standard library, include the namespace (e.g. github.com/containerd/containerd).
                 - If the component is from the Go standard library, use a specific package name and return it first in the components array in addition to the component 'golang'.
                 - Use Red Hat distribution package names, not upstream project or product names. Examples: Linux kernel → 'kernel', Google Chrome/Chromium (including sub-components like V8, Blink, ANGLE, PDFium, Skia, DevTools, WebGL, WebML, Compositing) → 'chromium-browser', MySQL Server → 'mysql', uutils/coreutils → 'rust-coreutils', Mbed TLS → 'mbedtls', PowerDNS Recursor → 'pdns-recursor', Roundcube Webmail → 'roundcubemail', OpenPrinting CUPS → 'cups', .NET Framework → 'dotnet'.
+                - When a vulnerability is in a product's own code (e.g. its shared certificate validation logic), list only the product itself as the affected component. Do not list services, protocols, or features that the product merely uses or integrates (e.g. RouterOS using OpenVPN/CAPsMAN/Dot1x → 'RouterOS' only).
                 - Provide a concise explanation of the rationale.
             """,
             rules="""


### PR DESCRIPTION
## What
Generalizes the `suggest-affected-components` prompt to map well-known upstream
product names to their Red Hat distribution package names, and adds 29 evaluation
cases covering the new mappings across 13 ecosystems.

## Why
The previous prompt only handled Chromium sub-components. Other upstream names
(e.g. "Linux kernel", "MySQL Server", "Roundcube Webmail", ".NET Framework")
were returned verbatim instead of as their package names (`kernel`, `mysql`,
`roundcubemail`, `dotnet`).

## How to Test
```bash
uv run pytest evals/features/cve/test_suggest_affected_components.py -x
```

## Depends On
- #609

## Related Tickets
Related: https://redhat.atlassian.net/browse/AEGIS-404

## Summary by Sourcery

Update CVE component suggestion behavior and expand evaluation coverage for Red Hat package naming.

New Features:
- Introduce guidance to map well-known upstream products to their corresponding Red Hat distribution package names in CVE component suggestions.

Enhancements:
- Clarify that vulnerabilities in a product's own code should list only the product as the affected component, not its dependent services or protocols.

Tests:
- Expand the default CVE evaluation set with additional cases across multiple ecosystems, including corresponding OSIDB cache fixtures.
- Mark several CVE IDs as known-to-fail where model output still diverges from expected Red Hat package names to stabilize evaluations.