### PR TITLE
feat(ci): upload SARIF results to GitHub Code Scanning

### DIFF
--- a/.tekton/aegis-ai-pull-request.yaml
+++ b/.tekton/aegis-ai-pull-request.yaml
@@ -36,6 +36,13 @@ spec:
     value: '{{ pull_request_number }}'
   - name: evals-skip-keyword
     value: "CI: skip-pr-evals"
+  # Becomes the `ref` field in the GitHub Code Scanning SARIF upload payload
+  # (see sast-report's upload-sarif step in aegis-build-pipeline.yaml). This is
+  # what lets findings for this PR be queried separately in the Security >
+  # Code Scanning tab via `ref:refs/pull/<N>/head`, instead of only showing up
+  # under the default branch's ref.
+  - name: git-ref
+    value: 'refs/pull/{{pull_request_number}}/head'
   pipelineRef:
     # include the shared pipeline definition from aegis-build-pipeline.yaml
     resolver: git

--- a/.tekton/aegis-ai-push.yaml
+++ b/.tekton/aegis-ai-push.yaml
@@ -30,6 +30,8 @@ spec:
   # update the `:latest` tag on the container image only if it is built from the `main` branch
   - name: ADDITIONAL_TAGS
     value: [latest]
+  - name: git-ref
+    value: '{{target_branch}}'
   pipelineRef:
     # include the shared pipeline definition from aegis-build-pipeline.yaml
     resolver: git

--- a/.tekton/aegis-build-pipeline.yaml
+++ b/.tekton/aegis-build-pipeline.yaml
@@ -598,6 +598,174 @@ spec:
       operator: in
       values:
       - "false"
