### PR TITLE
fix: pass static_context to feature_deps in SuggestStatementText

### DIFF
--- a/src/aegis_ai/features/cve/__init__.py
+++ b/src/aegis_ai/features/cve/__init__.py
@@ -640,7 +640,10 @@ class SuggestStatementText(Feature):
     """Based on current CVE information and context suggest a statement and mitigation."""
 
     async def exec(self, cve_id: CVEID, static_context: Any = None):
-        deps = feature_deps(exclude_osidb_fields=["statement", "mitigation"])
+        deps = feature_deps(
+            exclude_osidb_fields=["statement", "mitigation"],
+            static_context=static_context,
+        )
         NO_MITIGATION_TEXT = (
             "Mitigation for this issue is either not available or the currently available "
             "options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, "


### PR DESCRIPTION
## What
Pass `static_context` to `feature_deps()` in `SuggestStatementText`, matching the pattern already used by `SuggestCWE` and `SuggestDescriptionText`.

## Why
Commit 8f1498d8 removed `static_context` from `AegisPrompt` and updated features to pass it to `feature_deps()` instead, so the OSIDB `flaw_tool` can serve cached data without an API call. `SuggestStatementText` was missed, causing the OSIDB tool to always make a live API call — which fails when Kerberos delegation is not enabled.

## How to Test
- send a `suggest-statement` API request with CVE data in the body but without Kerberos delegation — it should succeed using the provided static context
- `make check && make test && make test-web`

## Related Tickets
Related: https://redhat.atlassian.net/browse/AEGIS-439

## Summary by Sourcery

Bug Fixes:
- Fix SuggestStatementText to pass static_context into feature_deps so OSIDB data can be obtained from cached context instead of requiring a live API call.