### PR TITLE
feat(osidb-bot): create manual-triage label on failure

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -16,7 +16,7 @@ jobs:
     if: "${{ !contains(github.event.pull_request.body || '', 'CI: skip-pr-evals') }}"
     name: Run evaluation suite
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 180
     env:
       # make the tables in pydantic-eval reports readable
       COLUMNS: 512

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,20 +5,6 @@ on:
   pull_request:
 
 jobs:
-  lint:
-    name: ruff
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v7
-
-      - uses: astral-sh/ruff-action@v3
-
-      - uses: astral-sh/ruff-action@v3
-        with:
-          version: "0.11.12"
-          args: "format --check --diff"
-
   tests:
     name: pytest
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,10 @@ run-otel:
 # dev
 ############################################################################
 lint:
-	uvx ruff check
+	uv run ruff check
 
 format:
-	uvx ruff format
+	uv run ruff format
 
 check-type: fetch-deps
 	uvx ty check --exclude src/aegis_ai_ml

--- a/src/aegis_ai/__init__.py
+++ b/src/aegis_ai/__init__.py
@@ -342,9 +342,7 @@ class AppSettings(BaseSettings):
 
             return GoogleModel(
                 model_name=self.default_llm_model_name,
-                provider=GoogleProvider(
-                    **provider_kwargs
-                ),  # ty: ignore[no-matching-overload]
+                provider=GoogleProvider(**provider_kwargs),  # ty: ignore[no-matching-overload]
             )
 
         else:

--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -254,6 +254,7 @@ class FlawUpdater:
                     "state": "NEW",
                 },
             )
+            self._info(f"created label '{label_name}'")
             return True
 
         except Exception as e:
@@ -294,7 +295,7 @@ class FlawUpdater:
                 raise
 
         # apply suggestions
-        await self.apply_suggestions()
+        all_ok = await self.apply_suggestions()
 
         if self.read_only:
             msg = f"read-only mode, skipping OSIDB update of {self.updated_fields}"
@@ -324,6 +325,9 @@ class FlawUpdater:
                 )
 
         except Exception as e:
+            # failed to save changes
+            all_ok = False
+
             msg_suffix = f"({e.__class__.__name__})"
             if flaw_saved:
                 self._warn(f"failed to save RH CVSS {msg_suffix}")
@@ -350,6 +354,9 @@ class FlawUpdater:
 
         if self.updated_fields:
             self._info(f"updated {self.updated_fields}")
+
+        if not all_ok:
+            self.create_alias_label("manual-triage")
 
 
 class Bot:

--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -239,7 +239,24 @@ class FlawUpdater:
             self._warn("left unchanged")
             return False
 
-        return all_ok
+        if not all_ok:
+            # something has already failed
+            return False
+
+        aegis_meta = self.flaw_data.get("aegis_meta", {})
+        if not isinstance(aegis_meta, dict):
+            self._warn("unexpected type of aegis_meta")
+            return False
+
+        # if everything is OK check that no suggestion was discarded with this timestamp
+        return not any(
+            entry.get("type", "") == "AI-Bot-Skipped"
+            and entry.get("timestamp", None) == timestamp.isoformat()
+            for sublist in aegis_meta.values()
+            if isinstance(sublist, list)  # skip over ["processed"], which is bool
+            for entry in sublist
+            if isinstance(entry, dict)  # guard against malformed OSIDB data
+        )
 
     def create_alias_label(self, label_name: str) -> bool:
         """create a flaw label of type "alias" with name label_name, return True on success"""

--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -233,7 +233,28 @@ class FlawUpdater:
             # nothing has changed
             raise RuntimeError("left unchanged")
 
-    def _create_labels(self, flaw_uuid: str) -> None:
+    def create_alias_label(self, label_name: str) -> bool:
+        """create a flaw label of type "alias" with name label_name, return True on success"""
+        assert self.flaw_data
+        try:
+            flaw_uuid = self.flaw_data["uuid"]
+            cast(Any, self.osidb.flaws).labels.create(
+                flaw_id=flaw_uuid,
+                form_data={
+                    "label": label_name,
+                    "type": "alias",
+                    "state": "NEW",
+                },
+            )
+            return True
+
+        except Exception as e:
+            msg = f"failed to create label '{label_name}' ({e.__class__.__name__})"
+            self._warn(msg)
+            logger.debug("%s: %s", self.cve, e)
+            return False
+
+    def _create_labels(self) -> None:
         assert self.flaw_data
         entries = self.flaw_data.get("aegis_meta", {}).get(_KERNEL_FLAGS_KEY, [])
         labels: list[str] = []
