### PR TITLE
osidb-bot: use `updated_dt` instead of `created_dt` in `BotPosition`

### DIFF
--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -341,9 +341,53 @@ class FlawUpdater:
         if not any_update:
             self.updated_fields.discard(_KERNEL_FLAGS_KEY)
 
+    def save_flaw(self) -> bool:
+        """Save flaw data to OSIDB (two-step: flaw update + CVSS subresource).
+
+        Returns True if the flaw was fully saved, False on error.
+        """
+        assert self.flaw_data
+        flaw_saved: bool = False
+        try:
+            flaw_uuid = self.flaw_data["uuid"]
+            self.osidb.flaws.update(
+                id=flaw_uuid,
+                form_data=self.flaw_data,
+            )
+            flaw_saved = True
+
+            if "cvss_scores" in self.updated_fields:
+                # Apply RH CVSS via subresource (flaws.update() does not update cvss_scores)
+                rh_cvss = self.flaw_data["cvss_scores"][0]
+                cast(Any, self.osidb.flaws).cvss_scores.create(
+                    flaw_id=flaw_uuid,
+                    form_data=rh_cvss,
+                )
+
+            # successfully processed (we do not retry when only label creation fails)
+            self.retry_list.pop(self.cve, None)
+            return True
+
+        except Exception as e:
+            # failed to save changes
+            msg_suffix = f"({e.__class__.__name__})"
+            if flaw_saved:
+                self._warn(f"failed to save RH CVSS {msg_suffix}")
+                self.updated_fields.remove("cvss_scores")
+            else:
+                self._warn(
+                    f"failed to save changes: {self.updated_fields} {msg_suffix}"
+                )
+                self.updated_fields.clear()
+
+            self._log_osidb_response(e)
+
+            # log full exception in debug mode only
+            logger.debug(f"{self.cve}: {e!s}")
+            return False
+
     async def do(self) -> bool:
         assert self.flaw_data
-        processed: bool = False
 
         # validate eligibility on the fresh flaw data to avoid TOCTOU
         try:
@@ -369,45 +413,9 @@ class FlawUpdater:
         aegis_meta["processed"] = True
 
         # write flaw data
-        flaw_saved: bool = False
-        try:
-            flaw_uuid = self.flaw_data["uuid"]
-            self.osidb.flaws.update(
-                id=flaw_uuid,
-                form_data=self.flaw_data,
-            )
-            flaw_saved = True
-
-            if "cvss_scores" in self.updated_fields:
-                # Apply RH CVSS via subresource (flaws.update() does not update cvss_scores)
-                rh_cvss = self.flaw_data["cvss_scores"][0]
-                cast(Any, self.osidb.flaws).cvss_scores.create(
-                    flaw_id=flaw_uuid,
-                    form_data=rh_cvss,
-                )
-
-            # successfully processed (we do not retry when only label creation fails)
-            processed = True
-            self.retry_list.pop(self.cve, None)
-
-        except Exception as e:
-            # failed to save changes
+        processed: bool = self.save_flaw()
+        if not processed:
             all_ok = self.on_failure(self.cve) if self.on_failure else False
-
-            msg_suffix = f"({e.__class__.__name__})"
-            if flaw_saved:
-                self._warn(f"failed to save RH CVSS {msg_suffix}")
-                self.updated_fields.remove("cvss_scores")
-            else:
-                self._warn(
-                    f"failed to save changes: {self.updated_fields} {msg_suffix}"
-                )
-                self.updated_fields.clear()
-
-            self._log_osidb_response(e)
-
-            # log full exception in debug mode only
-            logger.debug(f"{self.cve}: {e!s}")
 
         if _KERNEL_FLAGS_KEY in self.updated_fields:
             self._create_labels()

--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -48,12 +48,8 @@ ELIGIBLE_FLAWS = {
         "UBUNTU",
         "UPSTREAM",
     ),
-    # only flaws in the empty/NEW states
-    "classification": (
-        {"workflow": "", "state": ""},
-        {"workflow": "DEFAULT", "state": ""},
-        {"workflow": "DEFAULT", "state": "NEW"},
-    ),
+    # only flaws with the DEFAULT workflow in the NEW state
+    "classification": ({"workflow": "DEFAULT", "state": "NEW"},),
     # only flaws with no affects
     "affects": ([],),
     # only flaws with no owner

