### PR TITLE
Add KPI filters and detail enrichment for component feedback

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- KPI endpoint filters for component feedback: `cve_id`, `source_component`, and `multiple_source_components` query parameters on `GET /api/v1/analysis/kpi/cve`
+- `detail=true` on the KPI endpoint returns CVE and component diff fields (`suggested_components`, `accepted_components`, `rejected_suggestions`, `added_components`)
+- `source_component` feature alias on the KPI endpoint maps to both `source_component` and `suggest-affected-components` feedback logs
+
 ## [0.7.5] - 2026-06-26
 
 ### Changed

--- a/src/aegis_ai_web/src/data_models.py
+++ b/src/aegis_ai_web/src/data_models.py
@@ -298,6 +298,8 @@ class KPIEntry(BaseModel):
     Individual KPI entry model.
 
     Contains datetime, acceptance status, and AEGIS version for a feedback entry.
+    When ``detail=true`` is passed to the KPI endpoint, optional fields are
+    populated with CVE and component feedback context.
     """
 
     datetime: str = Field(
@@ -308,6 +310,38 @@ class KPIEntry(BaseModel):
     aegis_version: str = Field(
         default="",
         description="AEGIS version at time of feedback (may be empty string if not available)",
+    )
+    cve_id: Optional[str] = Field(
+        default=None,
+        description="CVE identifier (included when detail=true)",
+    )
+    email: Optional[str] = Field(
+        default=None,
+        description="User email from feedback (included when detail=true)",
+    )
+    feedback_source: Optional[str] = Field(
+        default=None,
+        description="Feedback origin: manual or programmatic (included when detail=true)",
+    )
+    suggested_components: Optional[List[str]] = Field(
+        default=None,
+        description="Components suggested by AEGIS (included when detail=true)",
+    )
+    submitted_components: Optional[List[str]] = Field(
+        default=None,
+        description="Components submitted by the user (included when detail=true)",
+    )
+    accepted_components: Optional[List[str]] = Field(
+        default=None,
+        description="Suggested components also present in submission (included when detail=true)",
+    )
+    rejected_suggestions: Optional[List[str]] = Field(
+        default=None,
+        description="Suggested components not present in submission (included when detail=true)",
+    )
+    added_components: Optional[List[str]] = Field(
+        default=None,
+        description="Submitted components not in the suggestion (included when detail=true)",
     )
 
 

--- a/src/aegis_ai_web/src/endpoints/kpi.py
+++ b/src/aegis_ai_web/src/endpoints/kpi.py
@@ -4,7 +4,7 @@ KPI endpoint module for CVE analysis feedback.
 
 import logging
 from datetime import datetime
-from typing import List, Dict, Any, Tuple
+from typing import List, Dict, Any, Tuple, Optional
 
 from enum import Enum
 
@@ -15,6 +15,7 @@ from aegis_ai_web.src.feedback_logger import (
     feedback_logger,
     programmatic_feedback_logger,
 )
+from aegis_ai_web.src.semantic_scoring import _parse_json_list
 
 
 class SortOrder(str, Enum):
@@ -22,6 +23,18 @@ class SortOrder(str, Enum):
 
     ASC = "asc"
     DESC = "desc"
+
+
+COMPONENT_FEATURE_KEYS = frozenset(
+    {"source_component", "suggest-affected-components"}
+)
+
+
+def _resolve_feature_aliases(query_feature: str) -> set[str]:
+    """Map component feature aliases to the same CSV feature keys."""
+    if query_feature in COMPONENT_FEATURE_KEYS:
+        return set(COMPONENT_FEATURE_KEYS)
+    return {query_feature}
 
 
 def _parse_datetime_str(dt_str: str) -> datetime:
@@ -35,30 +48,24 @@ def _parse_datetime_str(dt_str: str) -> datetime:
             return datetime.fromtimestamp(0)
 
 
-def _standard_entry_to_kpi(entry: Dict[str, Any]) -> KPIEntry:
-    """Convert standard feedback log entry to KPIEntry."""
-    accept_value = entry.get("accept", "")
-    return KPIEntry(
-        datetime=entry.get("datetime", ""),
-        accepted=accept_value == "true",
-        aegis_version=entry.get("version", ""),
-    )
+def _parse_components(value: str) -> list[str]:
+    """Parse a JSON component list from feedback CSV values."""
+    parsed = _parse_json_list(value or "")
+    return parsed or []
 
 
-def _programmatic_entry_to_kpi(entry: Dict[str, Any]) -> KPIEntry | None:
-    """Convert programmatic feedback entry to KPIEntry, or None if no valid score."""
-    score_str = entry.get("acceptance_score", "")
-    if not score_str:
-        return None
-    try:
-        score = float(score_str)
-    except ValueError:
-        return None
-    return KPIEntry(
-        datetime=entry.get("datetime", ""),
-        accepted=score == 1.0,
-        aegis_version=entry.get("version", ""),
-    )
+def _component_diff(
+    suggested: list[str], submitted: list[str]
+) -> tuple[list[str], list[str], list[str]]:
+    """Return accepted, rejected, and added component lists (case-insensitive)."""
+    suggested_map = {c.lower().strip(): c for c in suggested if c.strip()}
+    submitted_map = {c.lower().strip(): c for c in submitted if c.strip()}
+    suggested_keys = set(suggested_map)
+    submitted_keys = set(submitted_map)
+    accepted = sorted(suggested_map[k] for k in suggested_keys & submitted_keys)
+    rejected = sorted(suggested_map[k] for k in suggested_keys - submitted_keys)
+    added = sorted(submitted_map[k] for k in submitted_keys - suggested_keys)
+    return accepted, rejected, added
 
 
 def _deduplicate_programmatic_feedback(
@@ -76,7 +83,6 @@ def _deduplicate_programmatic_feedback(
     deduped: Dict[Tuple[str, str], Dict[str, Any]] = {}
 
     for entry in entries:
-        # Always overwrite the entry with the most recent one
         cve_id = entry.get("cve_id", "")
         feature = entry.get("feature", "")
         key = (cve_id, feature)
@@ -85,52 +91,207 @@ def _deduplicate_programmatic_feedback(
     return list(deduped.values())
 
 
-def _compute_kpi(entries: List[KPIEntry], order: SortOrder) -> FeatureKPI:
-    """Compute KPI metrics from a list of KPIEntry objects."""
-    if not entries:
+def _matches_entry_filters(
+    entry: Dict[str, Any],
+    *,
+    cve_id: Optional[str],
+    source_component: Optional[str],
+    multiple_source_components: bool,
+) -> bool:
+    """Apply optional CVE and component filters to a normalized feedback entry."""
+    if cve_id and entry.get("cve_id") != cve_id:
+        return False
+
+    suggested = _parse_components(entry.get("suggested_raw", ""))
+    if source_component:
+        needle = source_component.lower().strip()
+        if needle not in {c.lower().strip() for c in suggested}:
+            return False
+
+    if multiple_source_components and len(suggested) < 2:
+        return False
+
+    return True
+
+
+def _normalize_manual_entry(entry: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize a manual feedback CSV row for KPI processing."""
+    return {
+        "datetime": entry.get("datetime", ""),
+        "accepted": entry.get("accept", "") == "true",
+        "aegis_version": entry.get("version", ""),
+        "cve_id": entry.get("cve_id", ""),
+        "email": entry.get("email", ""),
+        "feedback_source": "manual",
+        "suggested_raw": entry.get("actual", ""),
+        "submitted_raw": entry.get("expected", ""),
+        "feature": entry.get("feature", ""),
+    }
+
+
+def _normalize_programmatic_entry(entry: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Normalize a programmatic feedback CSV row, or None if unscored."""
+    score_str = entry.get("acceptance_score", "")
+    if not score_str:
+        return None
+    try:
+        score = float(score_str)
+    except ValueError:
+        return None
+
+    return {
+        "datetime": entry.get("datetime", ""),
+        "accepted": score == 1.0,
+        "aegis_version": entry.get("version", ""),
+        "cve_id": entry.get("cve_id", ""),
+        "email": entry.get("email", ""),
+        "feedback_source": "programmatic",
+        "suggested_raw": entry.get("suggested_value", ""),
+        "submitted_raw": entry.get("submitted_value", ""),
+        "feature": entry.get("feature", ""),
+    }
+
+
+def _collect_normalized_entries(
+    feature: str,
+    *,
+    cve_id: Optional[str] = None,
+    source_component: Optional[str] = None,
+    multiple_source_components: bool = False,
+) -> List[Dict[str, Any]]:
+    """Read and filter feedback log entries for a feature query."""
+    if feature == "all":
+        feature_aliases = None
+    else:
+        feature_aliases = _resolve_feature_aliases(feature)
+
+    entries: List[Dict[str, Any]] = []
+
+    for raw in feedback_logger.read():
+        raw_feature = raw.get("feature")
+        if not raw_feature:
+            continue
+        if feature_aliases is not None and raw_feature not in feature_aliases:
+            continue
+        normalized = _normalize_manual_entry(raw)
+        if _matches_entry_filters(
+            normalized,
+            cve_id=cve_id,
+            source_component=source_component,
+            multiple_source_components=multiple_source_components,
+        ):
+            entries.append(normalized)
+
+    deduped_programmatic = _deduplicate_programmatic_feedback(
+        programmatic_feedback_logger.read()
+    )
+    for raw in deduped_programmatic:
+        raw_feature = raw.get("feature")
+        if not raw_feature:
+            continue
+        if feature_aliases is not None and raw_feature not in feature_aliases:
+            continue
+        normalized = _normalize_programmatic_entry(raw)
+        if normalized is None:
+            continue
+        if _matches_entry_filters(
+            normalized,
+            cve_id=cve_id,
+            source_component=source_component,
+            multiple_source_components=multiple_source_components,
+        ):
+            entries.append(normalized)
+
+    return entries
+
+
+def _to_kpi_entry(entry: Dict[str, Any], detail: bool) -> KPIEntry:
+    """Convert a normalized feedback entry to a KPIEntry response object."""
+    if not detail:
+        return KPIEntry(
+            datetime=entry["datetime"],
+            accepted=entry["accepted"],
+            aegis_version=entry["aegis_version"],
+        )
+
+    suggested = _parse_components(entry.get("suggested_raw", ""))
+    submitted = _parse_components(entry.get("submitted_raw", ""))
+    accepted_components, rejected, added = _component_diff(suggested, submitted)
+
+    return KPIEntry(
+        datetime=entry["datetime"],
+        accepted=entry["accepted"],
+        aegis_version=entry["aegis_version"],
+        cve_id=entry.get("cve_id") or None,
+        email=entry.get("email") or None,
+        feedback_source=entry.get("feedback_source"),
+        suggested_components=suggested or None,
+        submitted_components=submitted or None,
+        accepted_components=accepted_components or None,
+        rejected_suggestions=rejected or None,
+        added_components=added or None,
+    )
+
+
+def _compute_kpi(
+    normalized_entries: List[Dict[str, Any]],
+    order: SortOrder,
+    detail: bool,
+) -> FeatureKPI:
+    """Compute KPI metrics from normalized feedback entries."""
+    kpi_entries = [_to_kpi_entry(entry, detail) for entry in normalized_entries]
+    if not kpi_entries:
         return FeatureKPI(acceptance_percentage=0.0, entries=[])
 
-    entries.sort(
+    kpi_entries.sort(
         key=lambda e: _parse_datetime_str(e.datetime),
         reverse=(order == SortOrder.DESC),
     )
 
-    accepted_count = sum(1 for e in entries if e.accepted)
-    acceptance_percentage = round((accepted_count / len(entries)) * 100, 1)
+    accepted_count = sum(1 for e in kpi_entries if e.accepted)
+    acceptance_percentage = round((accepted_count / len(kpi_entries)) * 100, 1)
 
-    return FeatureKPI(acceptance_percentage=acceptance_percentage, entries=entries)
+    return FeatureKPI(
+        acceptance_percentage=acceptance_percentage,
+        entries=kpi_entries,
+    )
 
 
-def _get_all_features_kpi(order: SortOrder = SortOrder.ASC) -> Dict[str, FeatureKPI]:
+def _get_all_features_kpi(
+    order: SortOrder = SortOrder.ASC,
+    *,
+    cve_id: Optional[str] = None,
+    source_component: Optional[str] = None,
+    multiple_source_components: bool = False,
+    detail: bool = False,
+) -> Dict[str, FeatureKPI]:
     """Get KPI metrics for all features in a single pass over log data."""
-    entries_by_feature: Dict[str, List[KPIEntry]] = {}
+    entries_by_feature: Dict[str, List[Dict[str, Any]]] = {}
 
-    # Process standard feedback
-    for entry in feedback_logger.read():
-        feature = entry.get("feature")
-        if feature:
-            entries_by_feature.setdefault(feature, []).append(
-                _standard_entry_to_kpi(entry)
-            )
-
-    # Process programmatic feedback with deduplication
-    programmatic_entries = programmatic_feedback_logger.read()
-    deduped_programmatic = _deduplicate_programmatic_feedback(programmatic_entries)
-    for entry in deduped_programmatic:
-        feature = entry.get("feature")
-        if feature:
-            kpi_entry = _programmatic_entry_to_kpi(entry)
-            if kpi_entry:
-                entries_by_feature.setdefault(feature, []).append(kpi_entry)
+    for entry in _collect_normalized_entries(
+        "all",
+        cve_id=cve_id,
+        source_component=source_component,
+        multiple_source_components=multiple_source_components,
+    ):
+        feature_key = entry.get("feature", "")
+        if feature_key:
+            entries_by_feature.setdefault(feature_key, []).append(entry)
 
     return {
-        feature: _compute_kpi(entries, order)
+        feature: _compute_kpi(entries, order, detail)
         for feature, entries in entries_by_feature.items()
     }
 
 
 def get_cve_kpi(
-    feature: str, order: SortOrder = SortOrder.ASC
+    feature: str,
+    order: SortOrder = SortOrder.ASC,
+    *,
+    cve_id: Optional[str] = None,
+    source_component: Optional[str] = None,
+    multiple_source_components: bool = False,
+    detail: bool = False,
 ) -> Dict[str, FeatureKPI]:
     """
     Get KPI metrics for CVE analysis feedback filtered by feature.
@@ -138,13 +299,23 @@ def get_cve_kpi(
     Args:
         feature: Feature name to filter entries by, or "all" to get all features
         order: Sort order for datetime field (default: ASC)
+        cve_id: Optional exact CVE identifier filter
+        source_component: Optional filter for entries suggesting this component
+        multiple_source_components: When True, only entries with 2+ suggested components
+        detail: When True, include CVE and component fields on each entry
 
     Returns:
         Dict[str, FeatureKPI] mapping feature names to their KPI responses.
     """
     if feature == "all":
         try:
-            return _get_all_features_kpi(order)
+            return _get_all_features_kpi(
+                order,
+                cve_id=cve_id,
+                source_component=source_component,
+                multiple_source_components=multiple_source_components,
+                detail=detail,
+            )
         except Exception:
             logging.error(
                 "Error retrieving KPI data for all features",
@@ -156,23 +327,13 @@ def get_cve_kpi(
             )
 
     try:
-        entries: List[KPIEntry] = []
-
-        # Standard feedback
-        for entry in feedback_logger.read():
-            if entry.get("feature") == feature:
-                entries.append(_standard_entry_to_kpi(entry))
-
-        # Programmatic feedback with deduplication
-        programmatic_entries = programmatic_feedback_logger.read()
-        deduped_programmatic = _deduplicate_programmatic_feedback(programmatic_entries)
-        for entry in deduped_programmatic:
-            if entry.get("feature") == feature:
-                kpi_entry = _programmatic_entry_to_kpi(entry)
-                if kpi_entry:
-                    entries.append(kpi_entry)
-
-        return {feature: _compute_kpi(entries, order)}
+        normalized_entries = _collect_normalized_entries(
+            feature,
+            cve_id=cve_id,
+            source_component=source_component,
+            multiple_source_components=multiple_source_components,
+        )
+        return {feature: _compute_kpi(normalized_entries, order, detail)}
 
     except Exception:
         logging.error(

--- a/src/aegis_ai_web/src/main.py
+++ b/src/aegis_ai_web/src/main.py
@@ -492,6 +492,7 @@ async def component_analysis(
     summary="Get CVE Analysis KPI Metrics",
     description="Retrieve Key Performance Indicator (KPI) metrics for CVE analysis feedback, filtered by feature name. Returns a dictionary mapping feature names to their KPI responses (acceptance score percentage and all matching log entries sorted by datetime). Use feature='all' to get KPIs for all features. For single feature queries, the dict contains one key-value pair.",
     response_model=Dict[str, FeatureKPI],
+    response_model_exclude_none=True,
     responses={
         200: {
             "description": "Successful response with KPI metrics",
@@ -585,13 +586,37 @@ async def component_analysis(
 async def cve_kpi(
     feature: str = Query(
         ...,
-        description="Feature name to filter entries by. Valid values include: 'suggest-impact', 'suggest-cwe', 'suggest-description', 'suggest-statement', 'identify-pii', 'cvss-diff-explainer', or 'all' to get KPIs for all features.",
-        examples=["suggest-impact", "suggest-cwe", "suggest-description", "all"],
+        description="Feature name to filter entries by. Valid values include: 'suggest-impact', 'suggest-cwe', 'suggest-description', 'suggest-statement', 'identify-pii', 'cvss-diff-explainer', 'source_component', 'suggest-affected-components', or 'all' to get KPIs for all features.",
+        examples=[
+            "suggest-impact",
+            "source_component",
+            "suggest-affected-components",
+            "all",
+        ],
     ),
     order: SortOrder = Query(
         default=SortOrder.ASC,
         description="Sort order for datetime field. Must be 'asc' (ascending, oldest first) or 'desc' (descending, newest first). Defaults to 'asc'.",
         examples=["asc", "desc"],
+    ),
+    cve_id: Optional[str] = Query(
+        default=None,
+        description="Optional exact CVE identifier filter (e.g. CVE-2025-1234).",
+        pattern=r"^CVE-[0-9]{4}-[0-9]{4,7}$",
+        examples=["CVE-2025-1234"],
+    ),
+    source_component: Optional[str] = Query(
+        default=None,
+        description="Optional filter for entries where AEGIS suggested this component name.",
+        examples=["kernel"],
+    ),
+    multiple_source_components: bool = Query(
+        default=False,
+        description="When true, only include entries where AEGIS suggested two or more components.",
+    ),
+    detail: bool = Query(
+        default=False,
+        description="When true, include CVE and component fields on each KPI entry.",
     ),
 ) -> Dict[str, FeatureKPI]:
     """
@@ -601,8 +626,12 @@ async def cve_kpi(
     for a specific feature and returns all matching log entries sorted by datetime.
 
     **Parameters:**
-    - **feature**: Required. The feature name to filter by (e.g., 'suggest-impact', 'suggest-cwe', or 'all' for all features)
+    - **feature**: Required. The feature name to filter by (e.g., 'source_component', 'suggest-impact', or 'all')
     - **order**: Optional. Sort order for entries by datetime ('asc' or 'desc'). Defaults to 'asc'.
+    - **cve_id**: Optional. Restrict results to a single CVE.
+    - **source_component**: Optional. Restrict results to entries suggesting this component.
+    - **multiple_source_components**: Optional. Restrict to multi-component suggestions.
+    - **detail**: Optional. Include CVE/component context on each entry.
 
     **Returns:**
     - Dict[str, FeatureKPI] mapping feature names to their KPI responses.
@@ -611,13 +640,20 @@ async def cve_kpi(
 
     **Example:**
     ```
-    GET /api/v1/analysis/kpi/cve?feature=suggest-impact&order=desc
+    GET /api/v1/analysis/kpi/cve?feature=source_component&order=desc
+    GET /api/v1/analysis/kpi/cve?feature=source_component&detail=true&source_component=kernel
+    GET /api/v1/analysis/kpi/cve?feature=source_component&cve_id=CVE-2025-1234&detail=true
     GET /api/v1/analysis/kpi/cve?feature=all
     ```
     """
-    result = get_cve_kpi(feature, order)
-    # Always return Dict[str, FeatureKPI] for consistent API structure
-    # FastAPI will automatically serialize using response_model
+    result = get_cve_kpi(
+        feature,
+        order,
+        cve_id=cve_id,
+        source_component=source_component,
+        multiple_source_components=multiple_source_components,
+        detail=detail,
+    )
     return result
 
 

--- a/src/aegis_ai_web/tests/test_kpi.py
+++ b/src/aegis_ai_web/tests/test_kpi.py
@@ -1152,3 +1152,372 @@ class TestGetCveKpi:
 
         # Acceptance percentage: 1 accepted (standard), 1 rejected (programmatic) = 50%
         assert feature_data["acceptance_percentage"] == 50.0
+
+
+class TestComponentKpiHelpers:
+    """Unit tests for component KPI helper functions."""
+
+    def test_resolve_feature_aliases_for_source_component(self):
+        from aegis_ai_web.src.endpoints.kpi import _resolve_feature_aliases
+
+        aliases = _resolve_feature_aliases("source_component")
+        assert aliases == {"source_component", "suggest-affected-components"}
+
+    def test_resolve_feature_aliases_for_unrelated_feature(self):
+        from aegis_ai_web.src.endpoints.kpi import _resolve_feature_aliases
+
+        aliases = _resolve_feature_aliases("suggest-impact")
+        assert aliases == {"suggest-impact"}
+
+    def test_component_diff_exact_match(self):
+        from aegis_ai_web.src.endpoints.kpi import _component_diff
+
+        accepted, rejected, added = _component_diff(["kernel"], ["kernel"])
+        assert accepted == ["kernel"]
+        assert rejected == []
+        assert added == []
+
+    def test_component_diff_replacement(self):
+        from aegis_ai_web.src.endpoints.kpi import _component_diff
+
+        accepted, rejected, added = _component_diff(
+            ["kernel"], ["linux-kernel"]
+        )
+        assert accepted == []
+        assert rejected == ["kernel"]
+        assert added == ["linux-kernel"]
+
+    def test_component_diff_case_insensitive(self):
+        from aegis_ai_web.src.endpoints.kpi import _component_diff
+
+        accepted, rejected, added = _component_diff(["Kernel"], ["kernel"])
+        assert accepted == ["Kernel"]
+        assert rejected == []
+        assert added == []
+
+
+class TestComponentKpiFilters:
+    """Tests for source_component KPI filters and detail enrichment."""
+
+    @staticmethod
+    def _write_manual_rows(feedback_log_setup, rows):
+        with open(feedback_log_setup, "w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=FEEDBACK_SCHEMA.field_names)
+            writer.writeheader()
+            for row in rows:
+                writer.writerow(row)
+
+    @staticmethod
+    def _write_programmatic_rows(programmatic_feedback_log_setup, rows):
+        with open(
+            programmatic_feedback_log_setup, "w", newline="", encoding="utf-8"
+        ) as f:
+            writer = csv.DictWriter(
+                f, fieldnames=PROGRAMMATIC_FEEDBACK_SCHEMA.field_names
+            )
+            writer.writeheader()
+            for row in rows:
+                writer.writerow(row)
+
+    @staticmethod
+    def _component_rows():
+        return [
+            {
+                "datetime": "2026-03-19 21:52:24.452",
+                "feature": "source_component",
+                "cve_id": "CVE-2025-1001",
+                "email": "analyst@example.com",
+                "actual": '["kernel"]',
+                "expected": '["kernel"]',
+                "request_time": "2026-03-19 21:52:00",
+                "accept": "True",
+                "rejection_comment": "",
+                "version": "0.6.1",
+            },
+            {
+                "datetime": "2026-03-19 22:48:41.298",
+                "feature": "source_component",
+                "cve_id": "CVE-2025-1002",
+                "email": "analyst@example.com",
+                "actual": '["kernel"]',
+                "expected": '["linux-kernel"]',
+                "request_time": "2026-03-19 22:48:00",
+                "accept": "False",
+                "rejection_comment": "Wrong component",
+                "version": "0.6.1",
+            },
+            {
+                "datetime": "2026-03-20 13:16:01.227",
+                "feature": "source_component",
+                "cve_id": "CVE-2025-1003",
+                "email": "analyst@example.com",
+                "actual": '["kernel", "curl"]',
+                "expected": '["kernel"]',
+                "request_time": "2026-03-20 13:16:00",
+                "accept": "False",
+                "rejection_comment": "",
+                "version": "0.6.1",
+            },
+            {
+                "datetime": "2026-03-20 13:25:28.637",
+                "feature": "suggest-impact",
+                "cve_id": "CVE-2025-1004",
+                "email": "analyst@example.com",
+                "actual": "IMPORTANT",
+                "expected": "CRITICAL",
+                "request_time": "2026-03-20 13:25:00",
+                "accept": "False",
+                "rejection_comment": "",
+                "version": "0.6.1",
+            },
+        ]
+
+    def test_filter_by_cve_id(self, feedback_log_setup):
+        from aegis_ai_web.src.endpoints.kpi import get_cve_kpi
+
+        self._write_manual_rows(feedback_log_setup, self._component_rows())
+
+        result = get_cve_kpi(
+            "source_component",
+            cve_id="CVE-2025-1002",
+            detail=True,
+        )
+        data = result["source_component"]
+
+        assert len(data.entries) == 1
+        assert data.entries[0].cve_id == "CVE-2025-1002"
+        assert data.entries[0].accepted is False
+        assert data.acceptance_percentage == 0.0
+
+    def test_filter_by_source_component(self, feedback_log_setup):
+        from aegis_ai_web.src.endpoints.kpi import get_cve_kpi
+
+        self._write_manual_rows(feedback_log_setup, self._component_rows())
+
+        result = get_cve_kpi(
+            "source_component",
+            source_component="curl",
+            detail=True,
+        )
+        data = result["source_component"]
+
+        assert len(data.entries) == 1
+        assert data.entries[0].cve_id == "CVE-2025-1003"
+        assert data.entries[0].suggested_components == ["kernel", "curl"]
+
+    def test_filter_multiple_source_components(self, feedback_log_setup):
+        from aegis_ai_web.src.endpoints.kpi import get_cve_kpi
+
+        self._write_manual_rows(feedback_log_setup, self._component_rows())
+
+        result = get_cve_kpi(
+            "source_component",
+            multiple_source_components=True,
+            detail=True,
+        )
+        data = result["source_component"]
+
+        assert len(data.entries) == 1
+        assert data.entries[0].cve_id == "CVE-2025-1003"
+        assert len(data.entries[0].suggested_components) == 2
+
+    def test_detail_includes_component_replacement_fields(self, feedback_log_setup):
+        from aegis_ai_web.src.endpoints.kpi import get_cve_kpi
+
+        self._write_manual_rows(feedback_log_setup, self._component_rows())
+
+        result = get_cve_kpi(
+            "source_component",
+            cve_id="CVE-2025-1002",
+            detail=True,
+        )
+        entry = result["source_component"].entries[0]
+
+        assert entry.cve_id == "CVE-2025-1002"
+        assert entry.email == "analyst@example.com"
+        assert entry.feedback_source == "manual"
+        assert entry.suggested_components == ["kernel"]
+        assert entry.submitted_components == ["linux-kernel"]
+        assert entry.rejected_suggestions == ["kernel"]
+        assert entry.added_components == ["linux-kernel"]
+
+    def test_detail_false_keeps_legacy_entry_shape(self, feedback_log_setup):
+        from aegis_ai_web.src.endpoints.kpi import get_cve_kpi
+
+        self._write_manual_rows(feedback_log_setup, self._component_rows())
+
+        result = get_cve_kpi("source_component", detail=False)
+        entry = result["source_component"].entries[0]
+        payload = entry.model_dump(exclude_none=True)
+
+        assert payload == {
+            "datetime": "2026-03-19 21:52:24.452",
+            "accepted": True,
+            "aegis_version": "0.6.1",
+        }
+
+    def test_feature_alias_suggest_affected_components(self, feedback_log_setup):
+        from aegis_ai_web.src.endpoints.kpi import get_cve_kpi
+
+        self._write_manual_rows(
+            feedback_log_setup,
+            [
+                {
+                    "datetime": "2026-03-19 21:52:24.452",
+                    "feature": "suggest-affected-components",
+                    "cve_id": "CVE-2025-2001",
+                    "email": "analyst@example.com",
+                    "actual": '["openssl"]',
+                    "expected": '["openssl"]',
+                    "request_time": "2026-03-19 21:52:00",
+                    "accept": "True",
+                    "rejection_comment": "",
+                    "version": "0.6.1",
+                }
+            ],
+        )
+
+        result = get_cve_kpi("source_component", detail=True)
+        data = result["source_component"]
+
+        assert len(data.entries) == 1
+        assert data.entries[0].cve_id == "CVE-2025-2001"
+        assert data.entries[0].suggested_components == ["openssl"]
+
+    def test_filters_recompute_acceptance_percentage(self, feedback_log_setup):
+        from aegis_ai_web.src.endpoints.kpi import get_cve_kpi
+
+        self._write_manual_rows(feedback_log_setup, self._component_rows())
+
+        unfiltered = get_cve_kpi("source_component")
+        filtered = get_cve_kpi(
+            "source_component",
+            source_component="curl",
+        )
+
+        assert unfiltered["source_component"].acceptance_percentage == 33.3
+        assert len(unfiltered["source_component"].entries) == 3
+        assert filtered["source_component"].acceptance_percentage == 0.0
+        assert len(filtered["source_component"].entries) == 1
+
+    def test_includes_scored_programmatic_component_feedback(
+        self, feedback_log_setup, programmatic_feedback_log_setup
+    ):
+        from aegis_ai_web.src.endpoints.kpi import get_cve_kpi
+
+        self._write_programmatic_rows(
+            programmatic_feedback_log_setup,
+            [
+                {
+                    "datetime": "2026-03-21 10:00:00.123",
+                    "feature": "source_component",
+                    "cve_id": "CVE-2025-3001",
+                    "email": "bot@example.com",
+                    "suggested_value": '["kernel"]',
+                    "submitted_value": '["linux-kernel"]',
+                    "acceptance_score": "0.0",
+                    "llmjudge_explanation": "",
+                    "version": "0.6.1",
+                }
+            ],
+        )
+
+        result = get_cve_kpi("source_component", detail=True)
+        entry = result["source_component"].entries[0]
+
+        assert entry.cve_id == "CVE-2025-3001"
+        assert entry.feedback_source == "programmatic"
+        assert entry.accepted is False
+        assert entry.rejected_suggestions == ["kernel"]
+        assert entry.added_components == ["linux-kernel"]
+
+    def test_combined_cve_and_source_component_filters(self, feedback_log_setup):
+        from aegis_ai_web.src.endpoints.kpi import get_cve_kpi
+
+        self._write_manual_rows(feedback_log_setup, self._component_rows())
+
+        result = get_cve_kpi(
+            "source_component",
+            cve_id="CVE-2025-1003",
+            source_component="kernel",
+            detail=True,
+        )
+        data = result["source_component"]
+
+        assert len(data.entries) == 1
+        assert data.entries[0].cve_id == "CVE-2025-1003"
+
+    def test_no_matches_returns_empty_result(self, feedback_log_setup):
+        from aegis_ai_web.src.endpoints.kpi import get_cve_kpi
+
+        self._write_manual_rows(feedback_log_setup, self._component_rows())
+
+        result = get_cve_kpi(
+            "source_component",
+            cve_id="CVE-2099-0001",
+        )
+        data = result["source_component"]
+
+        assert data.entries == []
+        assert data.acceptance_percentage == 0.0
+
+
+class TestComponentKpiApi:
+    """HTTP tests for wired KPI query parameters."""
+
+    def test_api_default_response_shape(self, feedback_log_setup):
+        TestComponentKpiFilters._write_manual_rows(
+            feedback_log_setup, TestComponentKpiFilters._component_rows()
+        )
+
+        response = client.get("/api/v1/analysis/kpi/cve?feature=source_component")
+        assert response.status_code == 200
+        data = response.json()
+        assert "source_component" in data
+        assert len(data["source_component"]["entries"]) == 3
+        assert set(data["source_component"]["entries"][0].keys()) == {
+            "datetime",
+            "accepted",
+            "aegis_version",
+        }
+
+    def test_api_detail_and_filters(self, feedback_log_setup):
+        TestComponentKpiFilters._write_manual_rows(
+            feedback_log_setup, TestComponentKpiFilters._component_rows()
+        )
+
+        response = client.get(
+            "/api/v1/analysis/kpi/cve"
+            "?feature=source_component"
+            "&detail=true"
+            "&cve_id=CVE-2025-1002"
+        )
+        assert response.status_code == 200
+        entry = response.json()["source_component"]["entries"][0]
+        assert entry["cve_id"] == "CVE-2025-1002"
+        assert entry["suggested_components"] == ["kernel"]
+        assert entry["submitted_components"] == ["linux-kernel"]
+        assert entry["rejected_suggestions"] == ["kernel"]
+        assert entry["added_components"] == ["linux-kernel"]
+
+    def test_api_multiple_source_components_filter(self, feedback_log_setup):
+        TestComponentKpiFilters._write_manual_rows(
+            feedback_log_setup, TestComponentKpiFilters._component_rows()
+        )
+
+        response = client.get(
+            "/api/v1/analysis/kpi/cve"
+            "?feature=source_component"
+            "&multiple_source_components=true"
+            "&detail=true"
+        )
+        assert response.status_code == 200
+        entries = response.json()["source_component"]["entries"]
+        assert len(entries) == 1
+        assert entries[0]["cve_id"] == "CVE-2025-1003"
+
+    def test_api_invalid_cve_id_returns_422(self, feedback_log_setup):
+        response = client.get(
+            "/api/v1/analysis/kpi/cve?feature=source_component&cve_id=not-a-cve"
+        )
+        assert response.status_code == 422


### PR DESCRIPTION
## What
Extend `GET /api/v1/analysis/kpi/cve` with component feedback filters and optional detail enrichment.

## Why
Analysts need to query KPI data by CVE, suggested component, and multi-component suggestions, and inspect component diffs (accepted/rejected/added) without post-processing raw feedback logs.

## How
- Add query params: `cve_id`, `source_component`, `multiple_source_components`, `detail`
- Map `source_component` feature alias to both `source_component` and `suggest-affected-components` log entries
- Return optional `KPIEntry` fields when `detail=true` (`suggested_components`, `accepted_components`, `rejected_suggestions`, `added_components`, etc.)
- Set `response_model_exclude_none=True` so detail=false responses stay compact

## How to Test
```bash
uv run pytest src/aegis_ai_web/tests/test_kpi.py -q
```

After staging deploy:
```bash
curl --negotiate -u : -f \
  'https://aegis.prodsec.redhat.com/api/v1/analysis/kpi/cve?feature=source_component&source_component=kernel&detail=true'
```

## Related Tickets

## Summary by Sourcery

Extend the CVE KPI endpoint to support component feedback filtering and optional detail fields for enriched analysis.

New Features:
- Add component-specific KPI query parameters (cve_id, source_component, multiple_source_components, detail) to GET /api/v1/analysis/kpi/cve.
- Expose optional CVE and component context fields on KPI entries when detail=true, including suggested, submitted, accepted, rejected, and added components.
- Support source_component feature aliasing so KPI queries cover both source_component and suggest-affected-components feedback logs.

Enhancements:
- Refactor KPI computation to normalize manual and programmatic feedback entries, apply filters, and compute acceptance metrics from a unified representation.
- Ensure KPI API responses omit null fields via response_model_exclude_none for compact payloads when detail=false.

Documentation:
- Document the new KPI query parameters and enriched entry fields in the FastAPI endpoint docs and CHANGELOG, including component feedback filtering behavior.

Tests:
- Add unit and HTTP tests covering component alias resolution, component diffing, new KPI filters, detail enrichment behavior, and validation of CVE identifiers.