### PR TITLE
feat: add retry mechanism for failed CVEs in osidb-bot

### DIFF
--- a/evals/conftest.py
+++ b/evals/conftest.py
@@ -151,18 +151,11 @@ def setup_logging_for_session():
         logging.getLogger(noisy_logger).setLevel(logging.WARNING)
 
     # Suppress the "[tool call] ..." logs ONLY during eval runs
-    class _SuppressToolCallFilter(logging.Filter):
-        def filter(self, record: logging.LogRecord) -> bool:
-            try:
-                msg = record.getMessage()
-            except Exception:
-                return True
-            return not msg.startswith("[tool call] ")
-
-    # Skip suppression of logged tool during evals if user explicitly enables
-    #  verbose logging via env var
+    # Skip suppression if user explicitly enables verbose logging via env var
     if not os.getenv("AEGIS_LOGGING_EVALS_VERBOSE"):
-        logging.getLogger("aegis_ai.toolsets").addFilter(_SuppressToolCallFilter())
+        from aegis_ai import SuppressToolCallFilter
+
+        logging.getLogger("aegis_ai.toolsets").addFilter(SuppressToolCallFilter())
 
 
 # Cache OSIDB responses (maintained in git) so evals are invariant to

--- a/evals/features/cve/test_suggest_statement.py
+++ b/evals/features/cve/test_suggest_statement.py
@@ -441,7 +441,12 @@ cases = [
     SuggestStatementCase(
         cve_id="CVE-2026-4271",
         expected_mitigation="Mitigation for this issue is either not available or the currently available options don't meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability.",
-        metadata={"known_to_fail_evaluators": ["MitigationEvaluator"]},
+        metadata={
+            "known_to_fail_evaluators": [
+                "MitigationEvaluator",
+                "StatementNoDuplicatedInfo",
+            ]
+        },
     ),
     SuggestStatementCase(
         cve_id="CVE-2026-5483",

--- a/src/aegis_ai/__init__.py
+++ b/src/aegis_ai/__init__.py
@@ -133,6 +133,17 @@ class LivenessProbeLogFilter(logging.Filter):
         return args[1:] != ("GET", "/healthz", "1.1", 204)
 
 
+class SuppressToolCallFilter(logging.Filter):
+    """Suppress verbose '[tool call] ...' log lines from toolset loggers."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        try:
+            msg = record.getMessage()
+        except Exception:
+            return True
+        return not msg.startswith("[tool call] ")
+
+
 class SuppressThirdPartyTracebackFilter(logging.Filter):
     """
     Remove exception tracebacks from selected third-party loggers (Kerberos/GSSAPI)

--- a/src/aegis_ai/osidb_bot/__init__.py
+++ b/src/aegis_ai/osidb_bot/__init__.py
@@ -1,4 +1,5 @@
 from .bot import Bot as Bot
+from .state import BotPosition as BotPosition
 from .state import StateFileHandler as StateFileHandler
 from .state import StateProxy as StateProxy
 from .util import logger as logger

--- a/src/aegis_ai/osidb_bot/__init__.py
+++ b/src/aegis_ai/osidb_bot/__init__.py
@@ -1,3 +1,4 @@
 from .bot import Bot as Bot
 from .state import StateFileHandler as StateFileHandler
+from .state import StateProxy as StateProxy
 from .util import logger as logger

--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -543,4 +543,7 @@ class Bot(StateProxy):
         if self.retry_list:
             logger.info("retrying failed CVEs")
             self.retrying_failed = True
-            await self._process_cve_list(list(self.retry_list))
+
+            # sort the list such that CVEs with fewer remaining retry attempts are processed first
+            retry_cves = sorted(self.retry_list, key=self.retry_list.__getitem__)
+            await self._process_cve_list(retry_cves)

--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -467,6 +467,12 @@ class Bot(StateProxy):
         except RuntimeError as e:
             # something has failed
             logger.warning(f"{cve}: {str(e)}")
+            if flaw_updater:
+                if (not self.retrying_failed and not self.max_retries) or (
+                    self.retrying_failed and self.retry_list.get(cve) == 1
+                ):
+                    # the last retry attempt failed, create the manual-triage label
+                    flaw_updater.create_alias_label("manual-triage")
             if self.max_retries > 0 and not self.retrying_failed:
                 self.retry_list[cve] = self.max_retries
 

--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -187,6 +187,7 @@ class FlawUpdater:
     force: bool
     read_only: bool
     retry_list: dict[str, int]
+    on_failure: Any
 
     # OSIDB flaw from session.flaws.retrieve()
     flaw_data: Optional[FlawData]
@@ -203,6 +204,7 @@ class FlawUpdater:
         force: bool = False,
         read_only: bool = False,
         retry_list: Optional[dict[str, int]] = None,
+        on_failure: Any = None,
     ):
         self.osidb = osidb
         self.agent = agent
@@ -210,6 +212,7 @@ class FlawUpdater:
         self.force = force
         self.read_only = read_only
         self.retry_list = retry_list or {}
+        self.on_failure = on_failure
         self.updated_fields = set()
 
         try:
@@ -372,7 +375,7 @@ class FlawUpdater:
 
         except Exception as e:
             # failed to save changes
-            all_ok = False
+            all_ok = self.on_failure(self.cve) if self.on_failure else False
 
             msg_suffix = f"({e.__class__.__name__})"
             if flaw_saved:
@@ -473,6 +476,7 @@ class Bot(StateProxy):
                 force=self.force,
                 read_only=self.read_only,
                 retry_list=self.retry_list,
+                on_failure=self.schedule_retry,
             )
             if not self.retrying_failed:
                 self.pending[flaw_updater.position()] = True  # mark as pending

--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -18,6 +18,10 @@ from datetime import datetime, timezone
 from typing import Any, Optional, Sequence, cast
 
 
