### PR TITLE
fix: drop misleading cvss ignore clause from suggest-impact prompt

### DIFF
--- a/src/aegis_ai/features/cve/__init__.py
+++ b/src/aegis_ai/features/cve/__init__.py
@@ -448,7 +448,7 @@ class SuggestImpact(Feature):
             )
 
         prompt = AegisPrompt(
-            user_instruction="Analyze the CVE JSON and derive a CVSS v3.1 base vector and score with metric-by-metric rationale from the perspective of Red Hat customers. Based on the score, select the impact (LOW/MODERATE/IMPORTANT/CRITICAL). Ignore any pre-labeled impact/CVSS and decide independently.",
+            user_instruction="Analyze the CVE JSON and derive a CVSS v3.1 base vector and score with metric-by-metric rationale from the perspective of Red Hat customers. Based on the score, select the impact (LOW/MODERATE/IMPORTANT/CRITICAL).",
             goals="""
                 - Return exactly one CVSS:3.1 base vector and score consistent with each other.
                 - Provide short reasoning for each base metric (AV, AC, PR, UI, S, C, I, A).


### PR DESCRIPTION
## What

Removed the "Ignore any pre-labeled impact/CVSS and decide independently." clause from the `SuggestImpact` LLM prompt in `src/aegis_ai/features/cve/__init__.py`.

## Why

The clause was misleading: `feature_deps(exclude_osidb_fields=["impact", "rh_cvss_score"])` already strips Red Hat's internal impact label and CVSS score from the context before the prompt is built, so instructing the model to "ignore" fields that aren't present is inconsistent. Worse, the wording could inadvertently signal the LLM to also disregard external collector CVSS scores (e.g. NVD), which are intentionally kept in context. Fixes AEGIS-412.

## How to Test

Run the suggest-impact eval suite and confirm no regressions:

```bash
uv run pytest evals/features/cve/test_suggest_impact.py -x
uv run pytest evals/features/cve/test_suggest_impact_kernel_cves.py -x
```

## Related Tickets
https://redhat.atlassian.net/browse/AEGIS-412

## Summary by Sourcery

Align the suggest-impact LLM prompt with available context by removing an instruction to ignore pre-labeled impact/CVSS data that is no longer present.