### PR TITLE
fix(settings): treat empty env vars as unset in get_env_*()

### DIFF
--- a/src/aegis_ai/__init__.py
+++ b/src/aegis_ai/__init__.py
@@ -11,7 +11,7 @@ import warnings
 from urllib.parse import urlparse
 
 from pathlib import Path
-from typing import Dict, List, Any, Optional, TypedDict
+from typing import Dict, List, Any, Optional, TypedDict, TypeIs
 
 from platformdirs import user_config_dir
 from functools import lru_cache
@@ -50,12 +50,16 @@ config_dir = Path(user_config_dir(appname=APP_NAME))
 config_dir.mkdir(parents=True, exist_ok=True)
 
 
+def _is_env_set(value: Optional[str]) -> TypeIs[str]:
+    return bool(value and value.strip())
+
+
 def get_env_flag(key: str, default: bool) -> bool:
     """Return True if the value of env var "key" is interpreted as True.
-    Return "default" if env var "key" is not defined.
+    Return "default" if env var "key" is not defined, empty, or whitespace-only.
     Otherwise return False."""
     value = os.getenv(key)
-    if value is None:
+    if not _is_env_set(value):
         return default
 
     truthy = (
@@ -71,18 +75,18 @@ def get_env_flag(key: str, default: bool) -> bool:
 
 def get_env_float(key: str, default: float) -> float:
     """Return a float if the value of env var "key" can be interpreted as float.
-    Return "default" if env var "key" is not defined.
+    Return "default" if env var "key" is not defined, empty, or whitespace-only.
     Otherwise throw a ValueError exception."""
     value = os.getenv(key)
-    return default if value is None else float(value)
+    return float(value) if _is_env_set(value) else default
 
 
 def get_env_int(key: str, default: int) -> int:
     """Return an int if the value of env var "key" can be interpreted as int.
-    Return "default" if env var "key" is not defined.
+    Return "default" if env var "key" is not defined, empty, or whitespace-only.
     Otherwise throw a ValueError exception."""
     value = os.getenv(key)
-    return default if value is None else int(value)
+    return int(value) if _is_env_set(value) else default
 
 
 def _llm_base_url_hostname(host: str) -> Optional[str]:


### PR DESCRIPTION
## What
Treat empty (or whitespace-only) environment variables as unset in `get_env_flag()`, `get_env_float()`, and `get_env_int()`, returning the default value instead of raising a `ValueError`.

## Why
The evals GitHub Action fails with a `ValueError` when `AEGIS_LLM_TIMEOUT_SECS` is defined but empty in the GitHub project settings:

```
uv run pytest -vv -s --show-capture=no evals
ImportError while loading conftest '/home/runner/work/aegis-ai/aegis-ai/evals/conftest.py'.
evals/conftest.py:8: in <module>
    from aegis_ai import config_logging
src/aegis_ai/__init__.py:165: in <module>
    class AppSettings(BaseSettings):
src/aegis_ai/__init__.py:178: in AppSettings
    default_llm_prompt_timeout: int = get_env_int("AEGIS_LLM_TIMEOUT_SECS", 300)
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
src/aegis_ai/__init__.py:85: in get_env_int
    return default if value is None else int(value)
                                         ^^^^^^^^^^
E   ValueError: invalid literal for int() with base 10: ''
make: *** [Makefile:49: eval] Error 4
Error: Process completed with exit code 2.
```

## How to Test
```bash
AEGIS_LLM_TIMEOUT_SECS="" uv run python -c "from aegis_ai import get_env_int; print(get_env_int('AEGIS_LLM_TIMEOUT_SECS', 300))"
# Should print 300 instead of raising ValueError
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Handle empty or whitespace-only environment variables as unset when reading configuration values.

Bug Fixes:
- Prevent ValueError when environment variables expected to be numeric are defined but empty by treating them as unset and falling back to defaults.

Enhancements:
- Align get_env_flag(), get_env_float(), and get_env_int() behavior so empty or whitespace-only values consistently use the provided default.