@@ -246,20 +267,7 @@ class FlawUpdater:
 
         any_failed = False
         for label_name in labels:
-            try:
-                cast(Any, self.osidb.flaws).labels.create(
-                    flaw_id=flaw_uuid,
-                    form_data={
-                        "label": label_name,
-                        "type": "alias",
-                        "state": "NEW",
-                    },
-                )
-            except Exception as e:
-                self._warn(
-                    f"failed to create label '{label_name}' ({e.__class__.__name__})"
-                )
-                logger.debug("%s: %s", self.cve, e)
+            if not self.create_alias_label(label_name):
                 any_failed = True
 
         if any_failed:
@@ -330,7 +338,7 @@ class FlawUpdater:
             logger.debug(f"{self.cve}: {str(e)}")
 
         if _KERNEL_FLAGS_KEY in self.updated_fields:
-            self._create_labels(flaw_uuid)
+            self._create_labels()
 
         if self.updated_fields:
             self._info(f"updated {self.updated_fields}")

--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -211,8 +211,9 @@ class FlawUpdater:
             created_dt=datetime.fromisoformat(self.flaw_data["created_dt"]),
         )
 
-    async def apply_suggestions(self) -> None:
+    async def apply_suggestions(self) -> bool:
         assert self.flaw_data
+        all_ok: bool = True
 
         # query current server time once (before requesting suggestions)
         timestamp: Optional[datetime] = None
@@ -227,11 +228,17 @@ class FlawUpdater:
 
         # requests suggestions sequentially one by one
         for fnc in DEFAULT_SUGGESTION_LIST:
-            self.updated_fields |= await fnc(self.agent, self.flaw_data, timestamp)
+            try:
+                self.updated_fields |= await fnc(self.agent, self.flaw_data, timestamp)
+            except RuntimeError as e:
+                all_ok = False
+                self._warn(str(e))
 
         if not self.updated_fields:
             # nothing has changed
             raise RuntimeError("left unchanged")
+
+        return all_ok
 
     def create_alias_label(self, label_name: str) -> bool:
         """create a flaw label of type "alias" with name label_name, return True on success"""

--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -265,12 +265,12 @@ class FlawUpdater:
                     labels.extend(val)
         labels = list(dict.fromkeys(labels))
 
-        any_failed = False
+        any_update = False
         for label_name in labels:
-            if not self.create_alias_label(label_name):
-                any_failed = True
+            if self.create_alias_label(label_name):
+                any_update = True
 
-        if any_failed:
+        if not any_update:
             self.updated_fields.discard(_KERNEL_FLAGS_KEY)
 
     async def do(self) -> None:

--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -234,9 +234,10 @@ class FlawUpdater:
                 all_ok = False
                 self._warn(str(e))
 
-        if not self.updated_fields:
-            # nothing has changed
-            raise RuntimeError("left unchanged")
+        if not self.updated_fields and not self.force:
+            # nothing has changed (unexpectedly)
+            self._warn("left unchanged")
+            return False
 
         return all_ok
 

--- a/src/aegis_ai/osidb_bot/suggest.py
+++ b/src/aegis_ai/osidb_bot/suggest.py
@@ -55,8 +55,11 @@ async def exec_feature(feature: Feature, flaw_data: FlawData) -> Any:
         if isinstance(output, AegisFeatureModel):
             return output
 
+        # fallback for output being None or something unexpected
+        raise RuntimeError(f"exec_feature({feat_name}) got invalid output")
+
     except Exception as e:
-        msg = "exec_feature() terminated with Exception"
+        msg = f"exec_feature({feat_name}) terminated with Exception"
         logger.debug(f"{msg}: {str(e)}")
         raise RuntimeError(f"{msg}: {e.__class__.__name__}")
 
