### PR TITLE
ci-test: check updated `task-sast-snyk-check-oci-ta`

### DIFF
--- a/.tekton/aegis-build-pipeline.yaml
+++ b/.tekton/aegis-build-pipeline.yaml
@@ -499,7 +499,7 @@ spec:
       - name: name
         value: sast-snyk-check-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.5@sha256:91980bb3d6ba0b200a2030f2be0722da0fbc9338c0c6ff897d0005a2f1259a9b
+        value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.5@sha256:fda2e510511f5588de3882612f53eb06ea833889bc47da3d60ef7273555067bc
       - name: kind
         value: task
       resolver: bundles

--- a/.tekton/aegis-build-pipeline.yaml
+++ b/.tekton/aegis-build-pipeline.yaml
@@ -499,7 +499,7 @@ spec:
       - name: name
         value: sast-snyk-check-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:0ebf28a0abd5a167438d4628938a74ade6f00a44a4b7ed1cfa9cfc57a5b24748
+        value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.5@sha256:91980bb3d6ba0b200a2030f2be0722da0fbc9338c0c6ff897d0005a2f1259a9b
       - name: kind
         value: task
       resolver: bundles


### PR DESCRIPTION
## What
Verify a fix for the `task-sast-snyk-check-oci-ta` task in Konflux CI.

## Related Tickets
Related: https://redhat.atlassian.net/browse/PSSECAUT-1385

CI: skip-pr-evals

## Summary by Sourcery

CI:
- Bump the `task-sast-snyk-check-oci-ta` Tekton bundle in the aegis build pipeline from version 0.4 to 0.5.