### PR TITLE
ci: make the `sast-snyk-check` Tekton task work again

### DIFF
--- a/.tekton/aegis-build-pipeline.yaml
+++ b/.tekton/aegis-build-pipeline.yaml
@@ -99,10 +99,6 @@ spec:
     type: string
     default: "false"
     description: Whether to generate image labels from git tags pointing at HEAD. Set to true on push pipelines only.
-  - name: sast-target-dirs
-    type: string
-    default: docs,evals,scripts,src,tests
-    description: Target directories to scan with SAST tools. Multiple values should be separated with commas.
   results:
   - description: ""
     name: IMAGE_URL
@@ -490,8 +486,6 @@ spec:
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-    - name: TARGET_DIRS
-      value: $(params.sast-target-dirs)
     runAfter:
     - build-image-index
     taskRef:
@@ -542,8 +536,8 @@ spec:
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     - name: IMP_FINDINGS_ONLY
       value: "false"
-    - name: TARGET_DIRS
-      value: $(params.sast-target-dirs)
+    - name: TARGET_DIRS  # avoid scanning .git and .venv
+      value: docs,evals,scripts,src,tests
     runAfter:
     - build-image-index
     taskRef:
@@ -570,8 +564,6 @@ spec:
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-    - name: TARGET_DIRS
-      value: $(params.sast-target-dirs)
     runAfter:
     - build-image-index
     taskRef:

--- a/evals/features/cve/test_suggest_cwe.py
+++ b/evals/features/cve/test_suggest_cwe.py
@@ -929,6 +929,7 @@ cases = [
     SuggestCweCase(
         cve_id="CVE-2026-29063",
         cwe_list=["CWE-915"],
+        metadata={"known_to_fail_evaluators": ["SuggestCweEvaluator"]},
     ),
     SuggestCweCase(
         cve_id="CVE-2026-31966",


### PR DESCRIPTION
## What
Remove the shared `sast-target-dirs` pipeline parameter and drop the `TARGET_DIRS` param from the `sast-snyk-check` and `sast-unicode-check` Tekton tasks. Inline the value for `sast-shell-check`.

Also mark a flaky CWE eval case as known-to-fail.

## Why
Commit de2619cb introduced a shared `sast-target-dirs` parameter passed
as `TARGET_DIRS` to all three SAST tasks, which caused the `sast-snyk-check-oci-ta`
task to fail — snyk because it scanned non-existent directories under `/var/workdir/` and produced no output.

## How to Test
See the CI logs.

## Related Tickets
Related: https://redhat.atlassian.net/browse/AEGIS-86
Related: https://redhat.atlassian.net/browse/AEGIS-458
Related: https://redhat.atlassian.net/browse/PSSECAUT-1596

## Summary by Sourcery

Update SAST Tekton pipeline configuration to remove unsupported shared target directory parameter and mark a flaky CWE evaluation case as known to fail.

Bug Fixes:
- Fix SAST Snyk Tekton task failures by no longer passing unsupported TARGET_DIRS derived from a shared pipeline parameter.

CI:
- Remove the shared sast-target-dirs pipeline parameter and stop passing TARGET_DIRS to SAST Tekton tasks that do not support it, inlining directories only for the shell check task.

Tests:
- Mark the CVE CVE-2026-29063 CWE suggestion evaluation case as known to fail for the SuggestCweEvaluator.