+class FlawValidationError(RuntimeError):
+    """Raised when a flaw fails eligibility validation."""
+
+
 ELIGIBLE_FLAWS = {
     # only flaws coming from the following sources
     "source": (
@@ -177,7 +181,7 @@ class FlawFinder:
 
             short_value = textwrap.shorten(str(value), width=64, placeholder=" [...]")
             msg = f'skipped because {field}="{short_value}", allowed={allowed}'
-            raise RuntimeError(msg)
+            raise FlawValidationError(msg)
 
 
 class FlawUpdater:
@@ -488,8 +492,12 @@ class Bot(StateProxy):
             # something has failed
             logger.warning(f"{cve}: {str(e)}")
 
-            # schedule retry if enabled
-            if not self.schedule_retry(cve) and flaw_updater:
+            # schedule retry if enabled (but not for validation failures)
+            if (
+                not isinstance(e, FlawValidationError)
+                and not self.schedule_retry(cve)
+                and flaw_updater
+            ):
                 # the last retry attempt failed, create the manual-triage label
                 flaw_updater.create_alias_label("manual-triage")
 

--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -405,7 +405,6 @@ class Bot:
     sfh: StateFileHandler
     agent: Agent
     osidb: Session
-    total: int
     pending: dict[BotState, bool]
     force: bool
     read_only: bool
@@ -425,7 +424,6 @@ class Bot:
         self.force = force
         self.read_only = read_only
         self.age_cutoff = age_cutoff
-        self.total = 0
         self.pending = {}
         try:
             osidb_server = get_settings().osidb_server_url
@@ -482,25 +480,26 @@ class Bot:
                 # update state file
                 self.sfh.write_state(state)
 
-    async def process_cve_bounded(self, i: int, cve: CVEID) -> None:
-        async with max_jobs_sem:
-            logger.info(f"[{i}/{self.total}] processing {cve}")
-            log_memory(f"cve_start({cve})")
-            await self.process_cve(cve)
-            log_memory(f"cve_end({cve})")
+    async def _process_cve_list(self, cve_ids: Sequence[CVEID] = ()) -> None:
+        total: int = len(cve_ids)
+
+        async def process_cve_bounded(i: int, cve: CVEID) -> None:
+            async with max_jobs_sem:
+                logger.info(f"[{i}/{total}] processing {cve}")
+                log_memory(f"cve_start({cve})")
+                await self.process_cve(cve)
+                log_memory(f"cve_end({cve})")
+
+        log_memory(f"batch_start({total} CVEs)")
+        await asyncio.gather(
+            *[process_cve_bounded(*job) for job in enumerate(cve_ids, start=1)]
+        )
+        log_memory("batch_end")
+        logger.info(f"processed {total} CVEs")
 
     async def process(self, cve_ids: Sequence[CVEID] = ()) -> None:
         if not cve_ids:
             # look for CVEs to process
             cve_ids = self.search_cve_ids()
 
-        self.total = len(cve_ids)
-        if not self.total:
-            logger.info("nothing to do")
-            return
-
-        log_memory(f"batch_start({self.total}_cves)")
-        await asyncio.gather(
-            *[self.process_cve_bounded(*job) for job in enumerate(cve_ids, start=1)]
-        )
-        log_memory("batch_end")
+        await self._process_cve_list(cve_ids)

--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -121,10 +121,12 @@ class FlawFinder:
             "cve_id__isempty": False,  # only flaws with a CVE ID
             "order": ["created_dt"],
             "source_in": [s for s in ELIGIBLE_FLAWS["source"]],
-            "workflow_state_in": [
-                cast(dict[str, str], c)["state"]
-                for c in ELIGIBLE_FLAWS["classification"]
-            ],
+            "workflow_state_in": list(
+                dict.fromkeys(
+                    cast(dict[str, str], c)["state"]
+                    for c in ELIGIBLE_FLAWS["classification"]
+                )
+            ),
             # use a large page size to minimize round trips when only fetching IDs
             "limit": 1000,
         }

--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -448,6 +448,20 @@ class Bot(StateProxy):
             age_cutoff=self.age_cutoff,
         )
 
+    def schedule_retry(self, cve: CVEID) -> bool:
+        if self.retrying_failed:
+            # already retrying -> create the manual-triage label on the last retry
+            remains = self.retry_list.get(cve)
+            return remains is not None and remains > 1
+
+        if not self.max_retries:
+            # not retrying and retry is disabled
+            return False
+
+        # not yet retrying but retry is enabled -> schedule retry
+        self.retry_list[cve] = self.max_retries
+        return True
+
     async def process_cve(self, cve: CVEID) -> None:
         flaw_updater: Optional[FlawUpdater] = None
 
@@ -467,14 +481,11 @@ class Bot(StateProxy):
         except RuntimeError as e:
             # something has failed
             logger.warning(f"{cve}: {str(e)}")
-            if flaw_updater:
-                if (not self.retrying_failed and not self.max_retries) or (
-                    self.retrying_failed and self.retry_list.get(cve) == 1
-                ):
-                    # the last retry attempt failed, create the manual-triage label
-                    flaw_updater.create_alias_label("manual-triage")
-            if self.max_retries > 0 and not self.retrying_failed:
-                self.retry_list[cve] = self.max_retries
+
+            # schedule retry if enabled
+            if not self.schedule_retry(cve) and flaw_updater:
+                # the last retry attempt failed, create the manual-triage label
+                flaw_updater.create_alias_label("manual-triage")
 
         finally:
             if self.retrying_failed:

--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -411,6 +411,7 @@ class Bot(StateProxy):
     pending: dict[BotPosition, bool]
     force: bool
     age_cutoff: Optional[datetime]
