### PR TITLE
fix: OSIDB label creation broken by v2 API field rename

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.3] - 2026-08-10
+
+### Changed
+- `osidb-bot` now logs the OSIDB response body when label creation fails [\[AEGIS-486\]](https://redhat.atlassian.net/browse/AEGIS-486)
+
+### Fixed
+- fixed `osidb-bot` label creation broken by OSIDB's `label` → `name` field rename in the v2 labels API [\[AEGIS-486\]](https://redhat.atlassian.net/browse/AEGIS-486)
+
+
 ## [0.8.2] - 2026-08-06
 
 ### Changed

--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -232,6 +232,14 @@ class FlawUpdater:
     def _warn(self, msg: str) -> None:
         logger.warning(f"{self.cve}: {msg}")
 
+    def _log_osidb_response(self, e: Exception) -> None:
+        if isinstance(e, requests.exceptions.RequestException):
+            response = getattr(e, "response", None)
+            if response is not None:
+                fl = response.text.partition("\n")[0]
+                truncated = textwrap.shorten(fl, width=256, placeholder=" [...]")
+                self._info(f"OSIDB response: {truncated}")
+
     def position(self) -> BotPosition:
         assert self.flaw_data
         return BotPosition(
@@ -395,13 +403,7 @@ class FlawUpdater:
                 )
                 self.updated_fields.clear()
 
-            if isinstance(e, requests.exceptions.RequestException):
-                # log OSIDB response if available
-                response = getattr(e, "response", None)
-                if response is not None:
-                    fl = response.text.partition("\n")[0]
-                    truncated = textwrap.shorten(fl, width=256, placeholder=" [...]")
-                    self._info(f"OSIDB response: {truncated}")
+            self._log_osidb_response(e)
 
             # log full exception in debug mode only
             logger.debug(f"{self.cve}: {e!s}")

--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -307,7 +307,7 @@ class FlawUpdater:
             cast(Any, self.osidb.flaws).labels.create(
                 flaw_id=flaw_uuid,
                 form_data={
-                    "label": label_name,
+                    "name": label_name,
                     "type": label_type,
                     "state": "NEW",
                 },

--- a/src/aegis_ai/osidb_bot/bot.py
+++ b/src/aegis_ai/osidb_bot/bot.py
@@ -318,6 +318,7 @@ class FlawUpdater:
         except Exception as e:
             msg = f"failed to create label '{label_name}' ({e.__class__.__name__})"
             self._warn(msg)
+            self._log_osidb_response(e)
             logger.debug("%s: %s", self.cve, e)
             return False
 

--- a/tests/test_flaw_updater.py
+++ b/tests/test_flaw_updater.py
@@ -455,7 +455,7 @@ async def test_flaw_updater_read_only_no_manual_triage_label(mock_exec_feature):
 
 
 MANUAL_TRIAGE_LABEL = {
-    "label": "manual-triage",
+    "name": "manual-triage",
     "type": "workflow",
     "state": "NEW",
 }

--- a/tests/test_kernel_flags.py
+++ b/tests/test_kernel_flags.py
@@ -365,7 +365,7 @@ class TestFlawUpdaterLabelCreation:
         session.flaws.labels.create.assert_called_once_with(
             flaw_id="00000000-0000-0000-0000-000000000099",
             form_data={
-                "label": "kpanic",
+                "name": "kpanic",
                 "type": "alias",
                 "state": "NEW",
             },


### PR DESCRIPTION
## What
Fix `osidb-bot` label creation which has been failing with 400 Bad Request since the OSIDB upgrade on Aug 6, and improve error logging so similar issues are diagnosable without code changes.

## Why
OSIDB PR [#1412](https://github.com/RedHatProductSecurity/osidb/pull/1412) (commit `46a0645b` "make V2 labels be just labels") renamed the `label` field to `name` in the v2 labels API. Aegis was still sending `{"label": ...}`, causing all label creation to fail silently — the response body with the actual error was not being logged.

## How to Test
```bash
make check test
```
Deploy to stage and verify `osidb-bot` can create labels (e.g. `kpanic`, `manual-triage`) without 400 errors.

## Related Tickets
Related: https://redhat.atlassian.net/browse/AEGIS-486

## Summary by Sourcery

Fix OSIDB v2 label creation in osidb-bot and centralize logging of OSIDB error responses.

Bug Fixes:
- Restore osidb-bot label creation by using the renamed `name` field in the OSIDB v2 labels API.

Enhancements:
- Add a reusable helper to log truncated OSIDB HTTP response bodies when requests fail, and use it from label creation and the main bot flow.

Documentation:
- Update the changelog with version 0.8.3 documenting the label creation fix and improved OSIDB response logging.