--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -118,7 +118,7 @@ class FlawFinder:
     ) -> Sequence[CVEID]:
         # infer search predicates from ELIGIBLE_FLAWS
         kwargs: dict[str, Any] = {
-            "include_fields": ["cve_id"],
+            "include_fields": ["cve_id", "updated_dt"],
             "cve_id__isempty": False,  # only flaws with a CVE ID
             "order": ["updated_dt"],
             "source_in": [s for s in ELIGIBLE_FLAWS["source"]],
@@ -156,13 +156,16 @@ class FlawFinder:
         # initiate the OSIDB search
         logger.info("searching CVEs: %s", _kwargs_for_log(kwargs))
         flaw_iterator = self.osidb.flaws.retrieve_list_iterator(**kwargs)
-        cve_ids = [flaw.cve_id for flaw in flaw_iterator]
 
         if state.last_cve is None:
-            return cve_ids
+            return [flaw.cve_id for flaw in flaw_iterator]
 
-        # exclude the last processed CVE when resuming from state
-        return [cve for cve in cve_ids if cve != state.last_cve]
+        # skip the last processed CVE unless it was updated since last processing
+        return [
+            flaw.cve_id
+            for flaw in flaw_iterator
+            if flaw.cve_id != state.last_cve or flaw.updated_dt != state.updated_dt
+        ]
 
     @staticmethod
     def validate(flaw_data: FlawData) -> None:

--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -120,7 +120,7 @@ class FlawFinder:
         kwargs: dict[str, Any] = {
             "include_fields": ["cve_id"],
             "cve_id__isempty": False,  # only flaws with a CVE ID
-            "order": ["created_dt"],
+            "order": ["updated_dt"],
             "source_in": [s for s in ELIGIBLE_FLAWS["source"]],
             **{
                 f"workflow_{predicate}_in": list(
@@ -145,16 +145,13 @@ class FlawFinder:
                 key = f"{field}_isempty"
                 kwargs[key] = True
 
-        # compute the lower bound on created_dt
-        created_dt_gte: datetime | None
-        if state.created_dt is None:
-            created_dt_gte = age_cutoff
-        elif age_cutoff is None:
-            created_dt_gte = state.created_dt
-        else:
-            created_dt_gte = max(state.created_dt, age_cutoff)
-        if created_dt_gte is not None:
-            kwargs["created_dt_gte"] = created_dt_gte
+        # --max-age limits how far back we look by flaw creation time
+        if age_cutoff is not None:
+            kwargs["created_dt_gte"] = age_cutoff
+
+        # state file position limits by flaw update time
+        if state.updated_dt is not None:
+            kwargs["updated_dt_gte"] = state.updated_dt
 
         # initiate the OSIDB search
         logger.info("searching CVEs: %s", _kwargs_for_log(kwargs))
@@ -244,7 +241,7 @@ class FlawUpdater:
         assert self.flaw_data
         return BotPosition(
             last_cve=self.flaw_data["cve_id"],
-            created_dt=datetime.fromisoformat(self.flaw_data["created_dt"]),
+            updated_dt=datetime.fromisoformat(self.flaw_data["updated_dt"]),
         )
 
     async def apply_suggestions(self) -> bool:
@@ -529,7 +526,7 @@ class Bot(StateProxy):
             # determine the next state
             pkeys = self.pending.keys()
             next_state: BotPosition | None = None
-            for s in sorted(pkeys, key=lambda s: s.created_dt or datetime.min):  # noqa: DTZ901
+            for s in sorted(pkeys, key=lambda s: s.updated_dt or datetime.min):  # noqa: DTZ901
                 if self.pending[s]:
                     # this CVE is still being processed
                     break
@@ -538,7 +535,7 @@ class Bot(StateProxy):
                 next_state = s
                 del self.pending[next_state]
 
-            # do not update state if the CVE with lowest created_dt is still being processed
+            # do not update state if the CVE with lowest updated_dt is still being processed
             if next_state:
                 # update state (and state file unless read-only)
                 assert not self.retrying_failed

--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -270,7 +270,7 @@ class FlawUpdater:
                 all_ok = False
                 self._warn(str(e))
 
-        if not self.updated_fields and not self.force:
+        if not self.updated_fields:
             # nothing has changed (unexpectedly)
             self._warn("left unchanged")
             return False
@@ -403,22 +403,25 @@ class FlawUpdater:
         # apply suggestions
         all_ok: bool = await self.apply_suggestions()
 
-        if self.read_only:
-            msg = f"read-only mode, skipping OSIDB update of {self.updated_fields}"
-            self._warn(msg)
-            return False
+        # save flaw data only when any field has been updated
+        processed: bool = False
+        if self.updated_fields:
+            if self.read_only:
+                msg = f"read-only mode, skipping OSIDB update of {self.updated_fields}"
+                self._warn(msg)
+                return False
 
-        # mark the flaw as processed by Aegis/osidb-bot
-        aegis_meta = self.flaw_data.setdefault("aegis_meta", {})
-        aegis_meta["processed"] = True
+            # mark the flaw as processed by Aegis/osidb-bot
+            aegis_meta = self.flaw_data.setdefault("aegis_meta", {})
+            aegis_meta["processed"] = True
 
-        # write flaw data
-        processed: bool = self.save_flaw()
-        if not processed:
-            all_ok = self.on_failure(self.cve) if self.on_failure else False
+            # write flaw data
+            processed = self.save_flaw()
+            if not processed:
+                all_ok = self.on_failure(self.cve) if self.on_failure else False
 
-        if _KERNEL_FLAGS_KEY in self.updated_fields:
-            self._create_labels()
+            if _KERNEL_FLAGS_KEY in self.updated_fields:
+                self._create_labels()
 
         if self.updated_fields:
             self._info(f"updated {self.updated_fields}")

--- a/src/aegis_ai/osidb_bot/state.py
+++ b/src/aegis_ai/osidb_bot/state.py
@@ -19,8 +19,8 @@ class BotPosition(BaseModel):
     # the last processed CVE
     last_cve: CVEID | None = None
 
-    # creation timestamp of the last processed CVE
-    created_dt: datetime | None = None
+    # update timestamp of the last processed CVE
+    updated_dt: datetime | None = None
 
 
 class BotState(BotPosition):
@@ -196,10 +196,10 @@ class StateProxy:
 
     def _log_position(self, action: str) -> None:
         logger.info(
-            "state %s: last_cve=%s, created_dt=%s, len(retry_list)=%d",
+            "state %s: last_cve=%s, updated_dt=%s, len(retry_list)=%d",
             action,
             self._state.last_cve,
-            self._state.created_dt,
+            self._state.updated_dt,
             len(self._retry_list),
         )
 
@@ -218,7 +218,7 @@ class StateProxy:
         """Rebuild BotState from current retry_list and write to disk."""
         self._state = BotState(
             last_cve=self._state.last_cve,
-            created_dt=self._state.created_dt,
+            updated_dt=self._state.updated_dt,
             retry_list=self._retry_list,
         )
         if not self.read_only:
@@ -228,7 +228,7 @@ class StateProxy:
     def state(self, value: BotPosition) -> None:
         self._state = BotState(
             last_cve=value.last_cve,
-            created_dt=value.created_dt,
+            updated_dt=value.updated_dt,
             retry_list=self._retry_list,
         )
         if not self.read_only:


### PR DESCRIPTION
## What

Switch osidb-bot state tracking from `created_dt` to `updated_dt` so the bot can react to flaw updates in OSIDB, not just newly created flaws. Also extract `FlawUpdater.save_flaw()`, skip the OSIDB save when no fields were actually updated, and require workflow classification in `ELIGIBLE_FLAWS`.

## Why

The `created_dt`-based tracking only discovers fresh CVEs as they arrive from OSIDB collectors. In the new agent-based workflow, Aegis needs to be triggered based on updates of flaw data — for example, suggesting the statement when a flaw reaches `PRE_SECONDARY_ASSESSMENT`. A flaw created weeks ago but only now updated would be invisible to `created_dt`-based tracking.

Additionally, saving unchanged flaw data to OSIDB bumps `updated_dt`, which causes the same flaws to reappear in the next `search()` results despite the state file — a feedback loop that must be broken by skipping the save when nothing changed.

With `updated_dt` tracking in place, it is now safe to require workflow classification (`{"workflow": "DEFAULT", "state": "NEW"}`) in `ELIGIBLE_FLAWS` — flaws that lack classification are skipped, but when the OSIDB backend sets it, the flaw's `updated_dt` advances and the bot picks it up on the next run. Under the old `created_dt` tracking, this would have caused missed CVEs (AEGIS-465).

## How to Test

```bash
make all
```

For integration testing with OSIDB:
```bash
# First run after deploy will reprocess all eligible flaws (one-time migration)
aegis osidb-bot --state-file /tmp/test-state.json --read-only --max-age 7d
cat /tmp/test-state.json  # should contain "updated_dt", not "created_dt"
```

State file migration: existing state files contain a `created_dt` key that the renamed model no longer recognises. Pydantic validation fails gracefully (`read_state()` returns `None`), so the bot treats it as an empty state file. The file is still used for locking and gets overwritten with the new `updated_dt` field on the next state update. Reprocessing all eligible flaws during this one-time migration is desired — the `ELIGIBLE_FLAWS` validation skips flaws that have already been handled.

## Related Tickets
Related: https://redhat.atlassian.net/browse/AEGIS-465
Related: https://redhat.atlassian.net/browse/AEGIS-479