+    retrying_failed: bool
 
     def __init__(
         self,
@@ -425,6 +426,7 @@ class Bot(StateProxy):
         self.agent = agent
         self.force = force
         self.age_cutoff = age_cutoff
+        self.retrying_failed = False
         self.pending = {}
         try:
             osidb_server = get_settings().osidb_server_url
@@ -455,7 +457,8 @@ class Bot(StateProxy):
                 read_only=self.read_only,
                 retry_list=self.retry_list,
             )
-            self.pending[flaw_updater.position()] = True  # mark as pending
+            if not self.retrying_failed:
+                self.pending[flaw_updater.position()] = True  # mark as pending
             await flaw_updater.do()
 
         except RuntimeError as e:
@@ -463,7 +466,9 @@ class Bot(StateProxy):
             logger.warning(f"{cve}: {str(e)}")
 
         finally:
-            if flaw_updater:
+            if self.retrying_failed:
+                self.decrement_retry(cve)
+            elif flaw_updater:
                 self.pending[flaw_updater.position()] = False  # mark as done
 
             # determine the next state
@@ -480,6 +485,7 @@ class Bot(StateProxy):
             # do not update state if the CVE with lowest created_dt is still being processed
             if next_state:
                 # update state (and state file unless read-only)
+                assert not self.retrying_failed
                 self.state = next_state
 
     async def _process_cve_list(self, cve_ids: Sequence[CVEID] = ()) -> None:
@@ -505,3 +511,8 @@ class Bot(StateProxy):
             cve_ids = self.search_cve_ids()
 
         await self._process_cve_list(cve_ids)
+
+        if self.retry_list:
+            logger.info("retrying failed CVEs")
+            self.retrying_failed = True
+            await self._process_cve_list(list(self.retry_list))

--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -338,6 +338,8 @@ class FlawUpdater:
             if self.force:
                 self._warn(f"bypassing flaw eligibility check: {str(e)}")
             else:
+                # proactively remove ineligible CVEs from retry_list
+                self.retry_list.pop(self.cve, None)
                 raise
 
         # apply suggestions

--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -51,8 +51,6 @@ ELIGIBLE_FLAWS = {
         {"workflow": "DEFAULT", "state": ""},
         {"workflow": "DEFAULT", "state": "NEW"},
     ),
-    # only flaws where Aegis has not been used yet
-    "aegis_meta": ({},),
     # only flaws with no affects
     "affects": ([],),
     # only flaws with no owner
@@ -133,7 +131,7 @@ class FlawFinder:
 
         # emptiness predicates for indexed fields
         for field, allowed in ELIGIBLE_FLAWS.items():
-            if field in ("affects", "aegis_meta"):
+            if field in ("affects",):
                 # not indexed in OSIDB
                 continue
 
@@ -276,7 +274,7 @@ class FlawUpdater:
             self._warn("unexpected type of aegis_meta")
             return False
 
-        # if everything is OK check that no suggestion was discarded with this timestamp
+        # if everything is OK, check that no suggestion was discarded with this timestamp
         return not any(
             entry.get("type", "") == "AI-Bot-Skipped"
             and entry.get("timestamp", None) == timestamp.isoformat()

--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -1,5 +1,5 @@
 from aegis_ai import get_settings
-from aegis_ai.osidb_bot.state import BotState, StateFileHandler, StateProxy
+from aegis_ai.osidb_bot.state import BotPosition, StateFileHandler, StateProxy
 from aegis_ai.osidb_bot.suggest import DEFAULT_SUGGESTION_LIST, _KERNEL_FLAGS_KEY
 from aegis_ai.osidb_bot.util import FlawData, log_memory, logger
 from aegis_ai.data_models import CVEID
@@ -112,7 +112,7 @@ class FlawFinder:
 
     def search(
         self,
-        state: BotState = BotState(),
+        state: BotPosition = BotPosition(),
         age_cutoff: Optional[datetime] = None,
     ) -> Sequence[CVEID]:
         # infer search predicates from ELIGIBLE_FLAWS
@@ -229,9 +229,9 @@ class FlawUpdater:
     def _warn(self, msg: str) -> None:
         logger.warning(f"{self.cve}: {msg}")
 
-    def state(self) -> BotState:
+    def position(self) -> BotPosition:
         assert self.flaw_data
-        return BotState(
+        return BotPosition(
             last_cve=self.flaw_data["cve_id"],
             created_dt=datetime.fromisoformat(self.flaw_data["created_dt"]),
         )
@@ -404,7 +404,7 @@ class FlawUpdater:
 class Bot(StateProxy):
     agent: Agent
     osidb: Session
-    pending: dict[BotState, bool]
+    pending: dict[BotPosition, bool]
     force: bool
     age_cutoff: Optional[datetime]
 
@@ -450,7 +450,7 @@ class Bot(StateProxy):
                 force=self.force,
                 read_only=self.read_only,
             )
-            self.pending[flaw_updater.state()] = True  # mark as pending
+            self.pending[flaw_updater.position()] = True  # mark as pending
             await flaw_updater.do()
 
         except RuntimeError as e:
@@ -459,10 +459,10 @@ class Bot(StateProxy):
 
         finally:
             if flaw_updater:
-                self.pending[flaw_updater.state()] = False  # mark as done
+                self.pending[flaw_updater.position()] = False  # mark as done
 
             # determine the next state
-            next_state: Optional[BotState] = None
+            next_state: Optional[BotPosition] = None
             for s in sorted(self.pending.keys(), key=lambda s: s.created_dt):
                 if self.pending[s]:
                     # this CVE is still being processed

--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -188,6 +188,7 @@ class FlawUpdater:
     cve: CVEID
     force: bool
     read_only: bool
+    retry_list: dict[str, int]
 
     # OSIDB flaw from session.flaws.retrieve()
     flaw_data: Optional[FlawData]
@@ -203,12 +204,14 @@ class FlawUpdater:
         *,
         force: bool = False,
         read_only: bool = False,
+        retry_list: Optional[dict[str, int]] = None,
     ):
         self.osidb = osidb
         self.agent = agent
         self.cve = cve
         self.force = force
         self.read_only = read_only
