### PR TITLE
fix(osidb-bot): expand CVE source filter to cover all source types

### DIFF
--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -19,10 +19,31 @@ from typing import Any, Optional, Sequence, cast
 
 
 ELIGIBLE_FLAWS = {
-    # only flaws coming from collectors
+    # only flaws coming from the following sources
     "source": (
-        # TODO: extend the sequence
+        "APPLE",
+        "CERT",
+        "CUSTOMER",
+        "CVE",
         "CVEORG",
+        "DEBIAN",
+        "DISTROS",
+        "GENTOO",
+        "GOOGLE",
+        "HW_VENDOR",
+        "INTERNET",
+        "MAGEIA",
+        "MOZILLA",
+        "NVD",
+        "OPENSSL",
+        "OSSSECURITY",
+        "OSV",
+        "REDHAT",
+        "RESEARCHER",
+        "SECUNIA",
+        "SUSE",
+        "UBUNTU",
+        "UPSTREAM",
     ),
     # only flaws in the NEW/empty state
     "classification": (


### PR DESCRIPTION
## What

Expand the OSIDB bot's CVE source filter from only `CVEORG` to all known
CVE source types, so that every eligible flaw is processed by the kernel
CVE classifier logic.

## Why

Some kernel CVEs (e.g. CVE-2026-46333, CVE-2026-43023) arrive with source
`UPSTREAM` instead of `CVEORG`. The bot was skipping these flaws because
the source filter only matched `CVEORG`, leaving them unprocessed by the
kernel-cve-impact-classifier and LLM pipeline.

## How to Test

1. Verify the updated `ELIGIBLE_FLAWS["source"]` tuple in
   `src/aegis_ai/osidb_bot/bot.py` includes all expected source values.
2. Run `make all` to confirm no regressions.
3. Deploy and confirm that flaws with source `UPSTREAM` are now picked up
   by the bot.

Related: https://redhat.atlassian.net/browse/AEGIS-436

## Summary by Sourcery

New Features:
- Enable the OSIDB bot to process CVEs from all recognized flaw sources, including UPSTREAM, instead of restricting to CVEORG.