### PR TITLE
CI: make `run-evals` work with `microdnf`

### DIFF
--- a/.tekton/aegis-build-pipeline.yaml
+++ b/.tekton/aegis-build-pipeline.yaml
@@ -693,7 +693,7 @@ spec:
         script: |
           #!/bin/bash -ex
           set -o pipefail
-          dnf install -yq jq
+          dnf install -y jq
           export KUBECONFIG="/var/run/eaas-space/kubeconfig"
 
           # transfer the gemini-key secret to the ephemeral namespace


### PR DESCRIPTION
## What
Make `run-evals` work with `microdnf`.

## Why

Unlike `dnf`, `microdnf` does not accept the `-q/--quiet` option:
```
step-run :-
+ set -o pipefail
+ dnf install -yq jq

(microdnf:17): librhsm-WARNING **: 10:46:17.109: Found 0 entitlement certificates

(microdnf:17): librhsm-WARNING **: 10:46:17.110: Found 0 entitlement certificates
error: Unknown option -q
```

## How to Test
See the CI logs.

## Summary by Sourcery

CI:
- Adjust Tekton build pipeline to install jq without using the unsupported quiet flag so it works with microdnf-based images.