### PR TITLE
feat(osidb-bot): record `aegis_meta` when suggestion is discarded

### DIFF
--- a/evals/features/cve/test_suggest_cwe.py
+++ b/evals/features/cve/test_suggest_cwe.py
@@ -418,7 +418,7 @@ cases = [
     ),
     SuggestCweCase(
         cve_id="CVE-2025-9390",
-        cwe_list=["CWE-120", "CWE-131"],  # kdudka: added CWE-131
+        cwe_list=["CWE-120", "CWE-131", "CWE-787"],  # kdudka: added CWE-131 and CWE-787
     ),
     SuggestCweCase(
         cve_id="CVE-2025-9394",

--- a/evals/features/cve/test_suggest_cwe.py
+++ b/evals/features/cve/test_suggest_cwe.py
@@ -423,7 +423,12 @@ cases = [
     SuggestCweCase(
         cve_id="CVE-2025-9394",
         cwe_list=["CWE-825"],
-        metadata={"known_to_fail_evaluators": ["CWEExplanationRootCause"]},
+        metadata={
+            "known_to_fail_evaluators": [
+                "CWEExplanationRootCause",
+                "SuggestCweEvaluator",
+            ]
+        },
     ),
     SuggestCweCase(
         cve_id="CVE-2025-11429",

--- a/evals/features/cve/test_suggest_cwe.py
+++ b/evals/features/cve/test_suggest_cwe.py
@@ -738,7 +738,12 @@ cases = [
     SuggestCweCase(
         cve_id="CVE-2025-43529",
         cwe_list=["CWE-825"],
-        metadata={"known_to_fail_evaluators": ["CWEExplanationRootCause"]},
+        metadata={
+            "known_to_fail_evaluators": [
+                "CWEExplanationRootCause",
+                "SuggestCweEvaluator",
+            ]
+        },
     ),
     SuggestCweCase(
         cve_id="CVE-2025-49133",

--- a/evals/features/cve/test_suggest_cwe.py
+++ b/evals/features/cve/test_suggest_cwe.py
@@ -385,7 +385,12 @@ cases = [
     SuggestCweCase(
         cve_id="CVE-2024-56658",
         cwe_list=["CWE-825", "CWE-826"],  # kdudka: added CWE-826
-        metadata={"known_to_fail_evaluators": ["SuggestCweEvaluator"]},
+        metadata={
+            "known_to_fail_evaluators": [
+                "SuggestCweEvaluator",
+                "CWEExplanationRootCause",
+            ]
+        },
     ),
     SuggestCweCase(
         cve_id="CVE-2025-5302",

--- a/evals/features/cve/test_suggest_impact.py
+++ b/evals/features/cve/test_suggest_impact.py
@@ -492,7 +492,12 @@ cases = [
     SuggestImpactCase(
         cve_id="CVE-2025-40320",
         expected_cvss3_vector="CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:L/I:H/A:H",
-        metadata={"known_to_fail_evaluators": ["CVSSVectorEvaluator"]},
+        metadata={
+            "known_to_fail_evaluators": [
+                "CVSSVectorEvaluator",
+                "CVSSKernelScopeAndPrivileges",
+            ]
+        },
     ),
     SuggestImpactCase(
         cve_id="CVE-2025-50334",

--- a/evals/features/cve/test_suggest_impact_kernel_cves.py
+++ b/evals/features/cve/test_suggest_impact_kernel_cves.py
@@ -240,6 +240,14 @@ KNOWN_FAILURES: dict[str, dict] = {
             "(predicted MODERATE vs expected IMPORTANT)."
         ),
     },
+    "CVE-2026-23074": {
+        "known_to_fail_evaluators": ["CVSSKernelScopeAndPrivileges"],
+        "reason": (
+            "Explanation for S:C describes privilege escalation to elevated system "
+            "access but the CVSS vector uses S:U. Scope narration inconsistent "
+            "with vector."
+        ),
+    },
 }
 
 # Without the kernel classifier the LLM alone underestimates these
@@ -253,8 +261,11 @@ if not get_settings().use_kernel_classifier:
             "requires kernel classifier to reach correct impact."
         ),
     }
-    for _cve in ("CVE-2025-38590", "CVE-2023-53186", "CVE-2026-23074"):
+    for _cve in ("CVE-2025-38590", "CVE-2023-53186"):
         KNOWN_FAILURES[_cve] = _NO_CLF_WAIVER
+    KNOWN_FAILURES["CVE-2026-23074"]["known_to_fail_evaluators"].append(
+        "UnderestimationEvaluator"
+    )
 
 
 def _normalize_impact(raw: str) -> str:

--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -161,6 +161,7 @@ class FlawUpdater:
     osidb: Session
     agent: Agent
     cve: CVEID
+    force: bool
 
     # OSIDB flaw from session.flaws.retrieve()
     flaw_data: Optional[FlawData]
@@ -168,10 +169,13 @@ class FlawUpdater:
     # list of fields updated by the agent
     updated_fields: set[str]
 
-    def __init__(self, osidb: Session, agent: Agent, cve: CVEID):
+    def __init__(
+        self, osidb: Session, agent: Agent, cve: CVEID, *, force: bool = False
+    ):
         self.osidb = osidb
         self.agent = agent
         self.cve = cve
+        self.force = force
         self.updated_fields = set()
 
         try:
@@ -225,7 +229,13 @@ class FlawUpdater:
         assert self.flaw_data
 
         # validate eligibility on the fresh flaw data to avoid TOCTOU
-        FlawFinder.validate(self.flaw_data)
+        try:
+            FlawFinder.validate(self.flaw_data)
+        except RuntimeError as e:
+            if self.force:
+                self._warn(f"bypassing flaw eligibility check: {str(e)}")
+            else:
+                raise
 
         # apply suggestions
         await self.apply_suggestions()
@@ -284,10 +294,18 @@ class Bot:
     osidb: Session
     total: int
     pending: dict[BotState, bool]
+    force: bool
 
-    def __init__(self, state_file_handler: StateFileHandler, agent: Agent):
+    def __init__(
+        self,
+        state_file_handler: StateFileHandler,
+        agent: Agent,
+        *,
+        force: bool = False,
+    ):
         self.sfh = state_file_handler
         self.agent = agent
+        self.force = force
         self.total = 0
         self.pending = {}
         try:
@@ -308,7 +326,7 @@ class Bot:
         flaw_updater: Optional[FlawUpdater] = None
 
         try:
-            flaw_updater = FlawUpdater(self.osidb, self.agent, cve)
+            flaw_updater = FlawUpdater(self.osidb, self.agent, cve, force=self.force)
             self.pending[flaw_updater.state()] = True  # mark as pending
             await flaw_updater.do()
 

--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -162,6 +162,7 @@ class FlawUpdater:
     agent: Agent
     cve: CVEID
     force: bool
+    read_only: bool
 
     # OSIDB flaw from session.flaws.retrieve()
     flaw_data: Optional[FlawData]
@@ -170,12 +171,19 @@ class FlawUpdater:
     updated_fields: set[str]
 
     def __init__(
-        self, osidb: Session, agent: Agent, cve: CVEID, *, force: bool = False
+        self,
+        osidb: Session,
+        agent: Agent,
+        cve: CVEID,
+        *,
+        force: bool = False,
+        read_only: bool = False,
     ):
         self.osidb = osidb
         self.agent = agent
         self.cve = cve
         self.force = force
+        self.read_only = read_only
         self.updated_fields = set()
 
         try:
@@ -240,6 +248,11 @@ class FlawUpdater:
         # apply suggestions
         await self.apply_suggestions()
 
+        if self.read_only:
+            msg = f"read-only mode, skipping OSIDB update of {self.updated_fields}"
+            self._warn(msg)
+            return
+
         # mark the flaw as processed by Aegis/osidb-bot
         aegis_meta = self.flaw_data.setdefault("aegis_meta", {})
         aegis_meta["processed"] = True
@@ -295,6 +308,7 @@ class Bot:
     total: int
     pending: dict[BotState, bool]
     force: bool
+    read_only: bool
 
     def __init__(
         self,
@@ -302,10 +316,12 @@ class Bot:
         agent: Agent,
         *,
         force: bool = False,
+        read_only: bool = False,
     ):
         self.sfh = state_file_handler
         self.agent = agent
         self.force = force
+        self.read_only = read_only
         self.total = 0
         self.pending = {}
         try:
@@ -326,7 +342,13 @@ class Bot:
         flaw_updater: Optional[FlawUpdater] = None
 
         try:
-            flaw_updater = FlawUpdater(self.osidb, self.agent, cve, force=self.force)
+            flaw_updater = FlawUpdater(
+                self.osidb,
+                self.agent,
+                cve,
+                force=self.force,
+                read_only=self.read_only,
+            )
             self.pending[flaw_updater.state()] = True  # mark as pending
             await flaw_updater.do()
 
@@ -350,7 +372,7 @@ class Bot:
                 del self.pending[state]
 
             # do not update state file if the CVE with lowest created_dt is still being processed
-            if state:
+            if not self.read_only and state:
                 # update state file
                 self.sfh.write_state(state)
 

--- a/src/aegis_ai/osidb_bot/suggest.py
+++ b/src/aegis_ai/osidb_bot/suggest.py
@@ -60,6 +60,24 @@ async def exec_feature(feature: Feature, flaw_data: FlawData) -> Any:
         raise RuntimeError(f"{msg}: {e.__class__.__name__}")
 
 
+def record_aegis_meta(
+    flaw_data: FlawData,
+    timestamp: datetime,
+    dst: str,
+    output: AegisFeatureModel,
+    **extra: Any,
+) -> None:
+    aegis_meta = flaw_data.setdefault("aegis_meta", {})
+    dst_field = aegis_meta.setdefault(dst, [])
+    entry: dict[str, Any] = {
+        "timestamp": timestamp.isoformat(),
+        "data_quality": output.data_quality,
+        "confidence": output.confidence,
+        **extra,
+    }
+    dst_field.append(entry)
+
+
 def update_field(
     flaw_data: FlawData,
     timestamp: datetime,
@@ -97,17 +115,14 @@ def update_field(
     flaw_data[dst] = value
 
     # record Aegis metadata
-    aegis_meta = flaw_data.setdefault("aegis_meta", {})
-    dst_field = aegis_meta.setdefault(dst, [])
-    dst_field.append(
-        {
-            "type": "AI-Bot",
-            "value": value,
-            "explanation": output.explanation,
-            "timestamp": timestamp.isoformat(),
-            "data_quality": output.data_quality,
-            "confidence": output.confidence,
-        }
+    record_aegis_meta(
+        flaw_data,
+        timestamp,
+        dst,
+        output,
+        type="AI-Bot",
+        value=value,
+        explanation=output.explanation,
     )
 
     return set([dst])

--- a/src/aegis_ai/osidb_bot/suggest.py
+++ b/src/aegis_ai/osidb_bot/suggest.py
@@ -22,21 +22,24 @@ METRICS_THR = {
 }
 
 
-def check_metrics(feat_name: str, cve_id: CVEID, output: AegisFeatureModel) -> bool:
-    """return True if both data_quality and confidence are above skip_thr"""
-    skip = False
+def check_metrics(
+    feat_name: str, cve_id: str | CVEID, output: AegisFeatureModel
+) -> Optional[str]:
+    """Return None if metrics are acceptable, or the name of the failing metric.
+
+    `cve_id` may be a `CVEID` or a raw string (including an empty string if the ID is missing)."""
+    skip_reason: Optional[str] = None
     for field, thr_map in METRICS_THR.items():
         value = getattr(output, field)
         if value <= thr_map["info_thr"]:
             logger.info(f"{cve_id}: {feat_name}: too low {field}: {value}")
         if value <= thr_map["skip_thr"]:
-            skip = True
+            skip_reason = field
 
-    if skip:
+    if skip_reason:
         logger.warning(f"{cve_id}: {feat_name}: discarding suggestion")
-        return False
 
-    return True
+    return skip_reason
 
 
 async def exec_feature(feature: Feature, flaw_data: FlawData) -> Any:
@@ -48,12 +51,8 @@ async def exec_feature(feature: Feature, flaw_data: FlawData) -> Any:
         result = await feature.exec(cve_id, static_context=flaw_data)
         log_memory(f"{feat_name}_end({cve_id})")
         output = result.output
-        if not isinstance(output, AegisFeatureModel):
-            return None
-        if check_metrics(feat_name, cve_id, output):
+        if isinstance(output, AegisFeatureModel):
             return output
-        else:
-            return None
 
     except Exception as e:
         msg = "exec_feature() terminated with Exception"
@@ -73,6 +72,11 @@ def update_field(
     assert (not src) or (not value)
     if only_if_missing and flaw_data.get(dst):
         # do not override existing field
+        return set()
+
+    cve_id = flaw_data.get("cve_id", "")
+    skip_reason = check_metrics(dst, cve_id, output)
+    if skip_reason:
         return set()
 
     # get source value
@@ -198,6 +202,13 @@ async def suggest_impact(agent: Agent, flaw_data: FlawData, ts: datetime) -> set
     # pick the "impact" field
     changed = update_field(flaw_data, ts, "impact", output)
 
+    # record aegis_meta for RH CVSS (in the format used by OSIM)
+    if not update_field(
+        flaw_data, ts, "_cvss3_vector", output, value=output.cvss3_vector
+    ):
+        # do not update CVSS when check_metrics() decides to skip the update
+        return changed
+
     # RH CVSS is a subresource in OSIDB (flaws.cvss_scores), not part of flaw update.
     # Store pending data for the bot to apply via osidb.flaws.cvss_scores create/update.
     rh_cvss = {
@@ -209,10 +220,6 @@ async def suggest_impact(agent: Agent, flaw_data: FlawData, ts: datetime) -> set
     }
     flaw_data["cvss_scores"] = [rh_cvss]
     changed.add("cvss_scores")
-
-    # record aegis_meta for RH CVSS (in the format used by OSIM)
-    update_field(flaw_data, ts, "_cvss3_vector", output, value=output.cvss3_vector)
-
     return changed
 
 

--- a/src/aegis_ai/osidb_bot/suggest.py
+++ b/src/aegis_ai/osidb_bot/suggest.py
@@ -101,6 +101,8 @@ def update_field(
             "value": value,
             "explanation": output.explanation,
             "timestamp": timestamp.isoformat(),
+            "data_quality": output.data_quality,
+            "confidence": output.confidence,
         }
     )
 

--- a/src/aegis_ai/osidb_bot/suggest.py
+++ b/src/aegis_ai/osidb_bot/suggest.py
@@ -95,6 +95,19 @@ def update_field(
     cve_id = flaw_data.get("cve_id", "")
     skip_reason = check_metrics(dst, cve_id, output)
     if skip_reason:
+        skip_value = getattr(output, skip_reason)
+        record_aegis_meta(
+            flaw_data,
+            timestamp,
+            dst,
+            output,
+            type="AI-Bot-Skipped",
+            skip_reason=skip_reason,
+            skip_description=(
+                f"{dst} suggestion discarded: {skip_reason}={skip_value}"
+                f" is below threshold {METRICS_THR[skip_reason]['skip_thr']}"
+            ),
+        )
         return set()
 
     # get source value

--- a/src/aegis_ai_cli/main.py
+++ b/src/aegis_ai_cli/main.py
@@ -396,8 +396,14 @@ def component_intelligence(component_name):
     default=None,
     help="Path to state file.",
 )
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Skip flaw eligibility validation.",
+)
 @click.argument("cve_ids", nargs=-1, type=CVEID)
-def osidb_bot(state_file, cve_ids):
+def osidb_bot(state_file, force, cve_ids):
     """
     OSIDB bot: process CVE IDs (optional) with optional state file.
     """
@@ -414,7 +420,7 @@ def osidb_bot(state_file, cve_ids):
         # this prevents multiple processes running in parallel on a single state file
         # (if state_file is not None)
         with StateFileHandler(state_file) as sfh:
-            osidb_bot = Bot(sfh, cli_agent)
+            osidb_bot = Bot(sfh, cli_agent, force=force)
             log_memory("bot_created")
             runner = osidb_bot.process(cve_ids)
             asyncio.run(runner)

--- a/src/aegis_ai_cli/main.py
+++ b/src/aegis_ai_cli/main.py
@@ -402,8 +402,14 @@ def component_intelligence(component_name):
     default=False,
     help="Skip flaw eligibility validation.",
 )
+@click.option(
+    "--read-only",
+    is_flag=True,
+    default=False,
+    help="Skip OSIDB data updates (dry run).",
+)
 @click.argument("cve_ids", nargs=-1, type=CVEID)
-def osidb_bot(state_file, force, cve_ids):
+def osidb_bot(state_file, force, read_only, cve_ids):
     """
     OSIDB bot: process CVE IDs (optional) with optional state file.
     """
@@ -420,7 +426,7 @@ def osidb_bot(state_file, force, cve_ids):
         # this prevents multiple processes running in parallel on a single state file
         # (if state_file is not None)
         with StateFileHandler(state_file) as sfh:
-            osidb_bot = Bot(sfh, cli_agent, force=force)
+            osidb_bot = Bot(sfh, cli_agent, force=force, read_only=read_only)
             log_memory("bot_created")
             runner = osidb_bot.process(cve_ids)
             asyncio.run(runner)

--- a/tests/test_flaw_updater.py
+++ b/tests/test_flaw_updater.py
@@ -184,3 +184,38 @@ async def test_flaw_updater_do_sets_processed_in_aegis_meta(mock_exec_feature):
 
     aegis_meta = flaw_data["aegis_meta"]
     assert aegis_meta.get("processed") is True
+
+
+@pytest.mark.asyncio
+@patch("aegis_ai.osidb_bot.suggest.exec_feature", new_callable=AsyncMock)
+async def test_flaw_updater_force_skips_validation(mock_exec_feature):
+    """FlawUpdater.do() with force=True processes flaws that would fail validation."""
+    mock_exec_feature.side_effect = _canned_exec_feature
+
+    flaw_data = _minimal_flaw_data()
+    flaw_data["owner"] = "someone@example.com"
+
+    session = _mock_session(flaw_data)
+    agent = MagicMock()
+
+    updater = FlawUpdater(session, agent, CVE_ID, force=True)
+    await updater.do()
+
+    session.flaws.update.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("aegis_ai.osidb_bot.suggest.exec_feature", new_callable=AsyncMock)
+async def test_flaw_updater_no_force_raises_on_ineligible(mock_exec_feature):
+    """FlawUpdater.do() without force raises RuntimeError on ineligible flaw."""
+    mock_exec_feature.side_effect = _canned_exec_feature
+
+    flaw_data = _minimal_flaw_data()
+    flaw_data["owner"] = "someone@example.com"
+
+    session = _mock_session(flaw_data)
+    agent = MagicMock()
+
+    updater = FlawUpdater(session, agent, CVE_ID)
+    with pytest.raises(RuntimeError, match="skipped because owner="):
+        await updater.do()

--- a/tests/test_flaw_updater.py
+++ b/tests/test_flaw_updater.py
@@ -10,11 +10,13 @@ from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from typing import cast
+
 from aegis_ai.data_models import CVEID
+from aegis_ai.features.data_models import AegisAnswer
 from aegis_ai.osidb_bot.bot import FlawUpdater
+from aegis_ai.osidb_bot.suggest import METRICS_THR, update_field
 
-
-pytestmark = pytest.mark.asyncio
 
 CVE_ID: CVEID = "CVE-2025-0001"
 
@@ -98,6 +100,7 @@ async def _canned_exec_feature(feature, flaw_data):
     raise ValueError(f"Unknown feature: {name}")
 
 
+@pytest.mark.asyncio
 @patch("aegis_ai.osidb_bot.suggest.exec_feature", new_callable=AsyncMock)
 async def test_flaw_updater_aegis_meta_updated_by_suggestions(mock_exec_feature):
     """FlawUpdater.apply_suggestions() populates aegis_meta for each updated field."""
@@ -150,6 +153,7 @@ async def test_flaw_updater_aegis_meta_updated_by_suggestions(mock_exec_feature)
     mock_exec_feature.assert_called()
 
 
+@pytest.mark.asyncio
 @patch("aegis_ai.osidb_bot.suggest.exec_feature", new_callable=AsyncMock)
 async def test_flaw_updater_aegis_meta_entry_structure(mock_exec_feature):
     """Each aegis_meta entry has type, value, explanation, and timestamp."""
@@ -176,6 +180,7 @@ async def test_flaw_updater_aegis_meta_entry_structure(mock_exec_feature):
     datetime.fromisoformat(entry["timestamp"])
 
 
+@pytest.mark.asyncio
 @patch("aegis_ai.osidb_bot.suggest.exec_feature", new_callable=AsyncMock)
 async def test_flaw_updater_do_sets_processed_in_aegis_meta(mock_exec_feature):
     """FlawUpdater.do() sets aegis_meta['processed'] = True after apply_suggestions."""
@@ -243,3 +248,156 @@ async def test_flaw_updater_read_only_skips_osidb_writes(mock_exec_feature):
     assert updater.updated_fields
     session.flaws.update.assert_not_called()
     assert "processed" not in flaw_data.get("aegis_meta", {})
+
+
+# --- Tests for aegis_meta when suggestions are discarded by check_metrics ---
+
+LOW_QUALITY = METRICS_THR["data_quality"]["skip_thr"]
+LOW_CONFIDENCE = METRICS_THR["confidence"]["skip_thr"]
+TS = datetime(2025, 3, 13, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def test_update_field_skipped_low_data_quality():
+    """update_field records AI-Bot-Skipped when data_quality is at/below skip_thr."""
+    flaw_data = _minimal_flaw_data()
+    output = cast(
+        AegisAnswer,
+        SimpleNamespace(
+            cwe=["CWE-79"],
+            explanation="test",
+            data_quality=LOW_QUALITY,
+            confidence=1.0,
+        ),
+    )
+
+    changed = update_field(flaw_data, TS, "cwe_id", output, value="CWE-79")
+
+    assert changed == set()
+    assert flaw_data["cwe_id"] == ""
+
+    entries = flaw_data["aegis_meta"]["cwe_id"]
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["type"] == "AI-Bot-Skipped"
+    assert entry["skip_reason"] == "data_quality"
+    assert str(LOW_QUALITY) in entry["skip_description"]
+    assert str(METRICS_THR["data_quality"]["skip_thr"]) in entry["skip_description"]
+    assert entry["data_quality"] == LOW_QUALITY
+    assert entry["confidence"] == 1.0
+    assert "timestamp" in entry
+
+
+def test_update_field_skipped_low_confidence():
+    """update_field records AI-Bot-Skipped when confidence is at/below skip_thr."""
+    flaw_data = _minimal_flaw_data()
+    output = cast(
+        AegisAnswer,
+        SimpleNamespace(
+            impact="LOW",
+            explanation="test",
+            data_quality=1.0,
+            confidence=LOW_CONFIDENCE,
+        ),
+    )
+
+    changed = update_field(flaw_data, TS, "impact", output, value="LOW")
+
+    assert changed == set()
+    assert flaw_data["impact"] == ""
+
+    entries = flaw_data["aegis_meta"]["impact"]
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["type"] == "AI-Bot-Skipped"
+    assert entry["skip_reason"] == "confidence"
+    assert str(LOW_CONFIDENCE) in entry["skip_description"]
+    assert str(METRICS_THR["confidence"]["skip_thr"]) in entry["skip_description"]
+
+
+def test_update_field_skipped_both_metrics_low():
+    """When both metrics fail, skip_reason reflects the last failing metric."""
+    flaw_data = _minimal_flaw_data()
+    output = cast(
+        AegisAnswer,
+        SimpleNamespace(
+            title="Bad title",
+            explanation="test",
+            data_quality=LOW_QUALITY,
+            confidence=LOW_CONFIDENCE,
+        ),
+    )
+
+    changed = update_field(flaw_data, TS, "title", output, value="Bad title")
+
+    assert changed == set()
+    assert flaw_data["title"] == ""
+
+    entries = flaw_data["aegis_meta"]["title"]
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["type"] == "AI-Bot-Skipped"
+    assert entry["skip_reason"] == "confidence"
+
+
+@pytest.mark.asyncio
+@patch("aegis_ai.osidb_bot.suggest.exec_feature", new_callable=AsyncMock)
+async def test_flaw_updater_all_skipped_records_aegis_meta(mock_exec_feature):
+    """FlawUpdater records AI-Bot-Skipped entries when all features have low metrics."""
+
+    async def _low_metrics_exec(feature, flaw_data):
+        name = feature.__class__.__name__
+        cve_id = flaw_data["cve_id"]
+        explanation = f"Low-quality output for {name} ({cve_id})"
+        metrics = dict(data_quality=LOW_QUALITY, confidence=LOW_CONFIDENCE)
+
+        if name == "SuggestAffectedComponents":
+            return SimpleNamespace(
+                components=["kernel"],
+                ecosystems=[],
+                explanation=explanation,
+                **metrics,
+            )
+        if name == "SuggestDescriptionText":
+            return SimpleNamespace(
+                suggested_title="Bad title",
+                suggested_description="Bad description.",
+                explanation=explanation,
+                **metrics,
+            )
+        if name == "SuggestCWE":
+            return SimpleNamespace(cwe=["CWE-79"], explanation=explanation, **metrics)
+        if name == "SuggestImpact":
+            return SimpleNamespace(
+                impact="LOW",
+                cvss3_score="3.7",
+                cvss3_vector="CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L",
+                explanation=explanation,
+                **metrics,
+            )
+        raise ValueError(f"Unknown feature: {name}")
+
+    mock_exec_feature.side_effect = _low_metrics_exec
+
+    flaw_data = _minimal_flaw_data()
+    session = _mock_session(flaw_data)
+    agent = MagicMock()
+
+    updater = FlawUpdater(session, agent, CVE_ID)
+
+    with pytest.raises(RuntimeError, match="left unchanged"):
+        await updater.apply_suggestions()
+
+    assert updater.updated_fields == set()
+
+    aegis_meta = flaw_data["aegis_meta"]
+    for field in ("components", "title", "cve_description", "cwe_id", "impact"):
+        assert field in aegis_meta, f"aegis_meta missing skipped entry for {field!r}"
+        entries = aegis_meta[field]
+        assert len(entries) >= 1
+        for entry in entries:
+            assert entry["type"] == "AI-Bot-Skipped"
+            assert "skip_reason" in entry
+            assert "skip_description" in entry
+            assert entry["data_quality"] == LOW_QUALITY
+            assert entry["confidence"] == LOW_CONFIDENCE
+            datetime.fromisoformat(entry["timestamp"])

--- a/tests/test_flaw_updater.py
+++ b/tests/test_flaw_updater.py
@@ -65,22 +65,27 @@ async def _canned_exec_feature(feature, flaw_data):
     cve_id = flaw_data["cve_id"]
     explanation = f"Canned explanation for {name} ({cve_id})"
 
+    metrics = dict(data_quality=1.0, confidence=1.0)
+
     if name == "SuggestAffectedComponents":
         return SimpleNamespace(
             components=["kernel", "curl"],
             ecosystems=["upstream"],
             explanation=explanation,
+            **metrics,
         )
     if name == "SuggestDescriptionText":
         return SimpleNamespace(
             suggested_title="Canned title",
             suggested_description="Canned description text.",
             explanation=explanation,
+            **metrics,
         )
     if name == "SuggestCWE":
         return SimpleNamespace(
             cwe=["CWE-79"],
             explanation=explanation,
+            **metrics,
         )
     if name == "SuggestImpact":
         return SimpleNamespace(
@@ -88,6 +93,7 @@ async def _canned_exec_feature(feature, flaw_data):
             cvss3_score="3.7",
             cvss3_vector="CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L",
             explanation=explanation,
+            **metrics,
         )
     raise ValueError(f"Unknown feature: {name}")
 

--- a/tests/test_flaw_updater.py
+++ b/tests/test_flaw_updater.py
@@ -219,3 +219,21 @@ async def test_flaw_updater_no_force_raises_on_ineligible(mock_exec_feature):
     updater = FlawUpdater(session, agent, CVE_ID)
     with pytest.raises(RuntimeError, match="skipped because owner="):
         await updater.do()
+
+
+@pytest.mark.asyncio
+@patch("aegis_ai.osidb_bot.suggest.exec_feature", new_callable=AsyncMock)
+async def test_flaw_updater_read_only_skips_osidb_writes(mock_exec_feature):
+    """FlawUpdater.do() with read_only=True runs suggestions but skips OSIDB writes."""
+    mock_exec_feature.side_effect = _canned_exec_feature
+
+    flaw_data = _minimal_flaw_data()
+    session = _mock_session(flaw_data)
+    agent = MagicMock()
+
+    updater = FlawUpdater(session, agent, CVE_ID, read_only=True)
+    await updater.do()
+
+    assert updater.updated_fields
+    session.flaws.update.assert_not_called()
+    assert "processed" not in flaw_data.get("aegis_meta", {})


### PR DESCRIPTION
## What

Record `aegis_meta` entries when osidb-bot discards a suggestion due to low `data_quality` or `confidence` metrics, so OSIDB retains a trace of skipped suggestions. Also adds `--force` and `--read-only` CLI options and includes `data_quality`/`confidence` values in every `aegis_meta` entry.

## Why

Previously, when `check_metrics()` rejected a suggestion, no trace was left in the flaw data. This made it impossible to tell whether a field was never suggested or whether a suggestion was made but discarded. Recording `AI-Bot-Skipped` entries with `skip_reason` and `skip_description` provides visibility into the quality gate decisions. The `--force` and `--read-only` options support debugging and dry-run workflows.

## How to Test

```bash
make check   # format + lint + type-check
make test    # unit tests (includes new test_flaw_updater.py tests)
```

Key test cases in `tests/test_flaw_updater.py`:
- `test_update_field_skipped_low_data_quality`
- `test_update_field_skipped_low_confidence`
- `test_update_field_skipped_both_metrics_low`
- `test_flaw_updater_all_skipped_records_aegis_meta`

## Related Tickets
Related: https://redhat.atlassian.net/browse/AEGIS-447

## Summary by Sourcery

Record osidb-bot suggestion skips in aegis_meta, add control flags to bypass validation or perform dry runs, and refine metric handling and evaluations metadata.

New Features:
- Add recording of AI-Bot and AI-Bot-Skipped aegis_meta entries including data_quality and confidence for each updated or discarded field.
- Introduce force and read_only flags on FlawUpdater, Bot, and the osidb_bot CLI command to bypass eligibility checks or skip OSIDB writes.

Enhancements:
- Refine metric checking to return structured skip reasons and centralize aegis_meta entry creation in a helper.
- Extend evaluation fixtures and known failure metadata for CWE and impact suggestion tests to cover additional cases and evaluators.

Tests:
- Add unit tests covering force/read-only behaviors, metric-based suggestion skipping, and aegis_meta recording when all suggestions are discarded.