### PR TITLE
osidb-bot: use `workflow` label type for `manual-triage`

### DIFF
--- a/scripts/revert_manual_workflow.py
+++ b/scripts/revert_manual_workflow.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Revert flaws switched to the MANUAL workflow by mistake (AEGIS-475).
 
-Removes the ``manual-triage`` alias label from eligible flaws so that the
+Removes the ``manual-triage`` label from eligible flaws so that the
 OSIDB workflow reverts from MANUAL back to DEFAULT, allowing the Aegis bot
 to pick them up again.
 """

--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -286,8 +286,8 @@ class FlawUpdater:
             if isinstance(entry, dict)  # guard against malformed OSIDB data
         )
 
-    def create_alias_label(self, label_name: str) -> bool:
-        """create a flaw label of type "alias" with name label_name, return True on success"""
+    def create_label(self, label_name: str, label_type: str = "alias") -> bool:
+        """Create a flaw label with the given name and type, return True on success."""
         assert self.flaw_data
         if self.read_only:
             msg = f"read-only mode, skipping creation of label '{label_name}'"
@@ -300,7 +300,7 @@ class FlawUpdater:
                 flaw_id=flaw_uuid,
                 form_data={
                     "label": label_name,
-                    "type": "alias",
+                    "type": label_type,
                     "state": "NEW",
                 },
             )
@@ -326,7 +326,7 @@ class FlawUpdater:
 
         any_update = False
         for label_name in labels:
-            if self.create_alias_label(label_name):
+            if self.create_label(label_name):
                 any_update = True
 
         if not any_update:
@@ -413,7 +413,7 @@ class FlawUpdater:
             self._info(f"updated {self.updated_fields}")
 
         if not all_ok:
-            self.create_alias_label("manual-triage")
+            self.create_label("manual-triage")
 
         return processed
 
@@ -508,7 +508,7 @@ class Bot(StateProxy):
                 and flaw_updater
             ):
                 # the last retry attempt failed, create the manual-triage label
-                flaw_updater.create_alias_label("manual-triage")
+                flaw_updater.create_label("manual-triage")
 
             if not handled_failure:
                 # propagate all but RuntimeError exceptions

--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -413,7 +413,7 @@ class FlawUpdater:
             self._info(f"updated {self.updated_fields}")
 
         if not all_ok:
-            self.create_label("manual-triage")
+            self.create_label("manual-triage", label_type="workflow")
 
         return processed
 
@@ -508,7 +508,7 @@ class Bot(StateProxy):
                 and flaw_updater
             ):
                 # the last retry attempt failed, create the manual-triage label
-                flaw_updater.create_label("manual-triage")
+                flaw_updater.create_label("manual-triage", label_type="workflow")
 
             if not handled_failure:
                 # propagate all but RuntimeError exceptions

--- a/tests/test_flaw_updater.py
+++ b/tests/test_flaw_updater.py
@@ -456,7 +456,7 @@ async def test_flaw_updater_read_only_no_manual_triage_label(mock_exec_feature):
 
 MANUAL_TRIAGE_LABEL = {
     "label": "manual-triage",
-    "type": "alias",
+    "type": "workflow",
     "state": "NEW",
 }
 


### PR DESCRIPTION
## What
Switch the `manual-triage` label from OSIDB label type `alias` to `workflow`.

## Why
OSIDB now supports `workflow`-type labels in production. Aegis was using `alias` labels for `manual-triage` for compatibility, but this risks breaking when OSIDB starts enforcing label types. Kernel flag labels (e.g. `kpanic`) remain as `alias`.

## How to Test
```bash
make all
```

## Related Tickets
Related: https://redhat.atlassian.net/browse/AEGIS-480

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Switch OSIDB bot to create the `manual-triage` flaw label as a workflow-type label instead of an alias and generalize label creation.

Enhancements:
- Introduce a generic label creation helper that supports specifying label type instead of a dedicated alias-only helper.

Tests:
- Update tests to expect `manual-triage` labels to use the `workflow` type instead of `alias`.