+        self.retry_list = retry_list or {}
         self.updated_fields = set()
 
         try:
@@ -366,6 +369,9 @@ class FlawUpdater:
                     form_data=rh_cvss,
                 )
 
+            # successfully processed (we do not retry when only label creation fails)
+            self.retry_list.pop(self.cve, None)
+
         except Exception as e:
             # failed to save changes
             all_ok = False
@@ -449,6 +455,7 @@ class Bot(StateProxy):
                 cve,
                 force=self.force,
                 read_only=self.read_only,
+                retry_list=self.retry_list,
             )
             self.pending[flaw_updater.position()] = True  # mark as pending
             await flaw_updater.do()

--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -411,6 +411,7 @@ class Bot(StateProxy):
     pending: dict[BotPosition, bool]
     force: bool
     age_cutoff: Optional[datetime]
+    max_retries: int
     retrying_failed: bool
 
     def __init__(
@@ -421,11 +422,13 @@ class Bot(StateProxy):
         force: bool = False,
         read_only: bool = False,
         age_cutoff: Optional[datetime] = None,
+        max_retries: int = 0,
     ):
         super().__init__(state_file_handler, read_only=read_only)
         self.agent = agent
         self.force = force
         self.age_cutoff = age_cutoff
+        self.max_retries = max_retries
         self.retrying_failed = False
         self.pending = {}
         try:
@@ -464,6 +467,8 @@ class Bot(StateProxy):
         except RuntimeError as e:
             # something has failed
             logger.warning(f"{cve}: {str(e)}")
+            if self.max_retries > 0 and not self.retrying_failed:
+                self.retry_list[cve] = self.max_retries
 
         finally:
             if self.retrying_failed:

--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -1,5 +1,5 @@
 from aegis_ai import get_settings
-from aegis_ai.osidb_bot.state import BotState, StateFileHandler
+from aegis_ai.osidb_bot.state import BotState, StateFileHandler, StateProxy
 from aegis_ai.osidb_bot.suggest import DEFAULT_SUGGESTION_LIST, _KERNEL_FLAGS_KEY
 from aegis_ai.osidb_bot.util import FlawData, log_memory, logger
 from aegis_ai.data_models import CVEID
@@ -112,7 +112,7 @@ class FlawFinder:
 
     def search(
         self,
-        state: Optional[BotState] = None,
+        state: BotState = BotState(),
         age_cutoff: Optional[datetime] = None,
     ) -> Sequence[CVEID]:
         # infer search predicates from ELIGIBLE_FLAWS
@@ -143,7 +143,7 @@ class FlawFinder:
 
         # compute the lower bound on created_dt
         created_dt_gte: Optional[datetime]
-        if state is None:
+        if state.created_dt is None:
             created_dt_gte = age_cutoff
         elif age_cutoff is None:
             created_dt_gte = state.created_dt
@@ -164,7 +164,7 @@ class FlawFinder:
             ]  # workflow is not available as a search predicate
         ]
 
-        if state is None:
+        if state.last_cve is None:
             return cve_ids
 
         # exclude the last processed CVE when resuming from state
@@ -401,13 +401,11 @@ class FlawUpdater:
             self.create_alias_label("manual-triage")
 
 
-class Bot:
-    sfh: StateFileHandler
+class Bot(StateProxy):
     agent: Agent
     osidb: Session
     pending: dict[BotState, bool]
     force: bool
-    read_only: bool
     age_cutoff: Optional[datetime]
 
     def __init__(
@@ -419,10 +417,9 @@ class Bot:
         read_only: bool = False,
         age_cutoff: Optional[datetime] = None,
     ):
-        self.sfh = state_file_handler
+        super().__init__(state_file_handler, read_only=read_only)
         self.agent = agent
         self.force = force
-        self.read_only = read_only
         self.age_cutoff = age_cutoff
         self.pending = {}
         try:
@@ -438,7 +435,7 @@ class Bot:
     def search_cve_ids(self) -> Sequence[CVEID]:
         finder = FlawFinder(self.osidb)
         return finder.search(
-            state=self.sfh.read_state(),
+            state=self.state,
             age_cutoff=self.age_cutoff,
         )
 
@@ -465,20 +462,20 @@ class Bot:
                 self.pending[flaw_updater.state()] = False  # mark as done
 
             # determine the next state
-            state: Optional[BotState] = None
+            next_state: Optional[BotState] = None
             for s in sorted(self.pending.keys(), key=lambda s: s.created_dt):
                 if self.pending[s]:
                     # this CVE is still being processed
                     break
 
                 # record the last _done_ CVE
-                state = s
-                del self.pending[state]
+                next_state = s
+                del self.pending[next_state]
 
-            # do not update state file if the CVE with lowest created_dt is still being processed
-            if not self.read_only and state:
-                # update state file
-                self.sfh.write_state(state)
+            # do not update state if the CVE with lowest created_dt is still being processed
+            if next_state:
+                # update state (and state file unless read-only)
+                self.state = next_state
 
     async def _process_cve_list(self, cve_ids: Sequence[CVEID] = ()) -> None:
         total: int = len(cve_ids)

--- a/src/aegis_ai/osidb_bot/state.py
+++ b/src/aegis_ai/osidb_bot/state.py
@@ -24,12 +24,6 @@ class BotPosition(BaseModel):
     # creation timestamp of the last processed CVE
     created_dt: Optional[datetime] = None
 
