### PR TITLE
chore: consolidate runtime dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,8 @@ Issues = "https://github.com/RedHatProductSecurity/aegis-ai/issues"
 
 [project.optional-dependencies]
 classifier_deps = [
+    "imbalanced-learn>=0.13.0",
+    "pandas>=1.5.0",
     "scikit-learn>=1.1.0",
     "xgboost>=1.7.0",
 ]
@@ -140,10 +142,8 @@ ml_deps = [
     "accelerate>=0.20.0",
     "datasets>=2.0.0",
     "huggingface-hub>=0.8.0",
-    "imbalanced-learn>=0.13.0",
     "matplotlib>=3.10.5",
     "numpy>=2.3.2",
-    "pandas>=1.5.0",
     "seaborn>=0.13.2",
     "torch>=1.9.0",
     "tqdm>=4.60.0",

--- a/uv.lock
+++ b/uv.lock
@@ -61,6 +61,8 @@ dependencies = [
 
 [package.optional-dependencies]
 classifier-deps = [
+    { name = "imbalanced-learn" },
+    { name = "pandas" },
     { name = "scikit-learn" },
     { name = "xgboost" },
 ]
@@ -122,6 +124,7 @@ requires-dist = [
     { name = "fastmcp", specifier = ">=3.0.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "huggingface-hub", marker = "extra == 'ml-deps'", specifier = ">=0.8.0" },
+    { name = "imbalanced-learn", marker = "extra == 'classifier-deps'", specifier = ">=0.13.0" },
     { name = "imbalanced-learn", marker = "extra == 'ml-deps'", specifier = ">=0.13.0" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "logfire", extras = ["fastapi", "httpx", "sqlite3"] },
@@ -132,6 +135,7 @@ requires-dist = [
     { name = "numpy", marker = "extra == 'ml-deps'", specifier = ">=2.3.2" },
     { name = "osidb-bindings", specifier = ">=5.0.0" },
     { name = "packageurl-python", specifier = ">=0.16.0" },
+    { name = "pandas", marker = "extra == 'classifier-deps'", specifier = ">=1.5.0" },
     { name = "pandas", marker = "extra == 'ml-deps'", specifier = ">=1.5.0" },
     { name = "platformdirs", specifier = ">=4.3.8" },
     { name = "pydantic", specifier = ">=2.12.4" },


### PR DESCRIPTION
## What

Move `pandas>=1.5.0` and `imbalanced-learn>=0.13.0` from `ml_deps` into `classifier_deps`, and remove the duplicate entries from `ml_deps` (they're now inherited transitively via `aegis-ai[classifier_deps]`).

## Why

The production container image installs `--extra classifier_deps` and needs both packages for XGBoost retraining (`make retrain-kernel`). Previously, these were only in `ml_deps` (which also pulls torch, transformers, and other SecBERT libraries). Adding them to `classifier_deps` raises the production image from ~1.93 GB to ~2.03 GB. Since the Lead Engineer concluded that a 100 MB delta doesn't justify maintaining a separate training image, consolidating to one image that handles both inference and retraining is the pragmatic choice. The classifier remains optional at runtime via `AEGIS_USE_KERNEL_CLASSIFIER`.

## How to Test

- [ ] `uv sync --extra classifier_deps` resolves without errors
- [ ] `make retrain-kernel` completes successfully (verifies training scripts find pandas and imbalanced-learn)
- [ ] `make build-container` builds and produces ~2.03 GB image
- [ ] Existing test suite passes (`make all`)

## Related Tickets
https://redhat.atlassian.net/browse/AEGIS-423

## Summary by Sourcery

Consolidate runtime dependency groups to ensure classifier-related packages are available via the classifier_deps extra while avoiding duplication.

Build:
- Move pandas and imbalanced-learn from ml_deps to classifier_deps so the classifier_deps extra fully covers classifier retraining needs without duplicating dependencies in ml_deps.

Chores:
- Regenerate the uv lockfile to reflect the updated optional dependency groups.