### PR TITLE
fix: make stable release versioning work again

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -26,8 +26,8 @@ htmlcov/
 
 # Environment files (secrets)
 .env
-.env-example
 .env*
+!.env-example
 
 # Packaging
 dist/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 .attic/
-etc
 
 
 # Environment

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] - 2026-05-12
+
+### Added
+- added a CI test to check that no git-tracked files are excluded by `.dockerignore`
+
+### Fixed
+- replaced deprecated `retries` with `tool_retries` in pydantic-ai agent configuration
+- fixed stable release versioning
+
+
 ## [0.7.0] - 2026-05-11
 
 ### Changed

--- a/src/aegis_ai/agents/__init__.py
+++ b/src/aegis_ai/agents/__init__.py
@@ -42,12 +42,12 @@ simple_agent = create_aegis_agent(
 
 rh_feature_agent = create_aegis_agent(
     name="RHFeatureAgent",
-    retries=agent_default_max_retries,
+    tool_retries=agent_default_max_retries,
     toolsets=[redhat_cve_toolset, public_toolset],
 )
 
 public_feature_agent = create_aegis_agent(
     name="PublicFeatureAgent",
-    retries=agent_default_max_retries,
+    tool_retries=agent_default_max_retries,
     toolsets=[public_cve_toolset, public_toolset],
 )

--- a/tests/test_dockerignore.py
+++ b/tests/test_dockerignore.py
@@ -1,0 +1,30 @@
+import subprocess
+
+import pathspec
+import pytest
+
+
+def _git_tracked_files() -> list[str]:
+    try:
+        result = subprocess.run(
+            ["git", "ls-files"],
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        pytest.skip("git is not available")
+    if result.returncode != 0:
+        pytest.skip("not in a git repository")
+    return result.stdout.splitlines()
+
+
+def test_no_tracked_files_excluded_by_dockerignore():
+    tracked = _git_tracked_files()
+
+    with open(".dockerignore") as f:
+        spec = pathspec.PathSpec.from_lines("gitignore", f)
+
+    excluded = [f for f in tracked if spec.match_file(f)]
+    assert not excluded, "git-tracked files excluded by .dockerignore:\n" + "\n".join(
+        f"  {f}" for f in excluded
+    )


### PR DESCRIPTION
## What
make stable release versioning work again

## Why
Commit e1126beda5113e1aad3b30cafe38acec16b2ec71 added git-tracked file `.env-example` to `.dockerignore`, which caused the next stable release to be versioned as `0.7.1.dev0+gd0dc6c875.d20260511` instead of `0.7.0`, which `hatch-vcs` would use if it did not see any local changes, such as removal of a git-tracked file.

## How to Test
Create a stable git tag locally and build a container image out of it.

## Related Tickets
Fixes: commit e1126beda5113e1aad3b30cafe38acec16b2ec71
Related: https://redhat.atlassian.net/browse/AEGIS-401

## Summary by Sourcery

Ensure stable release versioning remains correct when building Docker images from tagged commits.

New Features:
- Add a CI test to verify that no git-tracked files are excluded by .dockerignore.

Bug Fixes:
- Fix stable release version detection by ensuring git-tracked files required for versioning are not ignored in Docker builds.
- Update agent configuration to replace deprecated retries with tool_retries in pydantic-ai agents.

Documentation:
- Document the 0.7.1 release with notes on added CI checks and fixes to versioning and agent configuration.

Tests:
- Add a test that fails if any git-tracked files are excluded by .dockerignore.