### PR TITLE
fix(ci): disable GitHub Actions evals on PRs

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -1,8 +1,8 @@
 name: Evals
 
 on:
-  pull_request:
-    branches: [ "main" ]
+  push:
+    branches: [ "github-actions-evals" ]
 
 permissions:
   contents: read


### PR DESCRIPTION
## What
Disable GitHub Actions evals on PRs.

## Why
The LLM provider used by GitHub Actions evals is being decommissioned on August 3rd, 2026.  Until we find a suitable replacement for it, this action will be disabled for pull requests.  It can still be triggered by pushes to the `github-actions-evals` upstream branch.

## How to Test
Check that the upstream CI is green again.

## Related Tickets
Related: https://redhat.atlassian.net/browse/AEGIS-481

## Summary by Sourcery

CI:
- Update evals workflow trigger to run on pushes to the github-actions-evals branch and disable PR-based runs.