@@ -152,8 +155,6 @@ async def suggest_components(
     # request the suggestion from Aegis
     feature = cve.SuggestAffectedComponents(agent)
     output = await exec_feature(feature, flaw_data)
-    if output is None:
-        return set()
 
     changed = update_field(flaw_data, ts, "components", output)
 
@@ -170,8 +171,6 @@ async def suggest_description(
     # request the suggestion from Aegis
     feature = cve.SuggestDescriptionText(agent)
     output = await exec_feature(feature, flaw_data)
-    if output is None:
-        return set()
 
     # pick the relevant fields
     changed = update_field(flaw_data, ts, "title", output, src="suggested_title")
@@ -193,8 +192,6 @@ async def suggest_cwe(agent: Agent, flaw_data: FlawData, ts: datetime) -> set[st
     # request the suggestion from Aegis
     feature = cve.SuggestCWE(agent)
     output = await exec_feature(feature, flaw_data)
-    if output is None:
-        return set()
 
     suggested_cwes = output.cwe
     if not suggested_cwes:
@@ -220,8 +217,6 @@ async def suggest_impact(agent: Agent, flaw_data: FlawData, ts: datetime) -> set
     # request the suggestion from Aegis
     feature = cve.SuggestImpact(agent)
     output = await exec_feature(feature, flaw_data)
-    if output is None:
-        return set()
 
     if not output.impact or not output.cvss3_vector:
         cve_id = flaw_data.get("cve_id")

--- a/tests/test_flaw_updater.py
+++ b/tests/test_flaw_updater.py
@@ -158,6 +158,26 @@ async def test_flaw_updater_aegis_meta_updated_by_suggestions(mock_exec_feature)
 
 @pytest.mark.asyncio
 @patch("aegis_ai.osidb_bot.suggest.exec_feature", new_callable=AsyncMock)
+async def test_flaw_updater_apply_suggestions_returns_true_on_success(
+    mock_exec_feature,
+):
+    """apply_suggestions() returns True when all features produce high-quality output."""
+    mock_exec_feature.side_effect = _canned_exec_feature
+
+    flaw_data = _minimal_flaw_data()
+    session = _mock_session(flaw_data)
+    agent = MagicMock()
+
+    updater = FlawUpdater(session, agent, CVE_ID)
+    result = await updater.apply_suggestions()
+
+    assert result is True
+    assert updater.updated_fields
+    session.flaws.labels.create.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("aegis_ai.osidb_bot.suggest.exec_feature", new_callable=AsyncMock)
 async def test_flaw_updater_aegis_meta_entry_structure(mock_exec_feature):
     """Each aegis_meta entry has type, value, explanation, and timestamp."""
     mock_exec_feature.side_effect = _canned_exec_feature

--- a/tests/test_flaw_updater.py
+++ b/tests/test_flaw_updater.py
@@ -385,8 +385,8 @@ async def test_flaw_updater_all_skipped_records_aegis_meta(mock_exec_feature):
 
     updater = FlawUpdater(session, agent, CVE_ID)
 
-    with pytest.raises(RuntimeError, match="left unchanged"):
-        await updater.apply_suggestions()
+    result = await updater.apply_suggestions()
+    assert result is False
 
     assert updater.updated_fields == set()
 

--- a/tests/test_flaw_updater.py
+++ b/tests/test_flaw_updater.py
@@ -507,6 +507,38 @@ async def test_flaw_updater_do_creates_manual_triage_label_on_all_skipped(
 
 @pytest.mark.asyncio
 @patch("aegis_ai.osidb_bot.suggest.exec_feature", new_callable=AsyncMock)
+async def test_flaw_updater_do_creates_manual_triage_label_on_partial_failure(
+    mock_exec_feature,
+):
+    """FlawUpdater.do() creates manual-triage label when some features fail mid-run."""
+
+    async def _partial_failure_exec(feature, flaw_data):
+        name = feature.__class__.__name__
+        if name == "SuggestCWE":
+            raise RuntimeError("CWE feature crashed")
+        return await _canned_exec_feature(feature, flaw_data)
+
+    mock_exec_feature.side_effect = _partial_failure_exec
+
+    flaw_data = _minimal_flaw_data()
+    session = _mock_session(flaw_data)
+    agent = MagicMock()
+
+    updater = FlawUpdater(session, agent, CVE_ID)
+    await updater.do()
+
+    assert updater.updated_fields
+    assert "cwe_id" not in updater.updated_fields
+    assert flaw_data["aegis_meta"].get("processed") is True
+
+    session.flaws.labels.create.assert_called_once_with(
+        flaw_id=flaw_data["uuid"],
+        form_data=MANUAL_TRIAGE_LABEL,
+    )
+
+
+@pytest.mark.asyncio
+@patch("aegis_ai.osidb_bot.suggest.exec_feature", new_callable=AsyncMock)
 async def test_flaw_updater_do_creates_manual_triage_label_on_save_failure(
     mock_exec_feature,
 ):

--- a/tests/test_flaw_updater.py
+++ b/tests/test_flaw_updater.py
@@ -252,6 +252,7 @@ async def test_flaw_updater_read_only_skips_osidb_writes(mock_exec_feature):
 
     assert updater.updated_fields
     session.flaws.update.assert_not_called()
+    session.flaws.labels.create.assert_not_called()
     assert "processed" not in flaw_data.get("aegis_meta", {})
 
 
@@ -406,6 +407,25 @@ async def test_flaw_updater_all_skipped_records_aegis_meta(mock_exec_feature):
             assert entry["data_quality"] == LOW_QUALITY
             assert entry["confidence"] == LOW_CONFIDENCE
             datetime.fromisoformat(entry["timestamp"])
+
+
+@pytest.mark.asyncio
+@patch("aegis_ai.osidb_bot.suggest.exec_feature", new_callable=AsyncMock)
+async def test_flaw_updater_read_only_no_manual_triage_label(mock_exec_feature):
+    """FlawUpdater.do() with read_only=True skips manual-triage label even on failure."""
+    mock_exec_feature.side_effect = AsyncMock(
+        side_effect=RuntimeError("feature failed")
+    )
+
+    flaw_data = _minimal_flaw_data()
+    session = _mock_session(flaw_data)
+    agent = MagicMock()
+
+    updater = FlawUpdater(session, agent, CVE_ID, read_only=True)
+    await updater.do()
+
+    session.flaws.update.assert_not_called()
+    session.flaws.labels.create.assert_not_called()
 
 
 MANUAL_TRIAGE_LABEL = {

--- a/tests/test_flaw_updater.py
+++ b/tests/test_flaw_updater.py
@@ -58,6 +58,8 @@ def _mock_session(flaw_data: dict) -> MagicMock:
     session.flaws.update = MagicMock()
     session.flaws.cvss_scores = MagicMock()
     session.flaws.cvss_scores.create = MagicMock()
+    session.flaws.labels = MagicMock()
+    session.flaws.labels.create = MagicMock()
     return session
 
 
@@ -196,6 +198,8 @@ async def test_flaw_updater_do_sets_processed_in_aegis_meta(mock_exec_feature):
 
     aegis_meta = flaw_data["aegis_meta"]
     assert aegis_meta.get("processed") is True
+
+    session.flaws.labels.create.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -402,3 +406,82 @@ async def test_flaw_updater_all_skipped_records_aegis_meta(mock_exec_feature):
             assert entry["data_quality"] == LOW_QUALITY
             assert entry["confidence"] == LOW_CONFIDENCE
             datetime.fromisoformat(entry["timestamp"])
+
+
+MANUAL_TRIAGE_LABEL = {
+    "label": "manual-triage",
+    "type": "alias",
+    "state": "NEW",
+}
+
+
+@pytest.mark.asyncio
+@patch("aegis_ai.osidb_bot.suggest.exec_feature", new_callable=AsyncMock)
+async def test_flaw_updater_do_creates_manual_triage_label_on_all_skipped(
+    mock_exec_feature,
+):
+    """FlawUpdater.do() creates manual-triage label when all suggestions are discarded."""
+
+    async def _low_metrics_exec(feature, flaw_data):
+        name = feature.__class__.__name__
+        explanation = f"Low-quality output for {name}"
+        metrics = dict(data_quality=LOW_QUALITY, confidence=LOW_CONFIDENCE)
+
+        if name == "SuggestAffectedComponents":
+            return SimpleNamespace(
+                components=["kernel"], ecosystems=[], explanation=explanation, **metrics
+            )
+        if name == "SuggestDescriptionText":
+            return SimpleNamespace(
+                suggested_title="t",
+                suggested_description="d",
+                explanation=explanation,
+                **metrics,
+            )
+        if name == "SuggestCWE":
+            return SimpleNamespace(cwe=["CWE-79"], explanation=explanation, **metrics)
+        if name == "SuggestImpact":
+            return SimpleNamespace(
+                impact="LOW",
+                cvss3_score="3.7",
+                cvss3_vector="CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L",
+                explanation=explanation,
+                **metrics,
+            )
+        raise ValueError(f"Unknown feature: {name}")
+
+    mock_exec_feature.side_effect = _low_metrics_exec
+
+    flaw_data = _minimal_flaw_data()
+    session = _mock_session(flaw_data)
+    agent = MagicMock()
+
+    updater = FlawUpdater(session, agent, CVE_ID)
+    await updater.do()
+
+    session.flaws.labels.create.assert_called_once_with(
+        flaw_id=flaw_data["uuid"],
+        form_data=MANUAL_TRIAGE_LABEL,
+    )
+
+
+@pytest.mark.asyncio
+@patch("aegis_ai.osidb_bot.suggest.exec_feature", new_callable=AsyncMock)
+async def test_flaw_updater_do_creates_manual_triage_label_on_save_failure(
+    mock_exec_feature,
+):
+    """FlawUpdater.do() creates manual-triage label when flaw save fails."""
+    mock_exec_feature.side_effect = _canned_exec_feature
+
+    flaw_data = _minimal_flaw_data()
+    session = _mock_session(flaw_data)
+    session.flaws.update.side_effect = RuntimeError("OSIDB write failed")
+    agent = MagicMock()
+
+    updater = FlawUpdater(session, agent, CVE_ID)
+    await updater.do()
+
+    session.flaws.labels.create.assert_called_once_with(
+        flaw_id=flaw_data["uuid"],
+        form_data=MANUAL_TRIAGE_LABEL,
+    )

--- a/tests/test_kernel_flags.py
+++ b/tests/test_kernel_flags.py
@@ -17,9 +17,6 @@ from aegis_ai.features.cve.data_models import SuggestImpactModel
 from aegis_ai.osidb_bot.bot import FlawUpdater
 
 
-pytestmark = pytest.mark.asyncio
-
-
 CVE_ID = "CVE-2025-99999"
 
 _DISCLAIMER = (
@@ -168,6 +165,7 @@ async def _canned_exec_feature_with_flags(feature, flaw_data):
     raise ValueError(f"Unknown feature: {name}")
 
 
+@pytest.mark.asyncio
 class TestSuggestImpactExecFlagsPopulation:
     """Verify that SuggestImpact.exec() populates _flags from classifier active_features."""
 
@@ -291,6 +289,7 @@ class TestSuggestImpactExecFlagsPopulation:
         assert result.output._flags == ["kpanic"]
 
 
+@pytest.mark.asyncio
 class TestSuggestImpactAegisMetaKernelFlags:
     """Test that suggest_impact() writes kernel_flags to aegis_meta."""
 
@@ -342,6 +341,7 @@ class TestSuggestImpactAegisMetaKernelFlags:
         assert "kernel_flags" not in flaw_data.get("aegis_meta", {})
 
 
+@pytest.mark.asyncio
 class TestFlawUpdaterLabelCreation:
     """Test that FlawUpdater.do() creates alias labels for kernel_flags."""
 


### PR DESCRIPTION
## What

Harden osidb-bot failure handling, create `manual-triage` flaw labels
in OSIDB when the bot cannot fully process a flaw, and fix CI/local
ruff version divergence.

## Why

Previously, `apply_suggestions()` raised `RuntimeError` on failure, which
could abort processing and leave no trace of what happened.  Now it returns
a boolean, recovers from individual feature failures, and always records
`aegis_meta` — even when all suggestions are discarded.  Flaws that need
human attention are flagged with a `manual-triage` label so analysts can
find them.

Also fixes a CI/local divergence where `make format` used an unpinned ruff
(via `uvx`) while CI pinned a stale `0.11.12`.

## Changes

- **`apply_suggestions()` returns `bool`** instead of raising on failure;
  individual feature errors are caught and logged
- **`exec_feature()` no longer returns `None`** — callers don't need
  `None` guards; unexpected output raises `RuntimeError`
- **`aegis_meta` is always written**, even when all suggestions are
  discarded (for auditing)
- **`manual-triage` label** is created in OSIDB after the flaw save when
  suggestions are discarded, a feature fails, or the flaw save itself
  fails
- **Label creation after save** — creating the label before
  `flaws.update()` caused mid-air collisions (bumps `updated_dt`), so
  the label is now created after the save attempt
- **Malformed `aegis_meta` guard** — `isinstance` checks before
  `.values()` and `.get()` prevent crashes on unexpected OSIDB data
- **`create_alias_label()`** extracted as a public method for reuse by
  kpanic labels
- **Makefile** switched from `uvx ruff` to `uv run ruff` (uses locked
  version from `uv.lock`)
- **CI** removed redundant `lint` job (`make all` already covers it)

## How to Test

```bash
uv run aegis osidb-bot --force CVE-YYYY-NNNN
```

## Related Tickets

Related: https://redhat.atlassian.net/browse/AEGIS-457