### PR TITLE
fix(suggest-impact): restrict revision LLM call to kernel post-proces…

### DIFF
--- a/src/aegis_ai/features/cve/__init__.py
+++ b/src/aegis_ai/features/cve/__init__.py
@@ -499,8 +499,8 @@ class SuggestImpact(Feature):
 
         impact_changed = result.output.impact != original_impact
         vector_changed = result.output.cvss3_vector != original_vector
-        guardrail_fired = (
-            impact_changed or vector_changed or "kpanic_cvss_override" in trace
+        guardrail_fired = classifier_result is not None and (
+            impact_changed or vector_changed
         )
         if guardrail_fired:
             await self._revise_explanation(


### PR DESCRIPTION
## What

Gate the `_revise_explanation` LLM call in `SuggestImpact.exec()` on the
presence of a kernel `classifier_result`. Previously any post-processing
change to impact or vector — including the generic score-vs-vector
consistency fix on non-kernel CVEs — triggered a full conversation-replay
revision call.

## Why

Non-kernel CVEs whose LLM-stated score didn't match the CVSS vector
(e.g. 6.7 stated vs 7.2 computed) had their impact label corrected by
`reconcile_severity`, which set `impact_changed = True` and fired
`_revise_explanation`. That second LLM round-trip added 2-4+ minutes of
wall time with no material benefit — the metric rationale was still valid
since the vector itself was unchanged.

## How to Test

1. Run the non-kernel eval suite and confirm no regressions  `uv run pytest evals/features/cve/test_suggest_impact.py`
2. Grep CI logs for a non-kernel CVE with a score adjustment  (`adjusting cvss3_score`) and confirm no subsequent
   `explanation revised after post-processing adjustments` line.

## Related Tickets

https://redhat.atlassian.net/browse/AEGIS-422

## Summary by Sourcery

Bug Fixes:
- Avoid unnecessary LLM revision calls for non-kernel CVEs when only CVSS score adjustments occur without a classifier result.