### PR TITLE
fix: accept both list and string for comments in CVEFeatureInput

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - 2026-07-28
+
+### Fixed
+- accept both lists and strings for `comments` in web API CVE input to fix `ValidationError` from OSIM requests [\[AEGIS-431\]](https://redhat.atlassian.net/browse/AEGIS-431)
+
+
 ## [0.8.0] - 2026-07-28
 
 ### Changed

--- a/src/aegis_ai/features/cve/data_models.py
+++ b/src/aegis_ai/features/cve/data_models.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from pydantic import Field, BaseModel, PrivateAttr, model_validator
 
@@ -15,7 +15,9 @@ class CVEFeatureInput(BaseModel):
     statement: Optional[str] = Field(None, description="CVE statement")
     mitigation: Optional[str] = Field(None, description="CVE mitigation")
     comment_zero: Optional[str] = Field(None, description="CVE comment_zero")
-    comments: Optional[List] = Field(None, description="All public comments")
+    comments: Optional[Union[List, str]] = Field(
+        None, description="All public comments"
+    )
     components: Optional[List] = Field(None, description="List of components")
     references: Optional[List] = Field(None, description="List of references")
     affects: Optional[List] = Field(None, description="List of affects")

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -259,6 +259,11 @@ class TestBuildCveInput:
         assert result.affects == [{"ps_module": "rhel-9"}]
         assert result.cvss_scores is not None and len(result.cvss_scores) == 1
 
+    def test_comments_accepts_string(self):
+        ctx = {"comments": "Additional context."}
+        result = cve._build_cve_input("CVE-2025-1234", ctx)
+        assert result.comments == "Additional context."
+
     def test_description_fallback_to_cve_description(self):
         ctx = {"cve_description": "NVD description text."}
         result = cve._build_cve_input("CVE-2025-1234", ctx)


### PR DESCRIPTION
## What
Accept both list and string types for the `comments` field in `CVEFeatureInput` to handle payloads from both OSIDB (list) and OSIM (string).

## Why
OSIM sends POST requests where `comments` is a string, which caused `ValidationError` after commit 0f249e46 changed the type from `Optional[str]` to `Optional[List]`.

## How to Test
Try an interactive suggestion in OSIM.

## Related Tickets
Related: https://redhat.atlassian.net/browse/AEGIS-431

## Summary by Sourcery

Allow CVE web API input to accept both list and string values for comments to restore compatibility with OSIM payloads.

Bug Fixes:
- Fix ValidationError by allowing the CVEFeatureInput comments field to accept either a list or a string from different upstream systems.

Documentation:
- Document the comments input compatibility fix in the changelog for version 0.8.1.

Tests:
- Add a regression test ensuring comments can be provided as a string in CVE feature input.