### PR TITLE
Release aegis 0.7.4

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -8,7 +8,7 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=off \
     PIP_INDEX_URL="${PIP_INDEX_URL}" \
     UV_NO_CACHE=off \
-    UV_NATIVE_TLS=true \
+    UV_SYSTEM_CERTS=true \
     UV_PROJECT_ENVIRONMENT="/opt/app-root/.venv" \
     REQUESTS_CA_BUNDLE="/etc/pki/tls/certs/ca-bundle.crt"
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.4] - 2026-06-05
+
+### Fixed
+- `osidb-bot` no longer processes flaws with empty state
+- `osidb-bot` now excludes flaws without a CVE ID from processing
+- replaced deprecated `UV_NATIVE_TLS` with `UV_SYSTEM_CERTS` in container image
+
+
 ## [0.7.3] - 2026-06-05
 
 ### Changed

--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -45,11 +45,8 @@ ELIGIBLE_FLAWS = {
         "UBUNTU",
         "UPSTREAM",
     ),
-    # only flaws in the NEW/empty state
-    "classification": (
-        {"workflow": "DEFAULT", "state": "NEW"},
-        {"workflow": "DEFAULT", "state": ""},
-    ),
+    # only flaws in the NEW state
+    "classification": ({"workflow": "DEFAULT", "state": "NEW"},),
     # only flaws where Aegis has not been used yet
     "aegis_meta": ({},),
     # only flaws with no affects

--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -110,6 +110,7 @@ class FlawFinder:
         # infer search predicates from ELIGIBLE_FLAWS
         kwargs: dict[str, Any] = {
             "include_fields": ["cve_id"],
+            "cve_id__isempty": False,  # only flaws with a CVE ID
             "order": ["created_dt"],
             "source_in": [s for s in ELIGIBLE_FLAWS["source"]],
             "workflow_state_in": [


### PR DESCRIPTION
## What
Release 0.7.4 with `osidb-bot` robustness fixes and a container build fix.

## Why
`osidb-bot` was processing flaws with empty state and flaws without a CVE ID, causing unnecessary failures. The container image used a deprecated `UV_NATIVE_TLS` env var that emits warnings with newer uv versions.

## How to Test
- run `osidb-bot` against OSIDB stage and verify it skips flaws with empty state and flaws without CVE ID
- build the container image and verify no `UV_NATIVE_TLS` deprecation warning is emitted

## Related Tickets
Related: https://redhat.atlassian.net/browse/AEGIS-453

## Summary by Sourcery

Release version 0.7.4 with robustness fixes for osidb-bot and a container TLS configuration update.

Bug Fixes:
- Restrict osidb-bot processing to flaws in the NEW state only.
- Exclude flaws without a CVE ID from osidb-bot search results to avoid unnecessary failures.

Enhancements:
- Update container configuration to use UV_SYSTEM_CERTS instead of the deprecated UV_NATIVE_TLS environment variable.

Documentation:
- Add 0.7.4 changelog entry documenting osidb-bot robustness fixes and the container TLS configuration change.