### PR TITLE
suggest components for rejected flaws

### DIFF
--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -11,6 +11,8 @@ from osidb_bindings.bindings.python_client.types import Unset
 from osidb_bindings.session import Session
 
 import asyncio
+import csv
+import io
 import requests
 import textwrap
 
@@ -63,6 +65,7 @@ FLAW_FIELDS = [
 
 
 max_jobs_sem = asyncio.Semaphore(get_settings().llm_max_jobs)
+_csv_lock = asyncio.Lock()
 
 
 def _kwargs_for_log(kwargs: dict[str, Any]) -> dict[str, Any]:
@@ -200,6 +203,21 @@ class FlawUpdater:
             # nothing has changed
             raise RuntimeError("left unchanged")
 
+    async def append_csv(self) -> None:
+        assert self.flaw_data
+        row = {
+            "cve_id": self.flaw_data["cve_id"],
+            "components": self.flaw_data["components"],
+        }
+        buf = io.StringIO()
+        writer = csv.DictWriter(buf, fieldnames=row.keys())
+        writer.writerow(row)
+        line = buf.getvalue()
+
+        async with _csv_lock:
+            with open("/opt/app-data/rejected_flaws_components.csv", "a") as f:
+                f.write(line)
+
     async def do(self) -> None:
         assert self.flaw_data
 
@@ -208,6 +226,8 @@ class FlawUpdater:
 
         # apply suggestions
         await self.apply_suggestions()
+
+        await self.append_csv()
 
         # XXX: do not save anything to OSIDB
         return

--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -211,6 +211,9 @@ class FlawUpdater:
         # apply suggestions
         await self.apply_suggestions()
 
+        # XXX: do not save anything to OSIDB
+        return
+
         # mark the flaw as processed by Aegis/osidb-bot
         aegis_meta = self.flaw_data.setdefault("aegis_meta", {})
         aegis_meta["processed"] = True

--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -193,6 +193,9 @@ class FlawUpdater:
         for fnc in DEFAULT_SUGGESTION_LIST:
             self.updated_fields |= await fnc(self.agent, self.flaw_data, timestamp)
 
+        # XXX: process flaws with an empty list of suggested components
+        return
+
         if not self.updated_fields:
             # nothing has changed
             raise RuntimeError("left unchanged")

--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -19,28 +19,8 @@ from typing import Any, Optional, Sequence, cast
 
 
 ELIGIBLE_FLAWS = {
-    # only flaws coming from collectors
-    "source": (
-        # TODO: extend the sequence
-        "CVEORG",
-    ),
-    # only flaws in the NEW/empty state
-    "classification": (
-        {"workflow": "DEFAULT", "state": "NEW"},
-        {"workflow": "DEFAULT", "state": ""},
-    ),
-    # only flaws where Aegis has not been used yet
-    "aegis_meta": ({},),
-    # only flaws with no affects
-    "affects": ([],),
-    # only flaws with no owner
-    "owner": ("",),
-    # only flaws with empty description
-    "cve_description": ("",),
-    # only flaws with no statement
-    "statement": ("",),
-    # only flaws with no mitigation
-    "mitigation": ("",),
+    "classification": ({"workflow": "REJECTED", "state": "REJECTED"},),
+    "components": ([],),
 }
 
 FLAW_FIELDS = [
@@ -91,9 +71,8 @@ class FlawFinder:
     def search(self, state: Optional[BotState] = None) -> Sequence[CVEID]:
         # infer search predicates from ELIGIBLE_FLAWS
         kwargs: dict[str, Any] = {
-            "include_fields": ["cve_id"],
+            "include_fields": ["cve_id", "components"],
             "order": ["created_dt"],
-            "source_in": [s for s in ELIGIBLE_FLAWS["source"]],
             "workflow_state_in": [
                 cast(dict[str, str], c)["state"]
                 for c in ELIGIBLE_FLAWS["classification"]
@@ -104,7 +83,7 @@ class FlawFinder:
 
         # emptiness predicates for indexed fields
         for field, allowed in ELIGIBLE_FLAWS.items():
-            if field in ("affects", "aegis_meta"):
+            if field in ("affects", "aegis_meta", "components"):
                 # not indexed in OSIDB
                 continue
 
@@ -119,7 +98,7 @@ class FlawFinder:
         # initiate the OSIDB search
         logger.info("searching CVEs: %s", _kwargs_for_log(kwargs))
         flaw_iterator = self.osidb.flaws.retrieve_list_iterator(**kwargs)
-        cve_ids = [flaw.cve_id for flaw in flaw_iterator]
+        cve_ids = [flaw.cve_id for flaw in flaw_iterator if not flaw.components]
         if state is None:
             return cve_ids
 

--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -18,7 +18,21 @@ from datetime import datetime, timezone
 from typing import Any, Optional, Sequence, cast
 
 
-ELIGIBLE_FLAWS = {
+class _NonEmpty:
+    """Sentinel that matches any truthy value in validate()."""
+
+    def __eq__(self, other: object) -> bool:
+        return bool(other)
+
+    def __bool__(self) -> bool:
+        return True
+
+    def __repr__(self) -> str:
+        return "<non-empty>"
+
+
+ELIGIBLE_FLAWS: dict[str, tuple] = {
+    "cve_id": (_NonEmpty(),),
     "classification": ({"workflow": "REJECTED", "state": "REJECTED"},),
     "components": ([],),
 }
@@ -87,9 +101,11 @@ class FlawFinder:
                 # not indexed in OSIDB
                 continue
 
-            if len(allowed) == 1 and not allowed[0]:
-                key = f"{field}_isempty"
-                kwargs[key] = True
+            if len(allowed) == 1:
+                if not allowed[0]:
+                    kwargs[f"{field}_isempty"] = True
+                elif isinstance(allowed[0], _NonEmpty):
+                    kwargs[f"{field}_isempty"] = False
 
         # filter by timestamp if state file is used
         if state is not None:

--- a/src/aegis_ai/osidb_bot/suggest.py
+++ b/src/aegis_ai/osidb_bot/suggest.py
@@ -154,7 +154,7 @@ async def suggest_impact(agent: Agent, flaw_data: FlawData, ts: datetime) -> set
 
 DEFAULT_SUGGESTION_LIST = [
     suggest_components,
-    suggest_description,
-    suggest_cwe,
-    suggest_impact,
+    #    suggest_description,
+    #    suggest_cwe,
+    #    suggest_impact,
 ]


### PR DESCRIPTION
## What
suggest components for rejected flaws

## Why
TODO

## How to Test
TODO

## Related Tickets
Related: https://redhat.atlassian.net/browse/AEGIS-418

## Summary by Sourcery

Collect suggested components for rejected CVEs without persisting changes back to OSIDB.

Enhancements:
- Restrict bot eligibility to rejected flaws that have a CVE ID and no components, using a sentinel to express non-empty constraints in search filters.
- Extend flaw search to retrieve components and filter out items that already have components populated.
- Run only the component suggestion routine for now, skipping other suggestion types.
- Write suggested components for each processed rejected flaw to an append-only CSV file under shared app data, guarded by an async lock.