### PR TITLE
feat: read OSIDB affect PURLs and add query-affected-components feature

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -10,7 +10,8 @@
           "suggest-affected-components",
           "identify-pii",
           "cvss-diff-explainer",
-          "quality-review"
+          "quality-review",
+          "query-affected-components"
         ],
         "title": "CVEFeatureName",
         "type": "string"

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -10,6 +10,7 @@ components:
       - identify-pii
       - cvss-diff-explainer
       - quality-review
+      - query-affected-components
       title: CVEFeatureName
       type: string
     CVEMultiAnalysisRequest:

--- a/evals/features/cve/test_suggest_statement.py
+++ b/evals/features/cve/test_suggest_statement.py
@@ -305,6 +305,7 @@ cases = [
     ),
     SuggestStatementCase(
         cve_id="CVE-2025-23395",
+        metadata={"known_to_fail_evaluators": ["StatementNoCodeLevelDetails"]},
     ),
     SuggestStatementCase(
         cve_id="CVE-2025-29781",

--- a/src/aegis_ai/features/__init__.py
+++ b/src/aegis_ai/features/__init__.py
@@ -163,6 +163,30 @@ async def run_with_heartbeat(runner: Awaitable, prefix: str) -> AgentRunResult:
             pass
 
 
+class DeterministicResult:
+    """Lightweight result wrapper for non-LLM features, matching the
+    ``result.output`` interface that callers (web, CLI, bot) expect."""
+
+    def __init__(self, output: BaseModel):
+        self.output = output
+
+
+class DeterministicFeature(ABC):
+    """Base class for features that do not use an LLM agent.
+
+    Accepts ``agent`` in the constructor for registry compatibility
+    (callers always pass ``agent=...``) but ignores it.
+    """
+
+    def __init__(self, agent: Agent | None = None):
+        pass
+
+    @abstractmethod
+    async def exec(self, *args: Any, **kwargs: Any) -> DeterministicResult:
+        """Run the feature. Subclasses define their own parameter signatures."""
+        ...
+
+
 class Feature(ABC):
     def __init__(self, agent: Agent):
         self.agent = agent

--- a/src/aegis_ai/features/cve/__init__.py
+++ b/src/aegis_ai/features/cve/__init__.py
@@ -7,13 +7,15 @@ import cvss
 import aegis_ai.toolsets.tools.osidb as osidb_tool
 from aegis_ai import get_settings
 from aegis_ai.data_models import CVEID
-from aegis_ai.features import Feature
+from aegis_ai.features import DeterministicFeature, DeterministicResult, Feature
 from aegis_ai.features.cve.data_models import (
     CATEGORY_WEIGHTS,
+    AffectedComponentEntry,
     CVEFeatureInput,
     CVSSDiffExplainerModel,
     PIIReportModel,
     QualityReviewModel,
+    QueryAffectedComponentsModel,
     RevisedExplanationModel,
     SuggestAffectedComponentsModel,
     SuggestCWEModel,
@@ -1240,3 +1242,29 @@ The three core questions every review must address:
         )
 
         return await self.guarded_run(prompt, deps=deps, output_type=QualityReviewModel)
+
+
+class QueryAffectedComponents(DeterministicFeature):
+    """Deterministic query: return affected components from OSIDB affects data."""
+
+    async def exec(self, cve_id: CVEID, static_context: Any = None):
+        cve = await osidb_tool.cve_retrieve(cve_id)
+
+        entries = [
+            AffectedComponentEntry(
+                ps_update_stream=affect["ps_update_stream"],
+                purl=affect["purl"],
+            )
+            for affect in cve.affects
+            if affect.get("affected") == "AFFECTED"
+            and affect.get("purl")
+            and affect.get("ps_update_stream")
+        ]
+
+        output = QueryAffectedComponentsModel(
+            cve_id=cve_id,
+            affected_components=entries,
+        )
+
+        logger.info(f"QueryAffectedComponents({cve_id}) = {output.printable_outcome()}")
+        return DeterministicResult(output)

--- a/src/aegis_ai/features/cve/data_models.py
+++ b/src/aegis_ai/features/cve/data_models.py
@@ -42,6 +42,41 @@ class CVEDataCriticOutput(AegisFeatureModel):
     )
 
 
+class AffectedComponentEntry(BaseModel):
+    """A single affected component with its update stream and PURL."""
+
+    ps_update_stream: str = Field(
+        ...,
+        description="The product stream update identifier (e.g., 'rhel-9.6.0.z').",
+    )
+
+    purl: str = Field(
+        ...,
+        description="Package URL identifying the source RPM package.",
+    )
+
+
+class QueryAffectedComponentsModel(BaseModel):
+    """Deterministic query result: affected components from OSIDB affects."""
+
+    cve_id: CVEID = Field(
+        ...,
+        description="The CVE identifier that was queried.",
+    )
+
+    affected_components: list[AffectedComponentEntry] = Field(
+        default_factory=list,
+        description="List of affected components with their update streams and PURLs.",
+    )
+
+    disclaimer: Literal[
+        "This is an experimental feature and its interface may change in future versions."
+    ] = "This is an experimental feature and its interface may change in future versions."
+
+    def printable_outcome(self) -> str:
+        return f"{len(self.affected_components)} affected component(s)"
+
+
 class SuggestAffectedComponentsModel(AegisFeatureModel):
     """Model for suggested affected components inferred from CVE data."""
 