-    def __str__(self) -> str:
-        return (
-            f"BotPosition(last_cve={self.last_cve!r},"
-            f" created_dt={str(self.created_dt)!r})"
-        )
-
 
 class BotState(BotPosition):
     """Full bot state for persistence — extends BotPosition with mutable fields."""
@@ -112,7 +106,7 @@ class StateFileHandler:
         # parse JSON
         try:
             state = BotState.model_validate_json(data)
-            logger.info(f"{self._sf_prefix()}: read {state}")
+            logger.debug(f"{self._sf_prefix()}: read {state.model_dump_json()}")
             return state
         except (ValidationError, json.JSONDecodeError):
             logger.warning(
@@ -139,7 +133,7 @@ class StateFileHandler:
         os.ftruncate(self.state_fd, size)
 
         # log a successfully written state file
-        logger.info(f"{self._sf_prefix()}: written {state}")
+        logger.debug(f"{self._sf_prefix()}: written {state.model_dump_json()}")
 
 
 class _ObservableDict(dict):
@@ -152,12 +146,18 @@ class _ObservableDict(dict):
         self._on_change = _on_change
 
     def __setitem__(self, key: object, value: object) -> None:
+        old = self.get(key)
         super().__setitem__(key, value)
+        if old is None:
+            logger.info("retry_list: added %s (%s attempts)", key, value)
+        elif old != value:
+            logger.info("retry_list: updated %s (%s → %s attempts)", key, old, value)
         if self._on_change:
             self._on_change()
 
     def __delitem__(self, key: object) -> None:
         super().__delitem__(key)
+        logger.info("retry_list: removed %s (%d entries remain)", key, len(self))
         if self._on_change:
             self._on_change()
 
@@ -165,6 +165,7 @@ class _ObservableDict(dict):
         if key not in self:
             return super().pop(key, *args)
         result = super().pop(key, *args)
+        logger.info("retry_list: removed %s (%d entries remain)", key, len(self))
         if self._on_change:
             self._on_change()
         return result
@@ -185,6 +186,7 @@ class StateProxy:
             self._state.retry_list, _on_change=self._flush
         )
         self.read_only = read_only
+        self._log_position("read")
 
     @property
     def state(self) -> BotState:
@@ -193,6 +195,15 @@ class StateProxy:
     @property
     def retry_list(self) -> dict[str, int]:
         return self._retry_list
+
+    def _log_position(self, action: str) -> None:
+        logger.info(
+            "state %s: last_cve=%s, created_dt=%s, len(retry_list)=%d",
+            action,
+            self._state.last_cve,
+            self._state.created_dt,
+            len(self._retry_list),
+        )
 
     def decrement_retry(self, cve: str) -> None:
         """Decrement the retry count for a CVE, removing it when it reaches zero."""
@@ -224,3 +235,4 @@ class StateProxy:
         )
         if not self.read_only:
             self._sfh.write_state(self._state)
+        self._log_position("written")

--- a/src/aegis_ai/osidb_bot/state.py
+++ b/src/aegis_ai/osidb_bot/state.py
@@ -5,7 +5,7 @@ import os
 from aegis_ai.osidb_bot.util import logger
 
 from datetime import datetime
-from typing import Never, Optional, Self
+from typing import Any, Never, Optional, Self
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
@@ -142,28 +142,74 @@ class StateFileHandler:
         logger.info(f"{self._sf_prefix()}: written {state}")
 
 
