### PR TITLE
ci(tests): run `make all` per commit in pull requests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,13 +4,19 @@ on:
     branches: [ "main" ]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   tests:
-    name: pytest
+    name: Sanity and unit tests
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
 
       - name: Install Kerberos development libraries
         run: |
@@ -20,9 +26,46 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v10.0.1
 
-      - name: Install the project
-        run: uv sync --all-extras --dev
-
       - name: Run checks and tests
-        run: make all
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            uv sync --all-extras --dev
+            make all
+            exit $?
+          fi
+
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+          COMMITS=$(git rev-list --reverse "$BASE".."$HEAD")
+          TOTAL=$(echo "$COMMITS" | wc -l)
+          CURRENT=0
+          for COMMIT in $COMMITS; do
+            CURRENT=$((CURRENT + 1))
+            SHORT=$(git rev-parse --short "$COMMIT")
+            SUBJECT=$(git log -1 --format=%s "$COMMIT")
+            echo ""
+            echo "::group::[$CURRENT/$TOTAL] $SHORT — $SUBJECT"
+            git checkout --force "$COMMIT"
+            git clean -dfx --exclude=.venv
+            if ! (uv sync --all-extras --dev && make all); then
+              echo "::endgroup::"
+              echo ""
+              echo "::error::commit $SHORT failed — $SUBJECT"
+              echo ""
+              echo "======================================================"
+              echo "  FAILED at commit [$CURRENT/$TOTAL]: $SHORT"
+              echo "  $SUBJECT"
+              echo "======================================================"
+              echo ""
+              echo "  This commit does not pass 'make all' on its own."
+              echo "  Each commit in a pull request must pass independently."
+              echo ""
+              echo "  To fix, use interactive rebase to edit the failing commit:"
+              echo ""
+              echo "    git rebase -i $SHORT~1"
+              echo ""
+              exit 1
+            fi
+            echo "::endgroup::"
+          done
 

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -9,6 +9,8 @@ This document outlines the core principles, architecture, and development practi
 
 Developers should squash fix-up commits before requesting a review.  Fix-up commits are commits that fix mistakes (or incorporate review comments) in the commits under review.  Otherwise, we prefer commits to be smaller and focused on one thing at a time.  In particular, we strictly separate commits doing refactoring and coding style changes in preexisting code from commits that actually change the behavior of Aegis.  This makes pull requests easier to review and the resulting git history more `git bisect` friendly.
 
+Each commit in a pull request must pass `make all` on its own.  CI checks every commit individually and will fail on the first one that breaks.  If CI fails on an intermediate commit, use `git rebase -i` to fix it up before requesting a review.
+
 ## Architecture
 
 Aegis uses Large Language Models (LLMs) to perform advanced security analysis and operations. Its architecture is built on four key principles:


### PR DESCRIPTION
## What

Run `make all` against each individual commit in a PR, not just the final merge commit. Each commit's output is wrapped in a collapsible `::group::` section labeled with its position, short SHA, and subject line. When `make all` fails, a summary is printed at the end identifying the broken commit and suggesting `git rebase -i` to fix it. Pushes to `main` keep the current single-run behavior.

Rename the job from `pytest` to `Sanity and unit tests` because the job runs formatting, linting, and type checks in addition to pytest.

Document the per-commit requirement in `DEVELOP.md`.

## Why

A PR could pass CI even when intermediate commits are broken — e.g., commit A calls a function defined only in commit B. This change catches such issues and identifies the first broken commit in the CI log.

## How to Test

1. Open a PR with a deliberately broken intermediate commit (e.g., one that references an identifier introduced in a later commit) and verify CI fails on the correct commit.
2. Open a clean PR and verify all commits pass with readable collapsible log groups.

## Related Tickets
Related: https://github.com/RedHatProductSecurity/aegis-ai/pull/711

🤖 Generated with [Claude Code](https://claude.com/claude-code)

CI: skip-pr-evals

## Summary by Sourcery

Validate every pull-request commit independently while retaining the existing checks behavior for pushes to `main`.

New Features:
- Run sanity and unit checks independently against every commit in pull requests and identify the first failing commit.

Enhancements:
- Rename the test job to reflect its formatting, linting, type-checking, and test coverage.
- Require full repository history and read-only contents permissions for the workflow.
- Document that every pull-request commit must pass `make all` independently.

CI:
- Preserve the existing single-run checks for pushes to `main` while grouping pull-request commit results in collapsible CI logs and providing rebase guidance on failure.

Documentation:
- Document the per-commit CI requirement and remediation process in `DEVELOP.md`.