### PR TITLE
Feat/configure pre commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.18
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.0
+    hooks:
+      - id: gitleaks
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-merge-conflict

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -94,6 +94,24 @@ We enforce code quality using **`ruff`** for linting and formatting. These check
     uvx ruff format .
     ```
 
+### Pre-commit Hooks
+
+The same linting and formatting checks can run automatically on every commit via [pre-commit](https://pre-commit.com/). To enable:
+
+```bash
+uv run pre-commit install
+```
+
+From that point on, each `git commit` will run ruff (lint + format), gitleaks (secret scanning), and a handful of file-hygiene checks (trailing whitespace, YAML/TOML validation, merge-conflict markers).
+
+> **Caution:** When a file-modifying hook fires, pre-commit will fail the commit and leave the fixed files as unstaged changes in the working tree. The developer then needs to review, `git add`, and commit again. So nothing lands in a commit without the developer seeing it, but **files on disk do get rewritten**.
+
+To run all hooks against the entire codebase (useful before opening a PR):
+
+```bash
+uv run pre-commit run --all-files
+```
+
 -----
 
 ## Configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ allow-direct-references = true
 dev = [
     "build>=1.2.2",
     "detect-secrets>=1.5.0",
+    "pre-commit>=4.2.0",
     "exceptiongroup>=1.3.0",
     "hatchling>=1.27.0",
     "ipdb>=0.13.13",


### PR DESCRIPTION
## What
adding pre-commit hooks

## Why
make check is manual

## How to Test

uvx pre-commit install

## Related Tickets
N/A

## Summary by Sourcery

Add and configure pre-commit hooks for code quality, formatting, and secret scanning.

New Features:
- Introduce a pre-commit configuration to run linting, formatting, secret scanning, and basic file hygiene checks on commit.

Enhancements:
- Add pre-commit to the development dependencies in pyproject.toml to support the new hook workflow.