+class _ObservableDict(dict):
+    """Dict subclass that calls a callback when its contents change."""
+
+    _on_change: Any
+
+    def __init__(self, *args: Any, _on_change: Any = None, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self._on_change = _on_change
+
+    def __setitem__(self, key: object, value: object) -> None:
+        super().__setitem__(key, value)
+        if self._on_change:
+            self._on_change()
+
+    def __delitem__(self, key: object) -> None:
+        super().__delitem__(key)
+        if self._on_change:
+            self._on_change()
+
+    def pop(self, key: object, *args: Any) -> Any:
+        if key not in self:
+            return super().pop(key, *args)
+        result = super().pop(key, *args)
+        if self._on_change:
+            self._on_change()
+        return result
+
+
 class StateProxy:
     """In-memory cache for BotState that auto-writes to disk on update."""
 
     _sfh: "StateFileHandler"
     _state: BotState
+    _retry_list: _ObservableDict
     read_only: bool
 
     def __init__(self, sfh: "StateFileHandler", read_only: bool = False):
         self._sfh = sfh
         self._state = sfh.read_state() or BotState()
+        self._retry_list = _ObservableDict(
+            self._state.retry_list, _on_change=self._flush
+        )
         self.read_only = read_only
 
     @property
     def state(self) -> BotState:
         return self._state
 
+    @property
+    def retry_list(self) -> dict[str, int]:
+        return self._retry_list
+
+    def _flush(self) -> None:
+        """Rebuild BotState from current retry_list and write to disk."""
+        self._state = BotState(
+            last_cve=self._state.last_cve,
+            created_dt=self._state.created_dt,
+            retry_list=self._retry_list,
+        )
+        if not self.read_only:
+            self._sfh.write_state(self._state)
+
     @state.setter
     def state(self, value: BotPosition) -> None:
         self._state = BotState(
             last_cve=value.last_cve,
             created_dt=value.created_dt,
-            retry_list=self._state.retry_list,
+            retry_list=self._retry_list,
         )
         if not self.read_only:
             self._sfh.write_state(self._state)

--- a/src/aegis_ai/osidb_bot/state.py
+++ b/src/aegis_ai/osidb_bot/state.py
@@ -194,6 +194,17 @@ class StateProxy:
     def retry_list(self) -> dict[str, int]:
         return self._retry_list
 
+    def decrement_retry(self, cve: str) -> None:
+        """Decrement the retry count for a CVE, removing it when it reaches zero."""
+        if cve not in self._retry_list:
+            return
+
+        remains = self._retry_list[cve] - 1
+        if remains <= 0:
+            self._retry_list.pop(cve)
+        else:
+            self._retry_list[cve] = remains
+
     def _flush(self) -> None:
         """Rebuild BotState from current retry_list and write to disk."""
         self._state = BotState(

--- a/src/aegis_ai/osidb_bot/state.py
+++ b/src/aegis_ai/osidb_bot/state.py
@@ -7,15 +7,15 @@ from aegis_ai.osidb_bot.util import logger
 from datetime import datetime
 from typing import Never, Optional, Self
 
-from pydantic import BaseModel, ConfigDict, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from aegis_ai.data_models import CVEID
 
 
-class BotState(BaseModel):
-    """State for the OSIDB bot, aligned with osidb_bindings flaw attributes."""
+class BotPosition(BaseModel):
+    """Position in the CVE stream — hashable, used as dict key in Bot.pending."""
 
-    # make the state hashable so that it can be used as key for a dict
+    # make the position hashable so that it can be used as key for a dict
     model_config = ConfigDict(frozen=True)
 
     # the last processed CVE
@@ -26,8 +26,18 @@ class BotState(BaseModel):
 
     def __str__(self) -> str:
         return (
-            f"BotState(last_cve={self.last_cve!r}, created_dt={str(self.created_dt)!r})"
+            f"BotPosition(last_cve={self.last_cve!r},"
+            f" created_dt={str(self.created_dt)!r})"
         )
+
+
+class BotState(BotPosition):
+    """Full bot state for persistence — extends BotPosition with mutable fields."""
+
+    model_config = ConfigDict(frozen=False)
+
+    # CVE IDs that failed processing, mapped to remaining retry attempts
+    retry_list: dict[str, int] = Field(default_factory=dict)
 
 
 class StateFileHandler:
@@ -119,8 +129,8 @@ class StateFileHandler:
 
         assert 0 <= self.state_fd
 
-        # serialize JSON
-        payload = state.model_dump_json() + "\n"
+        # serialize JSON (exclude_defaults omits empty retry_list)
+        payload = state.model_dump_json(exclude_defaults=True) + "\n"
         raw = payload.encode("utf-8")
 
         # write the data at the beginning of the state file
@@ -149,7 +159,11 @@ class StateProxy:
         return self._state
 
     @state.setter
-    def state(self, value: BotState) -> None:
-        self._state = value
+    def state(self, value: BotPosition) -> None:
+        self._state = BotState(
+            last_cve=value.last_cve,
+            created_dt=value.created_dt,
+            retry_list=self._state.retry_list,
+        )
         if not self.read_only:
-            self._sfh.write_state(value)
+            self._sfh.write_state(self._state)

--- a/src/aegis_ai/osidb_bot/state.py
+++ b/src/aegis_ai/osidb_bot/state.py
@@ -19,10 +19,10 @@ class BotState(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     # the last processed CVE
-    last_cve: CVEID
+    last_cve: Optional[CVEID] = None
 
     # creation timestamp of the last processed CVE
-    created_dt: datetime
+    created_dt: Optional[datetime] = None
 
     def __str__(self) -> str:
         return (
@@ -89,7 +89,7 @@ class StateFileHandler:
         """Read JSON-encoded BotState from state_fd. Returns None if file is empty."""
         if not self.state_file:
             # do nothing
-            return
+            return None
 
         # read file contents
         assert 0 <= self.state_fd
@@ -130,3 +130,26 @@ class StateFileHandler:
 
         # log a successfully written state file
         logger.info(f"{self._sf_prefix()}: written {state}")
+
+
+class StateProxy:
+    """In-memory cache for BotState that auto-writes to disk on update."""
+
+    _sfh: "StateFileHandler"
+    _state: BotState
+    read_only: bool
+
+    def __init__(self, sfh: "StateFileHandler", read_only: bool = False):
+        self._sfh = sfh
+        self._state = sfh.read_state() or BotState()
+        self.read_only = read_only
+
+    @property
+    def state(self) -> BotState:
+        return self._state
+
+    @state.setter
+    def state(self, value: BotState) -> None:
+        self._state = value
+        if not self.read_only:
+            self._sfh.write_state(value)

--- a/src/aegis_ai/osidb_bot/suggest.py
+++ b/src/aegis_ai/osidb_bot/suggest.py
@@ -77,6 +77,7 @@ def record_aegis_meta(
         "timestamp": timestamp.isoformat(),
         "data_quality": output.data_quality,
         "confidence": output.confidence,
+        "tools_used": output.tools_used,
         **extra,
     }
     dst_field.append(entry)

--- a/src/aegis_ai_cli/main.py
+++ b/src/aegis_ai_cli/main.py
@@ -437,6 +437,11 @@ def osidb_bot(state_file, force, read_only, max_age, max_retries, cve_ids):
     # avoid logging tracebacks when GSSAPI auth fails
     logging.getLogger("requests_gssapi").setLevel(logging.CRITICAL)
 
+    # suppress verbose tool call logs
+    from aegis_ai import SuppressToolCallFilter
+
+    logging.getLogger("aegis_ai.toolsets").addFilter(SuppressToolCallFilter())
+
     # parse --max-age and compute a cutoff datetime
     from datetime import datetime, timedelta, timezone
 

--- a/src/aegis_ai_cli/main.py
+++ b/src/aegis_ai_cli/main.py
@@ -417,8 +417,14 @@ def component_intelligence(component_name):
     default=None,
     help=f"Maximum flaw age, e.g. 7d (days), 4w (weeks), 5y (years). Default: {DEFAULT_MAX_AGE}.",
 )
+@click.option(
+    "--max-retries",
+    type=int,
+    default=0,
+    help="Number of retry attempts for failed CVEs. Default: 0 (no retries).",
+)
 @click.argument("cve_ids", nargs=-1, type=CVEID)
-def osidb_bot(state_file, force, read_only, max_age, cve_ids):
+def osidb_bot(state_file, force, read_only, max_age, max_retries, cve_ids):
     """
     OSIDB bot: process CVE IDs (optional) with optional state file.
     """
@@ -445,6 +451,11 @@ def osidb_bot(state_file, force, read_only, max_age, cve_ids):
     if cve_ids and max_age is not None:
         logger.warning("--max-age has no effect when CVE IDs are given as arguments")
 
+    if max_retries > 1 and state_file is None:
+        logger.warning(
+            "--max-retries > 1 without --state-file: retry list will not persist across runs"
+        )
+
     log_memory("cli_entry")
 
     try:
@@ -452,7 +463,12 @@ def osidb_bot(state_file, force, read_only, max_age, cve_ids):
         # (if state_file is not None)
         with StateFileHandler(state_file) as sfh:
             osidb_bot = Bot(
-                sfh, cli_agent, force=force, read_only=read_only, age_cutoff=age_cutoff
+                sfh,
+                cli_agent,
+                force=force,
+                read_only=read_only,
+                age_cutoff=age_cutoff,
+                max_retries=max_retries,
             )
             log_memory("bot_created")
             runner = osidb_bot.process(cve_ids)

--- a/tests/test_flaw_updater.py
+++ b/tests/test_flaw_updater.py
@@ -597,3 +597,30 @@ async def test_schedule_retry_creates_manual_triage_on_last_attempt(mock_exec_fe
         form_data=MANUAL_TRIAGE_LABEL,
     )
     assert CVE_ID not in bot.retry_list
+
+
+@pytest.mark.asyncio
+@patch("aegis_ai.osidb_bot.suggest.exec_feature", new_callable=AsyncMock)
+async def test_validation_failure_skips_retry_and_manual_triage(mock_exec_feature):
+    """process_cve() does not retry or label manual-triage for ineligible flaws."""
+    mock_exec_feature.side_effect = _canned_exec_feature
+
+    flaw_data = _minimal_flaw_data()
+    flaw_data["owner"] = "someone@example.com"
+    session = _mock_session(flaw_data)
+    agent = MagicMock()
+
+    from aegis_ai.osidb_bot.bot import Bot
+    from aegis_ai.osidb_bot.state import StateFileHandler
+
+    with (
+        StateFileHandler(None) as sfh,
+        patch(
+            "aegis_ai.osidb_bot.bot.osidb_bindings.new_session", return_value=session
+        ),
+    ):
+        bot = Bot(sfh, agent, max_retries=3)
+        await bot.process_cve(CVE_ID)
+
+    assert CVE_ID not in bot.retry_list
+    session.flaws.labels.create.assert_not_called()

--- a/tests/test_flaw_updater.py
+++ b/tests/test_flaw_updater.py
@@ -69,7 +69,7 @@ async def _canned_exec_feature(feature, flaw_data):
     cve_id = flaw_data["cve_id"]
     explanation = f"Canned explanation for {name} ({cve_id})"
 
-    metrics = dict(data_quality=1.0, confidence=1.0)
+    metrics = dict(data_quality=1.0, confidence=1.0, tools_used=[])
 
     if name == "SuggestAffectedComponents":
         return SimpleNamespace(
@@ -293,6 +293,7 @@ def test_update_field_skipped_low_data_quality():
             explanation="test",
             data_quality=LOW_QUALITY,
             confidence=1.0,
+            tools_used=[],
         ),
     )
 
@@ -323,6 +324,7 @@ def test_update_field_skipped_low_confidence():
             explanation="test",
             data_quality=1.0,
             confidence=LOW_CONFIDENCE,
+            tools_used=[],
         ),
     )
 
