### PR TITLE
fix: retry prompt on `UnexpectedModelBehavior` exception

### DIFF
--- a/src/aegis_ai/features/__init__.py
+++ b/src/aegis_ai/features/__init__.py
@@ -161,13 +161,9 @@ class Feature(ABC):
                     # retry the prompt with gradually increasing delay
                     delay = (delay * 2) if delay else PROMPT_RETRY_503_DELAY_INIT
 
-                except UnexpectedModelBehavior as e:
+                except UnexpectedModelBehavior:
                     if agent_default_max_retries <= attempt:
                         # exceeded retry attempts
-                        raise
-
-                    if "RECITATION" not in str(e):
-                        # propagate other exceptions
                         raise
 
                     # retry with high temperature


### PR DESCRIPTION
## What
fix: retry prompt on `UnexpectedModelBehavior` exception even when the failure is unrelated to the RECITATION filter.

## Why
This eliminates the following occasional failures:
```
FAILED evals/features/cve/test_suggest_impact.py::test_eval_suggest_impact - AssertionError: Unsatisfied assertion(s):
suggest-impact-for-CVE-2025-39822: case failure: UnexpectedModelBehavior: Exceeded maximum output retries (1)
```

## How to Test
See the CI results.

## Related Tickets
Related: https://github.com/RedHatProductSecurity/aegis-ai/pull/319

## Summary by Sourcery

Bug Fixes:
- Fix occasional evaluation failures caused by UnexpectedModelBehavior errors not triggering a retry when unrelated to the RECITATION filter.