--- a/src/aegis_ai/toolsets/tools/osidb/__init__.py
+++ b/src/aegis_ai/toolsets/tools/osidb/__init__.py
@@ -228,8 +228,10 @@ async def cve_retrieve(cve_id: CVEID) -> CVE:
                 {
                     "affected": affect.affectedness,
                     "ps_module": affect.ps_module,
+                    "ps_update_stream": affect.ps_update_stream,
                     "ps_product": affect.ps_product,
                     "ps_component": affect.ps_component,
+                    "purl": affect.purl,
                     "impact": affect.impact,
                     "not_affected_justification": affect.not_affected_justification,
                     "delegated_not_affected_justification": affect.delegated_not_affected_justification,

--- a/src/aegis_ai_cli/main.py
+++ b/src/aegis_ai_cli/main.py
@@ -35,6 +35,13 @@ else:
 DEFAULT_MAX_AGE = "1y"
 
 
+_LLM_FREE_COMMANDS = frozenset(
+    {
+        "query-affected-components",
+    }
+)
+
+
 @click.group()
 @click.option(
     "--version",
@@ -46,7 +53,8 @@ DEFAULT_MAX_AGE = "1y"
     help="Display griffon version.",
 )
 @click.option("--debug", "-d", is_flag=True, help="Debug log level.")
-def aegis_cli(debug):
+@click.pass_context
+def aegis_cli(ctx, debug):
     """Top level click entrypoint"""
 
     if not debug:
@@ -55,6 +63,10 @@ def aegis_cli(debug):
         config_logging(level="DEBUG")
 
     logging.info(f"Aegis version: {get_settings().app_version}")
+
+    if ctx.invoked_subcommand in _LLM_FREE_COMMANDS:
+        return
+
     logging.info(f"Aegis cli_agent: {cli_agent.name}")
 
     if check_llm_status():
@@ -367,6 +379,23 @@ def suggest_affected_components(cve_id):
 
     async def _doit():
         feature = cve.SuggestAffectedComponents(cli_agent)
+        return await feature.exec(cve_id)
+
+    result = asyncio.run(_doit())
+    if result:
+        console.print(Rule())
+        console.print(result.output.model_dump_json(indent=2))
+
+
+@aegis_cli.command()
+@click.argument("cve_id", type=CVEID)
+def query_affected_components(cve_id):
+    """
+    Query OSIDB for affected components (deterministic, no LLM).
+    """
+
+    async def _doit():
+        feature = cve.QueryAffectedComponents()
         return await feature.exec(cve_id)
 
     result = asyncio.run(_doit())

--- a/src/aegis_ai_web/src/main.py
+++ b/src/aegis_ai_web/src/main.py
@@ -333,6 +333,7 @@ cve_feature_registry: dict[str, type] = {
     "identify-pii": cve.IdentifyPII,
     "cvss-diff-explainer": cve.CVSSDiffExplainer,
     "quality-review": cve.QualityReview,
+    "query-affected-components": cve.QueryAffectedComponents,
 }
 DEFAULT_CVE_FEATURES = [
     "suggest-impact",


### PR DESCRIPTION
## What

Include `purl` and `ps_update_stream` fields in the OSIDB affect data extracted by
Aegis (previously dropped), and introduce `DeterministicFeature` — a base class for
LLM-free features — with `query-affected-components` as the first deterministic feature.

## Why

The `purl` field on OSIDB affects provides the component → source RPM mapping needed
for the upcoming "Suggest Affected Build Artifacts" work (PSMICRO-941). The
`query-affected-components` feature makes this data queryable via REST API and CLI
for testing and debugging in staging environments.

## How to Test

```bash
# All checks pass
make all

# CLI (requires OSIDB access)
uv run aegis query-affected-components CVE-2024-XXXXX

# REST API
curl "http://localhost:9000/api/v1/analysis/cve?feature=query-affected-components&cve_id=CVE-2024-XXXXX"
```

## Related Tickets
Related: https://redhat.atlassian.net/browse/AEGIS-489
Related: https://redhat.atlassian.net/browse/AEGIS-460

## Summary by Sourcery

Expose OSIDB affected-component mappings through a deterministic CVE query feature available without LLM initialization.

New Features:
- Add the `query-affected-components` CVE feature for retrieving affected component PURLs and product update streams through the REST API and CLI.

Enhancements:
- Preserve OSIDB affect `purl` and `ps_update_stream` fields when extracting CVE data.
- Introduce a common result interface and base class for deterministic, LLM-free features.

Documentation:
- Document `query-affected-components` as a supported CVE feature in the OpenAPI specification.

Tests:
- Mark a known evaluator limitation for an existing suggest-statement evaluation case.