@@ -350,6 +352,7 @@ def test_update_field_skipped_both_metrics_low():
             explanation="test",
             data_quality=LOW_QUALITY,
             confidence=LOW_CONFIDENCE,
+            tools_used=[],
         ),
     )
 
@@ -374,7 +377,9 @@ async def test_flaw_updater_all_skipped_records_aegis_meta(mock_exec_feature):
         name = feature.__class__.__name__
         cve_id = flaw_data["cve_id"]
         explanation = f"Low-quality output for {name} ({cve_id})"
-        metrics = dict(data_quality=LOW_QUALITY, confidence=LOW_CONFIDENCE)
+        metrics = dict(
+            data_quality=LOW_QUALITY, confidence=LOW_CONFIDENCE, tools_used=[]
+        )
 
         if name == "SuggestAffectedComponents":
             return SimpleNamespace(
@@ -465,7 +470,9 @@ async def test_flaw_updater_do_creates_manual_triage_label_on_all_skipped(
     async def _low_metrics_exec(feature, flaw_data):
         name = feature.__class__.__name__
         explanation = f"Low-quality output for {name}"
-        metrics = dict(data_quality=LOW_QUALITY, confidence=LOW_CONFIDENCE)
+        metrics = dict(
+            data_quality=LOW_QUALITY, confidence=LOW_CONFIDENCE, tools_used=[]
+        )
 
         if name == "SuggestAffectedComponents":
             return SimpleNamespace(

--- a/tests/test_flaw_updater.py
+++ b/tests/test_flaw_updater.py
@@ -564,3 +564,36 @@ async def test_flaw_updater_do_creates_manual_triage_label_on_save_failure(
         flaw_id=flaw_data["uuid"],
         form_data=MANUAL_TRIAGE_LABEL,
     )
+
+
+@pytest.mark.asyncio
+@patch("aegis_ai.osidb_bot.suggest.exec_feature", new_callable=AsyncMock)
+async def test_schedule_retry_creates_manual_triage_on_last_attempt(mock_exec_feature):
+    """process_cve() creates manual-triage label when the last retry attempt fails."""
+    mock_exec_feature.side_effect = _canned_exec_feature
+
+    flaw_data = _minimal_flaw_data()
+    session = _mock_session(flaw_data)
+    session.flaws.update.side_effect = RuntimeError("OSIDB write failed")
+    agent = MagicMock()
+
+    from aegis_ai.osidb_bot.bot import Bot
+    from aegis_ai.osidb_bot.state import StateFileHandler
+
+    with (
+        StateFileHandler(None) as sfh,
+        patch(
+            "aegis_ai.osidb_bot.bot.osidb_bindings.new_session", return_value=session
+        ),
+    ):
+        bot = Bot(sfh, agent, max_retries=1)
+        bot.retrying_failed = True
+        bot.retry_list[CVE_ID] = 1
+
+        await bot.process_cve(CVE_ID)
+
+    session.flaws.labels.create.assert_called_with(
+        flaw_id=flaw_data["uuid"],
+        form_data=MANUAL_TRIAGE_LABEL,
+    )
+    assert CVE_ID not in bot.retry_list

--- a/tests/test_kernel_flags.py
+++ b/tests/test_kernel_flags.py
@@ -136,6 +136,7 @@ async def _canned_exec_feature_with_flags(feature, flaw_data):
             explanation="test",
             data_quality=0.9,
             confidence=0.9,
+            tools_used=[],
         )
     if name == "SuggestDescriptionText":
         return SimpleNamespace(
@@ -144,6 +145,7 @@ async def _canned_exec_feature_with_flags(feature, flaw_data):
             explanation="test",
             data_quality=0.9,
             confidence=0.9,
+            tools_used=[],
         )
     if name == "SuggestCWE":
         return SimpleNamespace(
@@ -151,6 +153,7 @@ async def _canned_exec_feature_with_flags(feature, flaw_data):
             explanation="test",
             data_quality=0.9,
             confidence=0.9,
+            tools_used=[],
         )
     if name == "SuggestImpact":
         return SimpleNamespace(
@@ -160,6 +163,7 @@ async def _canned_exec_feature_with_flags(feature, flaw_data):
             explanation="Kernel panic detected",
             data_quality=0.9,
             confidence=0.9,
+            tools_used=[],
             _flags=["kpanic"],
         )
     raise ValueError(f"Unknown feature: {name}")
@@ -325,6 +329,7 @@ class TestSuggestImpactAegisMetaKernelFlags:
                     explanation="test",
                     data_quality=0.9,
                     confidence=0.9,
+                    tools_used=[],
                     _flags=[],
                 )
             return await _canned_exec_feature_with_flags(feature, flaw_data)


### PR DESCRIPTION
## What

Add a retry mechanism to `osidb-bot` that re-processes failed CVEs at the end of a run. Failed CVEs are tracked in a `retry_list` (CVE ID → remaining attempts) persisted in the state file, with a new `--max-retries=N` CLI option controlling the number of retry attempts (default 0, disabled). On the last retry attempt, the CVE is labeled `manual-triage` for human follow-up.

## Why

Transient OSIDB errors (network issues, rate limiting, temporary server errors) cause CVEs to be skipped permanently. A retry mechanism allows the bot to recover from these failures without manual intervention, while ensuring persistently failing CVEs are escalated via the `manual-triage` label.

## How to Test

```bash
make check    # format + lint + type-check
make test     # 225 unit tests pass

# Manual test with retries enabled
uv run aegis osidb-bot --state-file=state.json --max-retries=3 CVE-2025-XXXXX
```

## Key Changes

- **State layer refactoring**: split `BotState` into frozen `BotPosition` (hashable, dict key) and mutable `BotState`; introduce `StateProxy` as in-memory cache with auto-flush to disk; add `_ObservableDict` for transparent retry_list mutation tracking and logging
- **Retry mechanism**: `--max-retries=N` CLI option; `on_failure` callback from `FlawUpdater` to `Bot.schedule_retry()`; retry pass at end of `Bot.process()` sorted by fewest remaining attempts; `manual-triage` label on last attempt; `FlawValidationError` to skip retries for ineligible CVEs
- **Logging improvements**: DEBUG-level full model dumps in `StateFileHandler`, INFO-level concise summaries in `StateProxy`, per-entry mutation logging in `_ObservableDict`; shared `SuppressToolCallFilter` extracted to `aegis_ai` and used in both CLI and evals
- **Minor**: record `tools_used` in `aegis_meta` entries; drop `aegis_meta` eligibility check to allow retries of already-touched CVEs

## Related Tickets

Related: https://redhat.atlassian.net/browse/AEGIS-462

## Summary by Sourcery

Add a persistent retry mechanism for failed CVE processing in osidb-bot, with improved state management and logging, plus minor metadata and CLI updates.

New Features:
- Introduce configurable retry handling for failed CVEs controlled via a new --max-retries CLI option.
- Persist failed CVEs and their remaining retry attempts in the bot state so retries can continue across runs.
- Automatically apply a manual-triage label when a CVE exhausts its retry attempts or fails on the last scheduled retry.

Enhancements:
- Refactor bot state into separate BotPosition and BotState models and add a StateProxy cache that transparently syncs state and retry lists to disk.
- Improve logging around state file I/O, retry list mutations, and bot position summaries for better observability.
- Relax eligibility checks to allow processing and potential retries for CVEs that already have aegis_meta entries.
- Record tools_used metadata on aegis_meta records to capture tool usage context.
- Share the SuppressToolCallFilter across CLI and evals to consistently suppress verbose tool call logs.

Tests:
- Extend existing tests to cover tools_used metadata handling and add coverage for the retry/manual-triage behavior when save operations fail.