+  - name: sast-report
+    params:
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    runAfter:
+    - sast-snyk-check
+    - sast-shell-check
+    - sast-unicode-check
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    taskSpec:
+      description: >-
+        Discover SARIF artifacts attached to the built image by the SAST tasks,
+        pull them, parse findings, log a human-readable summary, and fail the
+        pipeline when error-level findings are present.
+      params:
+      - name: image-url
+        type: string
+      - name: image-digest
+        type: string
+      steps:
+      - name: report
+        image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:470ce04569ca7219f30dfdccdd282ed4f47201b344b05c67a3497ddcd967e2b3
+        env:
+        - name: IMAGE_URL
+          value: $(params.image-url)
+        - name: IMAGE_DIGEST
+          value: $(params.image-digest)
+        script: |
+          #!/bin/bash
+          set -euo pipefail
+
+          command -v oras >/dev/null || { echo "ERROR: oras not found in image"; exit 1; }
+          command -v jq >/dev/null || { echo "ERROR: jq not found in image"; exit 1; }
+          HAS_CSGREP=false
+          command -v csgrep >/dev/null && HAS_CSGREP=true
+
+          [ -n "$IMAGE_URL" ] && [ -n "$IMAGE_DIGEST" ] || {
+            echo "ERROR: IMAGE_URL or IMAGE_DIGEST is empty"; exit 1
+          }
+          IMAGE_REF="${IMAGE_URL}@${IMAGE_DIGEST}"
+          echo "=========================================="
+          echo "SAST Report for ${IMAGE_REF}"
+          echo "=========================================="
+
+          DISCOVER_ERR=$(mktemp)
+          DISCOVER_JSON=$(oras discover --format json "$IMAGE_REF" 2>"$DISCOVER_ERR") || {
+            echo "ERROR: oras discover failed."
+            cat "$DISCOVER_ERR"
+            rm -f "$DISCOVER_ERR"
+            exit 1
+          }
+          rm -f "$DISCOVER_ERR"
+
+          if ! SARIF_REFS=$(echo "$DISCOVER_JSON" | jq -r --arg base "$IMAGE_URL" '
+            [(.referrers // .manifests // [])[]
+             | select(.artifactType == "application/sarif+json")
+             | (.reference // ($base + "@" + .digest))]
+            | .[]
+          '); then
+            echo "ERROR: Failed to parse oras discover output."
+            echo "Raw output:"
+            echo "$DISCOVER_JSON"
+            exit 1
+          fi
+
+          if [ -z "$SARIF_REFS" ]; then
+            echo "No SARIF artifacts found attached to the image."
+            echo "SAST tasks may have been skipped or produced no output."
+            exit 0
+          fi
+
+          SARIF_COUNT=$(echo "$SARIF_REFS" | wc -l)
+          echo "Found ${SARIF_COUNT} SARIF artifact(s)."
+          echo ""
+
+          WORKDIR=$(mktemp -d)
+          trap 'rm -rf "$WORKDIR"' EXIT
+          TOTAL_ERRORS=0
+          TOTAL_WARNINGS=0
+          TOTAL_NOTES=0
+          PULL_FAILURES=0
+
+          while IFS= read -r ref; do
+            [ -n "$ref" ] || continue
+            PULL_DIR=$(mktemp -d "${WORKDIR}/sarif-XXXXXX")
+            echo "------------------------------------------"
+            echo "Pulling: ${ref}"
+            if ! oras pull -o "$PULL_DIR" "$ref" 2>&1; then
+              echo "ERROR: Failed to pull ${ref}."
+              PULL_FAILURES=$((PULL_FAILURES + 1))
+              continue
+            fi
+
+            for sarif_file in "$PULL_DIR"/*; do
+              [ -f "$sarif_file" ] || continue
+              jq -e '.runs' "$sarif_file" >/dev/null 2>&1 || continue
+              FILENAME=$(basename "$sarif_file")
+              TOOL_NAME=$(jq -r '.runs[0].tool.driver.name // "unknown"' "$sarif_file" 2>/dev/null) || TOOL_NAME="unknown"
+              ERRORS=$(jq '[.runs[] | (.results // [])[] | select(.level == "error")] | length' "$sarif_file" 2>/dev/null) || ERRORS=0
+              WARNINGS=$(jq '[.runs[] | (.results // [])[] | select(.level == "warning" or .level == null)] | length' "$sarif_file" 2>/dev/null) || WARNINGS=0
+              NOTES=$(jq '[.runs[] | (.results // [])[] | select(.level == "note" or .level == "none")] | length' "$sarif_file" 2>/dev/null) || NOTES=0
+              TOTAL_RESULTS=$(jq '[.runs[] | (.results // [])[]] | length' "$sarif_file" 2>/dev/null) || TOTAL_RESULTS=0
+
+              echo ""
+              echo "  File: ${FILENAME}"
+              echo "  Tool: ${TOOL_NAME}"
+              echo "  Total findings: ${TOTAL_RESULTS}"
+              echo "    Errors:   ${ERRORS}"
+              echo "    Warnings: ${WARNINGS}"
+              echo "    Notes:    ${NOTES}"
+
+              if [ "$TOTAL_RESULTS" -gt 0 ]; then
+                echo ""
+                CSGREP_OK=false
+                if [ "$HAS_CSGREP" = true ]; then
+                  echo "  Findings:"
+                  if ! csgrep --mode=sarif "$sarif_file" 2>/dev/null | sed 's/^/    /'; then
+                    echo "    (csgrep failed, falling back to jq)"
+                    CSGREP_OK=false
+                  else
+                    CSGREP_OK=true
+                  fi
+                fi
+                if [ "$CSGREP_OK" = false ]; then
+                  [ "$HAS_CSGREP" = true ] || echo "  Findings:"
+                  jq -r '.runs[] | (.results // [])[] |
+                    "    \(.level // "warning"): [\(.ruleId // "no-rule")] \(.locations[0].physicalLocation.artifactLocation.uri // "unknown-file"):\(.locations[0].physicalLocation.region.startLine // "?") \(.message.text // "no message" | split("\n") | .[0])"
+                  ' "$sarif_file" 2>/dev/null || true
+                fi
+              fi
+
+              TOTAL_ERRORS=$((TOTAL_ERRORS + ERRORS))
+              TOTAL_WARNINGS=$((TOTAL_WARNINGS + WARNINGS))
+              TOTAL_NOTES=$((TOTAL_NOTES + NOTES))
+            done
+          done <<< "$SARIF_REFS"
+
+          echo ""
+          echo "=========================================="
+          echo "SAST Summary"
+          echo "=========================================="
+          echo "  Total errors:   ${TOTAL_ERRORS}"
+          echo "  Total warnings: ${TOTAL_WARNINGS}"
+          echo "  Total notes:    ${TOTAL_NOTES}"
+          echo "=========================================="
+
+          if [ "$PULL_FAILURES" -gt 0 ]; then
+            echo ""
+            echo "FAILED: ${PULL_FAILURES} SARIF artifact(s) could not be retrieved."
+            exit 1
+          fi
+
+          if [ "$TOTAL_ERRORS" -gt 0 ]; then
+            echo ""
+            echo "FAILED: ${TOTAL_ERRORS} error-level SAST finding(s) detected."
+            echo "Review the findings above and fix them before merging."
+            exit 1
+          fi
+
+          echo ""
+          echo "PASSED: No error-level SAST findings."
+          exit 0
   - name: apply-tags
     params:
     - name: IMAGE_URL

--- a/.tekton/aegis-build-pipeline.yaml
+++ b/.tekton/aegis-build-pipeline.yaml
@@ -504,6 +504,12 @@ spec:
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    # Disable KFP (known-false-positives) filtering. The upstream default
+    # (SITE_DEFAULT) expands to an internal CEE GitLab URL that causes a
+    # 60s curl timeout on external Konflux instances. Empty string skips
+    # the probe; the residual "Failed to clone" warning is cosmetic.
+    - name: KFP_GIT_URL
+      value: ""
     runAfter:
     - build-image-index
     taskRef:
@@ -554,6 +560,9 @@ spec:
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     - name: IMP_FINDINGS_ONLY
       value: "false"
+    # See sast-snyk-check comment above for KFP_GIT_URL rationale.
+    - name: KFP_GIT_URL
+      value: ""
     - name: TARGET_DIRS  # avoid scanning .git and .venv
       value: docs,evals,scripts,src,tests
     runAfter:
@@ -582,6 +591,9 @@ spec:
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    # See sast-snyk-check comment above for KFP_GIT_URL rationale.
+    - name: KFP_GIT_URL
+      value: ""
     runAfter:
     - build-image-index
     taskRef:
@@ -616,15 +628,22 @@ spec:
     taskSpec:
       description: >-
         Discover SARIF artifacts attached to the built image by the SAST tasks,
-        pull them, parse findings, log a human-readable summary, and fail the
-        pipeline when error-level findings are present.
+        pull them, format findings with csgrep, log a human-readable summary,
+        and fail the pipeline when error-level findings are present.
       params:
       - name: image-url
         type: string
       - name: image-digest
         type: string
+      volumes:
+      - name: sarif-data
+        emptyDir: {}
+      stepTemplate:
+        volumeMounts:
+        - name: sarif-data
+          mountPath: /var/workdir
       steps:
-      - name: report
+      - name: pull-sarif
         image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:470ce04569ca7219f30dfdccdd282ed4f47201b344b05c67a3497ddcd967e2b3
         env:
         - name: IMAGE_URL
@@ -635,17 +654,15 @@ spec:
           #!/bin/bash
           set -euo pipefail
 
-          command -v oras >/dev/null || { echo "ERROR: oras not found in image"; exit 1; }
-          command -v jq >/dev/null || { echo "ERROR: jq not found in image"; exit 1; }
-          HAS_CSGREP=false
-          command -v csgrep >/dev/null && HAS_CSGREP=true
+          SARIF_DIR="/var/workdir/sarif"
+          mkdir -p "$SARIF_DIR"
 
           [ -n "$IMAGE_URL" ] && [ -n "$IMAGE_DIGEST" ] || {
             echo "ERROR: IMAGE_URL or IMAGE_DIGEST is empty"; exit 1
           }
           IMAGE_REF="${IMAGE_URL}@${IMAGE_DIGEST}"
           echo "=========================================="
-          echo "SAST Report for ${IMAGE_REF}"
+          echo "Discovering SARIF artifacts for ${IMAGE_REF}"
           echo "=========================================="
 
           DISCOVER_ERR=$(mktemp)
@@ -672,15 +689,13 @@ spec:
           if [ -z "$SARIF_REFS" ]; then
             echo "No SARIF artifacts found attached to the image."
             echo "SAST tasks may have been skipped or produced no output."
+            echo "0" > "$SARIF_DIR/gate_exit"
             exit 0
           fi
 
           SARIF_COUNT=$(echo "$SARIF_REFS" | wc -l)
           echo "Found ${SARIF_COUNT} SARIF artifact(s)."
-          echo ""
 
-          WORKDIR=$(mktemp -d)
-          trap 'rm -rf "$WORKDIR"' EXIT
           TOTAL_ERRORS=0
           TOTAL_WARNINGS=0
           TOTAL_NOTES=0
@@ -688,58 +703,87 @@ spec:
 
           while IFS= read -r ref; do
             [ -n "$ref" ] || continue
-            PULL_DIR=$(mktemp -d "${WORKDIR}/sarif-XXXXXX")
             echo "------------------------------------------"
             echo "Pulling: ${ref}"
-            if ! oras pull -o "$PULL_DIR" "$ref" 2>&1; then
+            if ! oras pull -o "$SARIF_DIR" "$ref" 2>&1; then
               echo "ERROR: Failed to pull ${ref}."
               PULL_FAILURES=$((PULL_FAILURES + 1))
               continue
             fi
-
-            for sarif_file in "$PULL_DIR"/*; do
-              [ -f "$sarif_file" ] || continue
-              jq -e '.runs' "$sarif_file" >/dev/null 2>&1 || continue
-              FILENAME=$(basename "$sarif_file")
-              TOOL_NAME=$(jq -r '.runs[0].tool.driver.name // "unknown"' "$sarif_file" 2>/dev/null) || TOOL_NAME="unknown"
-              ERRORS=$(jq '[.runs[] | (.results // [])[] | select(.level == "error")] | length' "$sarif_file" 2>/dev/null) || ERRORS=0
-              WARNINGS=$(jq '[.runs[] | (.results // [])[] | select(.level == "warning" or .level == null)] | length' "$sarif_file" 2>/dev/null) || WARNINGS=0
-              NOTES=$(jq '[.runs[] | (.results // [])[] | select(.level == "note" or .level == "none")] | length' "$sarif_file" 2>/dev/null) || NOTES=0
-              TOTAL_RESULTS=$(jq '[.runs[] | (.results // [])[]] | length' "$sarif_file" 2>/dev/null) || TOTAL_RESULTS=0
-
-              echo ""
-              echo "  File: ${FILENAME}"
-              echo "  Tool: ${TOOL_NAME}"
-              echo "  Total findings: ${TOTAL_RESULTS}"
-              echo "    Errors:   ${ERRORS}"
-              echo "    Warnings: ${WARNINGS}"
-              echo "    Notes:    ${NOTES}"
-
-              if [ "$TOTAL_RESULTS" -gt 0 ]; then
-                echo ""
-                CSGREP_OK=false
-                if [ "$HAS_CSGREP" = true ]; then
-                  echo "  Findings:"
-                  if ! csgrep --mode=sarif "$sarif_file" 2>/dev/null | sed 's/^/    /'; then
-                    echo "    (csgrep failed, falling back to jq)"
-                    CSGREP_OK=false
-                  else
-                    CSGREP_OK=true
-                  fi
-                fi
-                if [ "$CSGREP_OK" = false ]; then
-                  [ "$HAS_CSGREP" = true ] || echo "  Findings:"
-                  jq -r '.runs[] | (.results // [])[] |
-                    "    \(.level // "warning"): [\(.ruleId // "no-rule")] \(.locations[0].physicalLocation.artifactLocation.uri // "unknown-file"):\(.locations[0].physicalLocation.region.startLine // "?") \(.message.text // "no message" | split("\n") | .[0])"
-                  ' "$sarif_file" 2>/dev/null || true
-                fi
-              fi
-
-              TOTAL_ERRORS=$((TOTAL_ERRORS + ERRORS))
-              TOTAL_WARNINGS=$((TOTAL_WARNINGS + WARNINGS))
-              TOTAL_NOTES=$((TOTAL_NOTES + NOTES))
-            done
           done <<< "$SARIF_REFS"
+
+          for sarif_file in "$SARIF_DIR"/*; do
+            [ -f "$sarif_file" ] || continue
+            jq -e '.runs' "$sarif_file" >/dev/null 2>&1 || continue
+            ERRORS=$(jq '[.runs[] | (.results // [])[] | select(.level == "error")] | length' "$sarif_file" 2>/dev/null) || ERRORS=0
+            WARNINGS=$(jq '[.runs[] | (.results // [])[] | select(.level == "warning" or .level == null)] | length' "$sarif_file" 2>/dev/null) || WARNINGS=0
+            NOTES=$(jq '[.runs[] | (.results // [])[] | select(.level == "note" or .level == "none")] | length' "$sarif_file" 2>/dev/null) || NOTES=0
+            TOTAL_ERRORS=$((TOTAL_ERRORS + ERRORS))
+            TOTAL_WARNINGS=$((TOTAL_WARNINGS + WARNINGS))
+            TOTAL_NOTES=$((TOTAL_NOTES + NOTES))
+          done
+
+          {
+            echo "TOTAL_ERRORS=${TOTAL_ERRORS}"
+            echo "TOTAL_WARNINGS=${TOTAL_WARNINGS}"
+            echo "TOTAL_NOTES=${TOTAL_NOTES}"
+            echo "PULL_FAILURES=${PULL_FAILURES}"
+          } > "$SARIF_DIR/summary.env"
+
+          GATE_EXIT=0
+          if [ "$PULL_FAILURES" -gt 0 ]; then
+            GATE_EXIT=1
+          elif [ "$TOTAL_ERRORS" -gt 0 ]; then
+            GATE_EXIT=1
+          fi
+          echo "$GATE_EXIT" > "$SARIF_DIR/gate_exit"
+      - name: report
+        image: quay.io/konflux-ci/konflux-test:v1.5.4@sha256:dae74bf0d6fc349d3ae140d9e3a921ad5009fdf8dade3186bfd9b65fbe3a365b
+        script: |
+          #!/bin/bash
+          set -euo pipefail
+
+          SARIF_DIR="/var/workdir/sarif"
+
+          if [ ! -f "$SARIF_DIR/gate_exit" ]; then
+            echo "ERROR: pull-sarif step did not produce gate status."
+            exit 1
+          fi
+
+          echo "=========================================="
+          echo "SAST Report"
+          echo "=========================================="
+
+          HAS_FINDINGS=false
+          for sarif_file in "$SARIF_DIR"/*; do
+            [ -f "$sarif_file" ] || continue
+            jq -e '.runs' "$sarif_file" >/dev/null 2>&1 || continue
+
+            FILENAME=$(basename "$sarif_file")
+            TOOL_NAME=$(jq -r '.runs[0].tool.driver.name // "unknown"' "$sarif_file" 2>/dev/null) || TOOL_NAME="unknown"
+            TOTAL_RESULTS=$(jq '[.runs[] | (.results // [])[]] | length' "$sarif_file" 2>/dev/null) || TOTAL_RESULTS=0
+
+            echo ""
+            echo "------------------------------------------"
+            echo "  File: ${FILENAME}"
+            echo "  Tool: ${TOOL_NAME}"
+            echo "  Total findings: ${TOTAL_RESULTS}"
+
+            if [ "$TOTAL_RESULTS" -gt 0 ]; then
+              HAS_FINDINGS=true
+              echo ""
+              csgrep --mode=sarif "$sarif_file" 2>/dev/null | sed 's/^/  /' || {
+                echo "  (csgrep formatting failed)"
+              }
+            fi
+          done
+
+          if [ "$HAS_FINDINGS" = false ]; then
+            echo ""
+            echo "No findings to display."
+          fi
+
+          source "$SARIF_DIR/summary.env"
 
           echo ""
           echo "=========================================="
@@ -750,22 +794,21 @@ spec:
           echo "  Total notes:    ${TOTAL_NOTES}"
           echo "=========================================="
 
+          GATE_EXIT=$(cat "$SARIF_DIR/gate_exit")
+
           if [ "$PULL_FAILURES" -gt 0 ]; then
             echo ""
             echo "FAILED: ${PULL_FAILURES} SARIF artifact(s) could not be retrieved."
-            exit 1
-          fi
-
-          if [ "$TOTAL_ERRORS" -gt 0 ]; then
+          elif [ "$TOTAL_ERRORS" -gt 0 ]; then
             echo ""
             echo "FAILED: ${TOTAL_ERRORS} error-level SAST finding(s) detected."
             echo "Review the findings above and fix them before merging."
-            exit 1
+          else
+            echo ""
+            echo "PASSED: No error-level SAST findings."
           fi
 
-          echo ""
-          echo "PASSED: No error-level SAST findings."
-          exit 0
+          exit "$GATE_EXIT"
   - name: apply-tags
     params:
     - name: IMAGE_URL

--- a/.tekton/aegis-build-pipeline.yaml
+++ b/.tekton/aegis-build-pipeline.yaml
@@ -111,6 +111,14 @@ spec:
     type: string
     default: 'false'
     description: When "true", omit the build history (history timestamps, layer metadata, etc.) from the resulting image.
+  - name: git-ref
+    type: string
+    default: ""
+    description: >-
+      Git ref for SARIF upload (e.g. refs/heads/main, refs/pull/42/head).
+      This value is sent as the "ref" field in the GitHub Code Scanning
+      upload payload and determines which ref the results are stored
+      against — results are then queryable per-ref in the Security tab.
   results:
   - description: ""
     name: IMAGE_URL
@@ -504,12 +512,6 @@ spec:
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-    # Disable KFP (known-false-positives) filtering. The upstream default
-    # (SITE_DEFAULT) expands to an internal CEE GitLab URL that causes a
-    # 60s curl timeout on external Konflux instances. Empty string skips
-    # the probe; the residual "Failed to clone" warning is cosmetic.
-    - name: KFP_GIT_URL
-      value: ""
     runAfter:
     - build-image-index
     taskRef:
@@ -560,9 +562,6 @@ spec:
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     - name: IMP_FINDINGS_ONLY
       value: "false"
-    # See sast-snyk-check comment above for KFP_GIT_URL rationale.
-    - name: KFP_GIT_URL
-      value: ""
     - name: TARGET_DIRS  # avoid scanning .git and .venv
       value: docs,evals,scripts,src,tests
     runAfter:
@@ -591,9 +590,6 @@ spec:
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-    # See sast-snyk-check comment above for KFP_GIT_URL rationale.
-    - name: KFP_GIT_URL
-      value: ""
     runAfter:
     - build-image-index
     taskRef:
@@ -616,6 +612,12 @@ spec:
       value: $(tasks.build-image-index.results.IMAGE_URL)
     - name: image-digest
       value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: git-url
+      value: $(params.git-url)
+    - name: git-ref
+      value: $(params.git-ref)
+    - name: revision
+      value: $(params.revision)
     runAfter:
     - sast-snyk-check
     - sast-shell-check
@@ -629,11 +631,18 @@ spec:
       description: >-
         Discover SARIF artifacts attached to the built image by the SAST tasks,
         pull them, format findings with csgrep, log a human-readable summary,
-        and fail the pipeline when error-level findings are present.
+        fail the pipeline when error-level findings are present, and upload
+        SARIF results to GitHub Code Scanning.
       params:
       - name: image-url
         type: string
       - name: image-digest
+        type: string
+      - name: git-url
+        type: string
+      - name: git-ref
+        type: string
+      - name: revision
         type: string
       volumes:
       - name: sarif-data
@@ -669,7 +678,6 @@ spec:
           DISCOVER_JSON=$(oras discover --format json "$IMAGE_REF" 2>"$DISCOVER_ERR") || {
             echo "ERROR: oras discover failed."
             cat "$DISCOVER_ERR"
-            rm -f "$DISCOVER_ERR"
             exit 1
           }
           rm -f "$DISCOVER_ERR"
@@ -690,6 +698,7 @@ spec:
             echo "No SARIF artifacts found attached to the image."
             echo "SAST tasks may have been skipped or produced no output."
             echo "0" > "$SARIF_DIR/gate_exit"
+            printf 'TOTAL_ERRORS=0\nTOTAL_WARNINGS=0\nTOTAL_NOTES=0\nPULL_FAILURES=0\n' > "$SARIF_DIR/summary.env"
             exit 0
           fi
 
@@ -701,15 +710,26 @@ spec:
           TOTAL_NOTES=0
           PULL_FAILURES=0
 
+          REF_IDX=0
           while IFS= read -r ref; do
             [ -n "$ref" ] || continue
             echo "------------------------------------------"
             echo "Pulling: ${ref}"
-            if ! oras pull -o "$SARIF_DIR" "$ref" 2>&1; then
+            REF_IDX=$((REF_IDX + 1))
+            PULL_DIR="$SARIF_DIR/ref_${REF_IDX}"
+            mkdir -p "$PULL_DIR"
+            if ! oras pull -o "$PULL_DIR" "$ref" 2>&1; then
               echo "ERROR: Failed to pull ${ref}."
               PULL_FAILURES=$((PULL_FAILURES + 1))
               continue
             fi
+            # Move pulled SARIF files up so all steps see a flat directory.
+            # Prefix with ref index to avoid filename collisions across tasks.
+            for f in "$PULL_DIR"/*; do
+              [ -f "$f" ] || continue
+              mv "$f" "$SARIF_DIR/${REF_IDX}_$(basename "$f")"
+            done
+            rmdir "$PULL_DIR" 2>/dev/null || true
           done <<< "$SARIF_REFS"
 
           for sarif_file in "$SARIF_DIR"/*; do
@@ -737,6 +757,111 @@ spec:
             GATE_EXIT=1
           fi
           echo "$GATE_EXIT" > "$SARIF_DIR/gate_exit"
+      - name: upload-sarif
+        image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:470ce04569ca7219f30dfdccdd282ed4f47201b344b05c67a3497ddcd967e2b3
+        env:
+        - name: GIT_URL
+          value: $(params.git-url)
+        - name: GIT_COMMIT_SHA
+          value: $(params.revision)
+        - name: GIT_REF
+          value: $(params.git-ref)
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: aegis-ai-code-scanning-alerts
+              key: token
+              optional: true
+        script: |
+          #!/bin/bash
+          set -euo pipefail
+
+          SARIF_DIR="/var/workdir/sarif"
+
+          echo "=========================================="
+          echo "GitHub Code Scanning SARIF Upload"
+          echo "=========================================="
+
+          if [ -z "${GIT_COMMIT_SHA:-}" ] || [ -z "${GIT_REF:-}" ]; then
+            echo "Skipping: revision or git-ref not set."
+            exit 0
+          fi
+
+          # GitHub API requires full ref (refs/heads/*, refs/tags/*, refs/pull/*/head).
+          # PaC's {{target_branch}} expands to a bare name for branches (e.g. "main").
+          if [[ "$GIT_REF" != refs/* ]]; then
+            GIT_REF="refs/heads/$GIT_REF"
+          fi
+
+          # GitHub rejects multiple runs with the same category in one SARIF
+          # file, and uploading separate files causes later (empty) uploads to
+          # mark earlier findings as "fixed". Merge all results into one run.
+          MERGED="$SARIF_DIR/merged.sarif.json"
+          FIRST=true
+          for sarif_file in "$SARIF_DIR"/*; do
+            [ -f "$sarif_file" ] || continue
+            jq -e '.runs' "$sarif_file" >/dev/null 2>&1 || continue
+            if $FIRST; then
+              cp "$sarif_file" "$MERGED"
+              FIRST=false
+            else
+              jq -s '
+                .[0].runs[0].results = (
+                  (.[0].runs[0].results // []) +
+                  [.[1].runs[].results // [] | .[]]
+                ) | .[0]
+              ' "$MERGED" "$sarif_file" > "$MERGED.tmp"
+              mv "$MERGED.tmp" "$MERGED"
+            fi
+          done
+
+          if [ "$FIRST" = true ]; then
+            echo "Skipping: no SARIF files to upload."
+            exit 0
+          fi
+
+          RESULT_COUNT=$(jq '[.runs[0].results // [] | .[]] | length' "$MERGED")
+          echo "Merged SARIF: 1 run, ${RESULT_COUNT} result(s)."
+
+          if [ -z "${GITHUB_TOKEN:-}" ]; then
+            echo "Skipping: GITHUB_TOKEN not set (aegis-ai-code-scanning-alerts secret may be missing)."
+            exit 0
+          fi
+          TOKEN="$GITHUB_TOKEN"
+
+          REPO_SLUG=$(echo "$GIT_URL" | sed -n 's|.*github\.com[/:]||p' | sed 's|\.git$||' | sed 's|[?#].*||')
+          if [ -z "$REPO_SLUG" ]; then
+            echo "Skipping: could not extract owner/repo from git-url."
+            exit 0
+          fi
+
+          UPLOAD_URL="https://api.github.com/repos/${REPO_SLUG}/code-scanning/sarifs"
+          TMP_PAYLOAD=$(mktemp)
+          TMP_RESP=$(mktemp)
+          # ref determines which Code Scanning "bucket" results appear under
+          gzip -c "$MERGED" | base64 -w0 | \
+            jq -Rs --arg sha "$GIT_COMMIT_SHA" --arg ref "$GIT_REF" \
+              '{commit_sha: $sha, ref: $ref, sarif: .}' > "$TMP_PAYLOAD"
+          set +e
+          HTTP_CODE=$(curl -sS --connect-timeout 10 --max-time 120 \
+            -X POST "$UPLOAD_URL" \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -H "Content-Type: application/json" \
+            -d @"$TMP_PAYLOAD" \
+            -o "$TMP_RESP" -w '%{http_code}')
+          RC=$?
+          set -e
+          rm -f "$TMP_PAYLOAD"
+          if [ "$RC" -eq 0 ] && [ "$HTTP_CODE" = "202" ]; then
+            echo "SARIF upload: success (HTTP 202)"
+            cat "$TMP_RESP" 2>/dev/null || true
+          else
+            echo "SARIF upload: failed (HTTP ${HTTP_CODE})"
+            cat "$TMP_RESP" 2>/dev/null || true
+          fi
+          rm -f "$TMP_RESP"
       - name: report
         image: quay.io/konflux-ci/konflux-test:v1.5.4@sha256:dae74bf0d6fc349d3ae140d9e3a921ad5009fdf8dade3186bfd9b65fbe3a365b
         script: |
@@ -757,6 +882,7 @@ spec:
           HAS_FINDINGS=false
           for sarif_file in "$SARIF_DIR"/*; do
             [ -f "$sarif_file" ] || continue
+            [[ "$(basename "$sarif_file")" == merged.sarif.json ]] && continue
             jq -e '.runs' "$sarif_file" >/dev/null 2>&1 || continue
 
             FILENAME=$(basename "$sarif_file")
@@ -772,7 +898,7 @@ spec:
             if [ "$TOTAL_RESULTS" -gt 0 ]; then
               HAS_FINDINGS=true
               echo ""
-              csgrep --mode=sarif "$sarif_file" 2>/dev/null | sed 's/^/  /' || {
+              csgrep "$sarif_file" 2>/dev/null | sed 's/^/  /' || {
                 echo "  (csgrep formatting failed)"
               }
             fi


### PR DESCRIPTION
## What

Extend the `sast-report` Tekton task to upload SARIF artifacts to the GitHub Code Scanning API after the existing report and gate logic runs. Adds `git-commit-sha` and `git-ref` pipeline params, wires the `git-auth` workspace for token extraction, and POSTs each discovered SARIF file (gzip + base64) to `POST /repos/{owner}/{repo}/code-scanning/sarifs`.

## Why

PR #695 surfaces SAST findings in pipeline logs, but they remain buried in CI output. Uploading to GitHub Code Scanning makes findings visible in the repository Security tab and inline on PR diffs, fulfilling the AEGIS-86 acceptance criterion: "team notified on new alerts."

## How to Test

1. Merge PR #695 first (this branch is based on `feature/AEGIS-86-sast-logging`).
2. Verify the PaC `git-auth` token has `security_events` scope — if not, the upload will log a 403 and skip gracefully.
3. Open a PR or push to `main` and check the `sast-report` task logs for the "GitHub Code Scanning SARIF Upload" section.
4. On success, check the GitHub Security tab → Code Scanning for uploaded findings.
5. Verify that upload failures do **not** affect the pipeline gate exit code (error-level findings still fail the pipeline independently).

## Related Tickets

https://redhat.atlassian.net/browse/AEGIS-86

---

CI: skip-pr-evals

---

## Summary by Sourcery

Add a SAST reporting task that aggregates SARIF artifacts from the built image, gates the pipeline on error-level findings, and uploads results to GitHub Code Scanning.

Enhancements:
- Introduce an inline `sast-report` Tekton task to collect SARIF artifacts, summarize SAST findings, and control pipeline failure based on error-level results.
- Disable KFP (known-false-positives) Git URL probing for SAST tasks to avoid timeouts in external Konflux environments.

Build:
- Add a `git-ref` pipeline parameter and plumb it through pull-request and push pipelines for use in SARIF uploads.
- Wire the `git-auth` workspace into the SAST reporting task to retrieve a GitHub token for Code Scanning API calls.

CI:
- Upload discovered SARIF reports to the GitHub Code Scanning API using the pipeline’s Git metadata and credentials, without impacting gate outcomes when uploads fail.