### PR TITLE
fix: osidb-bot robustness improvements

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -68,7 +68,7 @@
             "required": true,
             "schema": {
               "type": "string",
-              "pattern": "^CVE-[0-9]{4}-[0-9]{4,7}$",
+              "pattern": "^CVE-[0-9]{4}-[0-9]{4,16}$",
               "title": "Cve Id"
             }
           },
@@ -227,7 +227,7 @@
                 "properties": {
                   "cve_id": {
                     "type": "string",
-                    "pattern": "^CVE-[0-9]{4}-[0-9]{4,7}$",
+                    "pattern": "^CVE-[0-9]{4}-[0-9]{4,16}$",
                     "description": "CVE identifier (e.g. CVE-2025-12345)"
                   },
                   "title": {
@@ -656,7 +656,7 @@
         "properties": {
           "cve_id": {
             "type": "string",
-            "pattern": "^CVE-[0-9]{4}-[0-9]{4,7}$",
+            "pattern": "^CVE-[0-9]{4}-[0-9]{4,16}$",
             "title": "Cve Id",
             "description": "CVE identifier (e.g. CVE-2025-12345)"
           },
@@ -761,7 +761,7 @@
               {
                 "type": "string",
                 "maxLength": 50,
-                "pattern": "^CVE-[0-9]{4}-[0-9]{4,7}$"
+                "pattern": "^CVE-[0-9]{4}-[0-9]{4,16}$"
               },
               {
                 "type": "null"

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -44,7 +44,7 @@ paths:
         required: true
         schema:
           type: string
-          pattern: ^CVE-[0-9]{4}-[0-9]{4,7}$
+          pattern: ^CVE-[0-9]{4}-[0-9]{4,16}$
           title: Cve Id
       - name: detail
         in: query
@@ -147,7 +147,7 @@ paths:
               properties:
                 cve_id:
                   type: string
-                  pattern: ^CVE-[0-9]{4}-[0-9]{4,7}$
+                  pattern: ^CVE-[0-9]{4}-[0-9]{4,16}$
                   description: CVE identifier (e.g. CVE-2025-12345)
                 title:
                   type: string
@@ -443,7 +443,7 @@ components:
       properties:
         cve_id:
           type: string
-          pattern: ^CVE-[0-9]{4}-[0-9]{4,7}$
+          pattern: ^CVE-[0-9]{4}-[0-9]{4,16}$
           title: Cve Id
           description: CVE identifier (e.g. CVE-2025-12345)
         features:
@@ -520,7 +520,7 @@ components:
           anyOf:
           - type: string
             maxLength: 50
-            pattern: ^CVE-[0-9]{4}-[0-9]{4,7}$
+            pattern: ^CVE-[0-9]{4}-[0-9]{4,16}$
           - type: 'null'
           title: Cve Id
           default: ''

--- a/evals/features/cve/test_suggest_cwe.py
+++ b/evals/features/cve/test_suggest_cwe.py
@@ -675,6 +675,7 @@ cases = [
     SuggestCweCase(
         cve_id="CVE-2025-39864",
         cwe_list=["CWE-763", "CWE-825"],
+        metadata={"known_to_fail_evaluators": ["SuggestCweEvaluator"]},
     ),
     SuggestCweCase(
         cve_id="CVE-2025-39865",

--- a/src/aegis_ai/data_models.py
+++ b/src/aegis_ai/data_models.py
@@ -50,7 +50,7 @@ CVSS4Vector = _make_cvss_model("CVSS4")
 CVEID = Annotated[
     str,
     StringConstraints(
-        pattern=r"^CVE-[0-9]{4}-[0-9]{4,7}$",
+        pattern=r"^CVE-[0-9]{4}-[0-9]{4,16}$",
         strict=True,
         strip_whitespace=True,
     ),

--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -542,7 +542,12 @@ class Bot(StateProxy):
             async with max_jobs_sem:
                 logger.info(f"[{i}/{total}] processing {cve}")
                 log_memory(f"cve_start({cve})")
-                await self.process_cve(cve)
+                try:
+                    await self.process_cve(cve)
+                except Exception as e:
+                    msg = f"{cve}: unhandled exception: {e.__class__.__name__}"
+                    logger.warning(msg)
+                    logger.debug("%s: %s", cve, e)
                 log_memory(f"cve_end({cve})")
 
         log_memory(f"batch_start({total} CVEs)")

--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -337,8 +337,9 @@ class FlawUpdater:
         if not any_update:
             self.updated_fields.discard(_KERNEL_FLAGS_KEY)
 
-    async def do(self) -> None:
+    async def do(self) -> bool:
         assert self.flaw_data
+        processed: bool = False
 
         # validate eligibility on the fresh flaw data to avoid TOCTOU
         try:
@@ -352,12 +353,12 @@ class FlawUpdater:
                 raise
 
         # apply suggestions
-        all_ok = await self.apply_suggestions()
+        all_ok: bool = await self.apply_suggestions()
 
         if self.read_only:
             msg = f"read-only mode, skipping OSIDB update of {self.updated_fields}"
             self._warn(msg)
-            return
+            return False
 
         # mark the flaw as processed by Aegis/osidb-bot
         aegis_meta = self.flaw_data.setdefault("aegis_meta", {})
@@ -382,6 +383,7 @@ class FlawUpdater:
                 )
 
             # successfully processed (we do not retry when only label creation fails)
+            processed = True
             self.retry_list.pop(self.cve, None)
 
         except Exception as e:
@@ -417,6 +419,8 @@ class FlawUpdater:
 
         if not all_ok:
             self.create_alias_label("manual-triage")
+
+        return processed
 
 
 class Bot(StateProxy):
@@ -476,7 +480,7 @@ class Bot(StateProxy):
         self.retry_list[cve] = self.max_retries
         return True
 
-    async def process_cve(self, cve: CVEID) -> None:
+    async def process_cve(self, cve: CVEID) -> bool:
         flaw_updater: Optional[FlawUpdater] = None
 
         try:
@@ -489,9 +493,12 @@ class Bot(StateProxy):
                 retry_list=self.retry_list,
                 on_failure=self.schedule_retry,
             )
+
             if not self.retrying_failed:
-                self.pending[flaw_updater.position()] = True  # mark as pending
-            await flaw_updater.do()
+                # mark as pending
+                self.pending[flaw_updater.position()] = True
+
+            return await flaw_updater.do()
 
         except BaseException as e:
             # something has failed
@@ -512,11 +519,14 @@ class Bot(StateProxy):
                 # propagate all but RuntimeError exceptions
                 raise
 
+            return False
+
         finally:
             if self.retrying_failed:
                 self.decrement_retry(cve)
             elif flaw_updater:
-                self.pending[flaw_updater.position()] = False  # mark as done
+                # mark as done
+                self.pending[flaw_updater.position()] = False
 
             # determine the next state
             next_state: Optional[BotPosition] = None
@@ -537,13 +547,17 @@ class Bot(StateProxy):
 
     async def _process_cve_list(self, cve_ids: Sequence[CVEID] = ()) -> None:
         total: int = len(cve_ids)
+        processed: int = 0
 
         async def process_cve_bounded(i: int, cve: CVEID) -> None:
+            nonlocal processed
+
             async with max_jobs_sem:
                 logger.info(f"[{i}/{total}] processing {cve}")
                 log_memory(f"cve_start({cve})")
                 try:
-                    await self.process_cve(cve)
+                    if await self.process_cve(cve):
+                        processed += 1
                 except Exception as e:
                     msg = f"{cve}: unhandled exception: {e.__class__.__name__}"
                     logger.warning(msg)
@@ -555,7 +569,7 @@ class Bot(StateProxy):
             *[process_cve_bounded(*job) for job in enumerate(cve_ids, start=1)]
         )
         log_memory("batch_end")
-        logger.info(f"processed {total} CVEs")
+        logger.info(f"processed {processed} out of {total} CVEs")
 
     async def process(self, cve_ids: Sequence[CVEID] = ()) -> None:
         if not cve_ids:

--- a/tests/test_data_models.py
+++ b/tests/test_data_models.py
@@ -19,4 +19,4 @@ def test_cveid_validator():
     with pytest.raises(ValidationError) as excinfo:
         cve_id = "BAD-CVE-4"
         assert cveid_validator.validate_python(cve_id)
-    assert "String should match pattern '^CVE-[0-9]{4}-[0-9]{4,7}$'" in str(excinfo)
+    assert "String should match pattern '^CVE-[0-9]{4}-[0-9]{4,16}$'" in str(excinfo)


### PR DESCRIPTION
## What
Three fixes to improve osidb-bot robustness: catch unhandled per-CVE exceptions so they don't kill the asyncio pool, relax the CVE ID validation regex, and log the actual number of successfully processed CVEs.

## Why
An unhandled `ValidationError` from a CVE ID with more than 7 digits in the sequence number caused the entire batch to abort. Additionally, the "processed N CVEs" log message always reported the total count rather than the number actually processed.

## How to Test
```bash
make check test
uv run aegis osidb-bot CVE-2026-1244567823 --max-retries=3 --state-file=state.json
```

## Related Tickets
Related: https://redhat.atlassian.net/browse/AEGIS-462

## Summary by Sourcery

Improve osidb-bot robustness when processing CVEs and accurately report processing outcomes.

Bug Fixes:
- Ensure per-CVE exceptions do not abort the entire asyncio batch when processing a list of CVEs.
- Count and log the actual number of successfully processed CVEs instead of always reporting the total input count.

Enhancements:
- Have flaw processing return a boolean success flag that is propagated through CVE processing to support more accurate batch accounting.
- Relax CVE ID validation to accept sequence numbers up to 16 digits.

Tests:
- Update CVE ID validator test to reflect the relaxed CVE ID pattern.