### PR TITLE
fix(osidb-bot): process flaws with empty workflow state again

### DIFF
--- a/evals/features/cve/test_suggest_statement.py
+++ b/evals/features/cve/test_suggest_statement.py
@@ -510,6 +510,7 @@ cases = [
             "of the flaw can lead to the exfiltration of all cluster-wide secrets, posing a "
             "significant risk to the integrity and confidentiality of the OpenShift environment."
         ),
+        metadata={"known_to_fail_evaluators": ["StatementNoDuplicatedInfo"]},
     ),
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "pydantic>=2.12.4",
     # Use slim provider set to avoid pulling AWS Bedrock (boto3/botocore)
     "pydantic-ai-slim[openai,google,anthropic,duckduckgo,mcp,tavily]>=1.20.0",
+    "pytimeparse2>=1.7.1",
     # Required by evaluation suite (imports `pydantic_evals`)
     "pydantic-evals>=1.20.0",
     "pygithub>=2.7.0",

--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -116,7 +116,7 @@ class FlawFinder:
     ) -> Sequence[CVEID]:
         # infer search predicates from ELIGIBLE_FLAWS
         kwargs: dict[str, Any] = {
-            "include_fields": ["cve_id"],
+            "include_fields": ["cve_id", "classification"],
             "cve_id__isempty": False,  # only flaws with a CVE ID
             "order": ["created_dt"],
             "source_in": [s for s in ELIGIBLE_FLAWS["source"]],
@@ -152,7 +152,15 @@ class FlawFinder:
         # initiate the OSIDB search
         logger.info("searching CVEs: %s", _kwargs_for_log(kwargs))
         flaw_iterator = self.osidb.flaws.retrieve_list_iterator(**kwargs)
-        cve_ids = [flaw.cve_id for flaw in flaw_iterator]
+        cve_ids = [
+            flaw.cve_id
+            for flaw in flaw_iterator
+            if flaw.classification.to_dict()
+            in ELIGIBLE_FLAWS[
+                "classification"
+            ]  # workflow is not available as a search predicate
+        ]
+
         if state is None:
             return cve_ids
 

--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -106,7 +106,11 @@ class FlawFinder:
     def __init__(self, osidb: Session) -> None:
         self.osidb = osidb
 
-    def search(self, state: Optional[BotState] = None) -> Sequence[CVEID]:
+    def search(
+        self,
+        state: Optional[BotState] = None,
+        age_cutoff: Optional[datetime] = None,
+    ) -> Sequence[CVEID]:
         # infer search predicates from ELIGIBLE_FLAWS
         kwargs: dict[str, Any] = {
             "include_fields": ["cve_id"],
@@ -131,9 +135,16 @@ class FlawFinder:
                 key = f"{field}_isempty"
                 kwargs[key] = True
 
-        # filter by timestamp if state file is used
-        if state is not None:
-            kwargs["created_dt_gte"] = state.created_dt
+        # compute the lower bound on created_dt
+        created_dt_gte: Optional[datetime]
+        if state is None:
+            created_dt_gte = age_cutoff
+        elif age_cutoff is None:
+            created_dt_gte = state.created_dt
+        else:
+            created_dt_gte = max(state.created_dt, age_cutoff)
+        if created_dt_gte is not None:
+            kwargs["created_dt_gte"] = created_dt_gte
 
         # initiate the OSIDB search
         logger.info("searching CVEs: %s", _kwargs_for_log(kwargs))
@@ -384,6 +395,7 @@ class Bot:
     pending: dict[BotState, bool]
     force: bool
     read_only: bool
+    age_cutoff: Optional[datetime]
 
     def __init__(
         self,
@@ -392,11 +404,13 @@ class Bot:
         *,
         force: bool = False,
         read_only: bool = False,
+        age_cutoff: Optional[datetime] = None,
     ):
         self.sfh = state_file_handler
         self.agent = agent
         self.force = force
         self.read_only = read_only
+        self.age_cutoff = age_cutoff
         self.total = 0
         self.pending = {}
         try:
@@ -411,7 +425,10 @@ class Bot:
 
     def search_cve_ids(self) -> Sequence[CVEID]:
         finder = FlawFinder(self.osidb)
-        return finder.search(state=self.sfh.read_state())
+        return finder.search(
+            state=self.sfh.read_state(),
+            age_cutoff=self.age_cutoff,
+        )
 
     async def process_cve(self, cve: CVEID) -> None:
         flaw_updater: Optional[FlawUpdater] = None

--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -45,8 +45,11 @@ ELIGIBLE_FLAWS = {
         "UBUNTU",
         "UPSTREAM",
     ),
-    # only flaws in the NEW state
-    "classification": ({"workflow": "DEFAULT", "state": "NEW"},),
+    # only flaws in the empty/NEW states
+    "classification": (
+        {"workflow": "DEFAULT", "state": ""},
+        {"workflow": "DEFAULT", "state": "NEW"},
+    ),
     # only flaws where Aegis has not been used yet
     "aegis_meta": ({},),
     # only flaws with no affects

--- a/src/aegis_ai_cli/main.py
+++ b/src/aegis_ai_cli/main.py
@@ -31,6 +31,9 @@ else:
 
     cli_agent = rh_feature_agent
 
+# default value for `aegis osidb-bot --max-age=...`
+DEFAULT_MAX_AGE = "1y"
+
 
 @click.group()
 @click.option(
@@ -408,17 +411,39 @@ def component_intelligence(component_name):
     default=False,
     help="Skip OSIDB data updates (dry run).",
 )
+@click.option(
+    "--max-age",
+    type=str,
+    default=None,
+    help=f"Maximum flaw age, e.g. 7d (days), 4w (weeks), 5y (years). Default: {DEFAULT_MAX_AGE}.",
+)
 @click.argument("cve_ids", nargs=-1, type=CVEID)
-def osidb_bot(state_file, force, read_only, cve_ids):
+def osidb_bot(state_file, force, read_only, max_age, cve_ids):
     """
     OSIDB bot: process CVE IDs (optional) with optional state file.
     """
     # lazy import to speed up basic Aegis CLI operations
+    from pytimeparse2 import parse as parse_duration
+
     from aegis_ai.osidb_bot import Bot, StateFileHandler, logger
     from aegis_ai.osidb_bot.util import log_memory
 
     # avoid logging tracebacks when GSSAPI auth fails
     logging.getLogger("requests_gssapi").setLevel(logging.CRITICAL)
+
+    # parse --max-age and compute a cutoff datetime
+    from datetime import datetime, timedelta, timezone
+
+    age_str = max_age or DEFAULT_MAX_AGE
+    parsed = parse_duration(age_str)
+    if not isinstance(parsed, (int, float)):
+        raise click.BadParameter(
+            f"invalid duration: {age_str!r}", param_hint="--max-age"
+        )
+    age_cutoff = datetime.now(tz=timezone.utc) - timedelta(seconds=parsed)
+
+    if cve_ids and max_age is not None:
+        logger.warning("--max-age has no effect when CVE IDs are given as arguments")
 
     log_memory("cli_entry")
 
@@ -426,7 +451,9 @@ def osidb_bot(state_file, force, read_only, cve_ids):
         # this prevents multiple processes running in parallel on a single state file
         # (if state_file is not None)
         with StateFileHandler(state_file) as sfh:
-            osidb_bot = Bot(sfh, cli_agent, force=force, read_only=read_only)
+            osidb_bot = Bot(
+                sfh, cli_agent, force=force, read_only=read_only, age_cutoff=age_cutoff
+            )
             log_memory("bot_created")
             runner = osidb_bot.process(cve_ids)
             asyncio.run(runner)

--- a/uv.lock
+++ b/uv.lock
@@ -54,6 +54,7 @@ dependencies = [
     { name = "pydantic-ai-slim", extra = ["anthropic", "duckduckgo", "google", "mcp", "openai", "tavily"] },
     { name = "pydantic-evals" },
     { name = "pygithub" },
+    { name = "pytimeparse2" },
     { name = "requests-gssapi" },
     { name = "rich" },
     { name = "uv" },
@@ -148,6 +149,7 @@ requires-dist = [
     { name = "pydantic-ai-slim", extras = ["anthropic", "duckduckgo", "google", "mcp", "openai", "tavily"], specifier = ">=1.20.0" },
     { name = "pydantic-evals", specifier = ">=1.20.0" },
     { name = "pygithub", specifier = ">=2.7.0" },
+    { name = "pytimeparse2", specifier = ">=1.7.1" },
     { name = "requests-gssapi", specifier = ">=1.4.0" },
     { name = "rich", specifier = ">=14.0.0" },
     { name = "scikit-learn", marker = "extra == 'classifier-deps'", specifier = ">=1.1.0" },
@@ -3938,6 +3940,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
+name = "pytimeparse2"
+version = "1.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/10/cc63fecd69905eb4d300fe71bd580e4a631483e9f53fdcb8c0ad345ce832/pytimeparse2-1.7.1.tar.gz", hash = "sha256:98668cdcba4890e1789e432e8ea0059ccf72402f13f5d52be15bdfaeb3a8b253", size = 10431, upload-time = "2023-05-11T21:40:55.774Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/9e/85abf91ef5df452f56498927affdb7128194d15644084f6c6722477c305b/pytimeparse2-1.7.1-py3-none-any.whl", hash = "sha256:a162ea6a7707fd0bb82dd99556efb783935f51885c8bdced0fce3fffe85ab002", size = 6136, upload-time = "2023-05-11T21:40:46.051Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -519,16 +519,16 @@ wheels = [
 
 [[package]]
 name = "build"
-version = "1.5.0"
+version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "os_name == 'nt'" },
     { name = "packaging" },
     { name = "pyproject-hooks" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/78/e0/df5e171f685f82f37b12e1f208064e24244911079d7b767447d1af7e0d70/build-1.5.0.tar.gz", hash = "sha256:302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647", size = 89796, upload-time = "2026-04-30T03:18:25.17Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/21/6ec54248b4d0d51f12f3ca4aa77a128077d747a5db86cb5a2fcd9aedecbd/build-1.5.1.tar.gz", hash = "sha256:94e17f1db803ab22f46049376c44c8437c52090f0dfdf1adc43df56542d644fb", size = 112439, upload-time = "2026-07-09T06:21:59.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl", hash = "sha256:13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f", size = 26018, upload-time = "2026-04-30T03:18:23.644Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f7/2c3f99ff9282f1c1ec9f6298f2c03034658a0901eeacb3b3501cb488574c/build-1.5.1-py3-none-any.whl", hash = "sha256:f1a58fe2e5af5b0238a07b9e70207492c79ddebbdb1ad954fc86d62a56be3e0d", size = 31195, upload-time = "2026-07-09T06:21:58.551Z" },
 ]
 
 [[package]]
@@ -899,7 +899,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "python_full_version < '3.15' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/6e/2394f8163360f8391f8f1b7e72d300a82724edb81a7b7084c799fbd4c91f/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9efb21c1ee64981e184b9e0ba5eb3179e5ba3d4b51665a6cb52b8ef3d01a7cbf", size = 5920504, upload-time = "2026-05-29T23:11:56.883Z" },
@@ -928,43 +928,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-runtime", marker = "(python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufft", marker = "(python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-cupti", marker = "(python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-curand", marker = "(python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusolver", marker = "(python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusparse", marker = "(python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "(python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvtx", marker = "(python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 
 [[package]]
@@ -2679,7 +2679,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -2718,7 +2718,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -2730,7 +2730,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -2760,9 +2760,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
+    { name = "nvidia-cusparse", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -2774,7 +2774,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -3154,7 +3154,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -4407,8 +4407,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
+    { name = "jeepney", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
## What

Re-enables processing of flaws with empty workflow state and adds a new `--max-age` option to `aegis osidb-bot` that limits the OSIDB search window by `created_dt` (defaults to 1 year).

## Why

Commit 2672e0437f7b excluded flaws with empty workflow state from `ELIGIBLE_FLAWS` to work around a problem where osidb-bot iterated through 20000+ (mostly ineligible) CVEs when the state file was lost or corrupted. However, this caused Aegis to silently skip real CVEs — reported in AEGIS-465 as missed by osidb-bot.

The new `--max-age` option (using `pytimeparse2` for human-readable duration parsing) properly bounds the search window, making the empty-state exclusion workaround unnecessary.

## How to Test

```bash
# verify the new option appears
uv run aegis osidb-bot --help

# dry-run with explicit max-age
uv run aegis osidb-bot --max-age 7d --read-only

# warning when combining --max-age with explicit CVE IDs
uv run aegis osidb-bot --max-age 2w --read-only CVE-2025-1234
```

## Related Tickets
Related: https://redhat.atlassian.net/browse/AEGIS-465