### PR TITLE
osidb-bot: harden suggest_impact against incomplete LLM output

### DIFF
--- a/src/aegis_ai/osidb_bot/suggest.py
+++ b/src/aegis_ai/osidb_bot/suggest.py
@@ -131,6 +131,11 @@ async def suggest_impact(agent: Agent, flaw_data: FlawData, ts: datetime) -> set
     feature = cve.SuggestImpact(agent)
     output = await exec_feature(feature, flaw_data)
 
+    if not output.impact or not output.cvss3_vector:
+        cve_id = flaw_data.get("cve_id")
+        logger.warning(f"{cve_id}: impact suggestion incomplete, skipping")
+        return set()
+
     # pick the "impact" field
     changed = update_field(flaw_data, ts, "impact", output)
 

--- a/src/aegis_ai/osidb_bot/suggest.py
+++ b/src/aegis_ai/osidb_bot/suggest.py
@@ -120,16 +120,16 @@ async def suggest_cwe(agent: Agent, flaw_data: FlawData, ts: datetime) -> set[st
 
 
 async def suggest_impact(agent: Agent, flaw_data: FlawData, ts: datetime) -> set[str]:
-    # request the suggestion from Aegis
-    feature = cve.SuggestImpact(agent)
-    output = await exec_feature(feature, flaw_data)
-
     # look for existing RH CVSS
     for cvss in flaw_data["cvss_scores"]:
         if cvss["issuer"] == "RH":
             cve_id = flaw_data.get("cve_id")
             logger.warning(f"{cve_id}: refusing to overwrite RH CVSS")
             return set()
+
+    # request the suggestion from Aegis
+    feature = cve.SuggestImpact(agent)
+    output = await exec_feature(feature, flaw_data)
 
     # pick the "impact" field
     changed = update_field(flaw_data, ts, "impact", output)


### PR DESCRIPTION
## What
Hardens `suggest_impact` so that incomplete LLM responses (where impact
or CVSS vector is `None`) are handled gracefully instead of crashing.
Also moves the existing-RH-CVSS check before the LLM call to avoid
wasting a request when the result would be discarded anyway.

## Why
When the LLM cannot determine impact for a CVE, it returns `None` for
both `impact` and `cvss3_vector`. The code then called `update_field()`
with `value=None`, which fell through to `getattr(output, "_cvss3_vector")`
— an attribute that does not exist on `SuggestImpactModel`, causing an
`AttributeError` crash that aborted the entire bot run.

## How to Test
```bash
make test
```

## Related Tickets

## Summary by Sourcery

Bug Fixes:
- Prevent suggest_impact from crashing when the LLM returns missing impact or CVSS data by skipping incomplete suggestions.