### PR TITLE
feat: add SuggestAffectedPackages feature (source RPM level)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -123,6 +123,7 @@
           "identify-pii",
           "cvss-diff-explainer",
           "quality-review",
+          "suggest-affected-packages",
           "query-affected-components"
         ],
         "title": "CVEFeatureName",

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -105,6 +105,7 @@ components:
       - identify-pii
       - cvss-diff-explainer
       - quality-review
+      - suggest-affected-packages
       - query-affected-components
       title: CVEFeatureName
       type: string

--- a/evals/features/common.py
+++ b/evals/features/common.py
@@ -467,34 +467,72 @@ class ToolsUsedEvaluator(Evaluator[str, AegisFeatureModel]):
 
 
 class DataQualityEvaluator(Evaluator[str, AegisFeatureModel]):
-    """Compare data_quality with the expected value when specified."""
+    """Compare data_quality against an expected value or upper bound.
+
+    In point mode (default), uses Gaussian similarity against
+    ``ctx.expected_output.data_quality``.  In bound mode (``max_value``
+    set), scores 1.0 when the value is at or below the bound and applies
+    Gaussian falloff above it.
+    """
 
     _sigma = 0.1  # controls tolerance: ~0.61 at ±0.1, ~0.14 at ±0.2
+
+    def __init__(self, *, max_value: float | None = None):
+        super().__init__()
+        self._max_value = max_value
 
     def evaluate(
         self, ctx: EvaluatorContext[str, AegisFeatureModel]
     ) -> EvaluationReason:
-        assert ctx.expected_output is not None
         got = ctx.output.data_quality
+
+        if self._max_value is not None:
+            if got <= self._max_value:
+                return EvaluationReason(value=1.0, reason=None)
+            diff = got - self._max_value
+            score = math.exp(-(diff**2) / (2 * self._sigma**2))
+            return EvaluationReason(
+                value=score, reason=f"got {got}, expected <={self._max_value}"
+            )
+
+        assert ctx.expected_output is not None
         expected = ctx.expected_output.data_quality
         diff = got - expected
-
-        # Gaussian similarity
         score = math.exp(-(diff**2) / (2 * self._sigma**2))
         reason = None if score >= 1.0 else f"got {got}, expected {expected}"
         return EvaluationReason(value=score, reason=reason)
 
 
 class ConfidenceEvaluator(Evaluator[str, AegisFeatureModel]):
-    """Compare confidence with the expected value."""
+    """Compare confidence against an expected value or upper bound.
+
+    In point mode (default), uses Gaussian similarity against
+    ``ctx.expected_output.confidence``.  In bound mode (``max_value``
+    set), scores 1.0 when the value is at or below the bound and applies
+    Gaussian falloff above it.
+    """
 
     _sigma = 0.1
+
+    def __init__(self, *, max_value: float | None = None):
+        super().__init__()
+        self._max_value = max_value
 
     def evaluate(
         self, ctx: EvaluatorContext[str, AegisFeatureModel]
     ) -> EvaluationReason:
-        assert ctx.expected_output is not None
         got = ctx.output.confidence
+
+        if self._max_value is not None:
+            if got <= self._max_value:
+                return EvaluationReason(value=1.0, reason=None)
+            diff = got - self._max_value
+            score = math.exp(-(diff**2) / (2 * self._sigma**2))
+            return EvaluationReason(
+                value=score, reason=f"got {got}, expected <={self._max_value}"
+            )
+
+        assert ctx.expected_output is not None
         expected = ctx.expected_output.confidence
         diff = got - expected
         score = math.exp(-(diff**2) / (2 * self._sigma**2))

--- a/evals/features/common.py
+++ b/evals/features/common.py
@@ -466,6 +466,25 @@ class ToolsUsedEvaluator(Evaluator[str, AegisFeatureModel]):
         )
 
 
+class DataQualityEvaluator(Evaluator[str, AegisFeatureModel]):
+    """Compare data_quality with the expected value when specified."""
+
+    _sigma = 0.1  # controls tolerance: ~0.61 at ±0.1, ~0.14 at ±0.2
+
+    def evaluate(
+        self, ctx: EvaluatorContext[str, AegisFeatureModel]
+    ) -> EvaluationReason:
+        assert ctx.expected_output is not None
+        got = ctx.output.data_quality
+        expected = ctx.expected_output.data_quality
+        diff = got - expected
+
+        # Gaussian similarity
+        score = math.exp(-(diff**2) / (2 * self._sigma**2))
+        reason = None if score >= 1.0 else f"got {got}, expected {expected}"
+        return EvaluationReason(value=score, reason=reason)
+
+
 def _parse_trace(trace: str | None) -> tuple[list[str], list[str]]:
     """Extract rules_fired and guardrails_fired lists from a reconciliation trace."""
     import re

--- a/evals/features/common.py
+++ b/evals/features/common.py
@@ -485,6 +485,23 @@ class DataQualityEvaluator(Evaluator[str, AegisFeatureModel]):
         return EvaluationReason(value=score, reason=reason)
 
 
+class ConfidenceEvaluator(Evaluator[str, AegisFeatureModel]):
+    """Compare confidence with the expected value."""
+
+    _sigma = 0.1
+
+    def evaluate(
+        self, ctx: EvaluatorContext[str, AegisFeatureModel]
+    ) -> EvaluationReason:
+        assert ctx.expected_output is not None
+        got = ctx.output.confidence
+        expected = ctx.expected_output.confidence
+        diff = got - expected
+        score = math.exp(-(diff**2) / (2 * self._sigma**2))
+        reason = None if score >= 1.0 else f"got {got}, expected {expected}"
+        return EvaluationReason(value=score, reason=reason)
+
+
 def _parse_trace(trace: str | None) -> tuple[list[str], list[str]]:
     """Extract rules_fired and guardrails_fired lists from a reconciliation trace."""
     import re

--- a/evals/features/cve/test_suggest_affected_packages.py
+++ b/evals/features/cve/test_suggest_affected_packages.py
@@ -42,8 +42,13 @@ SAMPLE_SEED = int(os.getenv("AEGIS_EVALS_SUGGEST_AFFECTED_PACKAGES_SAMPLE_SEED",
 
 # CVE IDs with OSIDB cache entries that include affects with purl and
 # ps_update_stream fields.  Populate by re-fetching qualifying CVEs with
-# include_affects=True.  Empty until cache entries are updated.
-DEFAULT_CVE_IDS: tuple[str, ...] = ()
+# include_affects=True in write_cache_entry().
+DEFAULT_CVE_IDS: tuple[str, ...] = (
+    "CVE-2014-9984",
+    "CVE-2025-49175",
+    "CVE-2026-3904",
+    "CVE-2026-34982",
+)
 
 
 KNOWN_TO_FAIL_CVE_IDS: tuple[str, ...] = ()

--- a/evals/features/cve/test_suggest_affected_packages.py
+++ b/evals/features/cve/test_suggest_affected_packages.py
@@ -1,0 +1,230 @@
+"""
+Suggest affected packages evaluation suite.
+
+Uses osidb_cache CVE data. Input: cve_id. The feature analyzes OSIDB affects
+(with PURLs and product streams) to suggest which source RPM packages are
+affected by the vulnerability.
+
+Requires cache entries with affects data including ``purl`` and
+``ps_update_stream`` fields.  To populate, re-fetch qualifying CVEs with
+``include_affects=True`` in ``write_cache_entry()``.
+
+Runnable: pytest evals/features/cve/test_suggest_affected_packages.py
+Optional: --sample N or AEGIS_EVALS_SUGGEST_AFFECTED_PACKAGES_SAMPLE=N
+"""
+
+import logging
+import os
+import random
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from pydantic_evals import Case
+from pydantic_evals.evaluators import EvaluationReason, Evaluator, EvaluatorContext
+
+from aegis_ai.agents import rh_feature_agent
+from aegis_ai.data_models import CVEID
+from aegis_ai.features.cve import SuggestAffectedPackages
+from aegis_ai.features.cve.data_models import SuggestAffectedPackagesModel
+from aegis_ai.toolsets.tools.osidb import CVE
+from evals.features.common import (
+    FeatureMetricsEvaluator,
+    ToolsUsedEvaluator,
+    reflect_confidence,
+    run_evaluation,
+)
+from evals.utils.osidb_cache import OSIDB_CACHE_DIR
+
+logger = logging.getLogger(__name__)
+
+SAMPLE_SEED = int(os.getenv("AEGIS_EVALS_SUGGEST_AFFECTED_PACKAGES_SAMPLE_SEED", "42"))
+
+# CVE IDs with OSIDB cache entries that include affects with purl and
+# ps_update_stream fields.  Populate by re-fetching qualifying CVEs with
+# include_affects=True.  Empty until cache entries are updated.
+DEFAULT_CVE_IDS: tuple[str, ...] = ()
+
+
+KNOWN_TO_FAIL_CVE_IDS: tuple[str, ...] = ()
+
+
+def _affects_with_purls(cve: CVE) -> list[dict[str, Any]]:
+    """Return affect entries that have both purl and ps_update_stream."""
+    if not cve.affects:
+        return []
+    return [
+        a
+        for a in cve.affects
+        if isinstance(a, dict) and a.get("purl") and a.get("ps_update_stream")
+    ]
+
+
+def _load_qualifying_cves(
+    cve_id_filter: set[str] | None = None,
+) -> list[tuple[str, CVE, list[dict[str, Any]]]]:
+    """Load CVEs from osidb_cache that have affects with PURLs."""
+    cache_path = Path(OSIDB_CACHE_DIR)
+    if not cache_path.is_dir():
+        logger.warning("OSIDB_CACHE_DIR %s is not a directory", OSIDB_CACHE_DIR)
+        return []
+
+    qualifying = []
+    for json_file in sorted(cache_path.glob("CVE-*.json")):
+        cve_id = json_file.stem
+        if cve_id_filter is not None and cve_id not in cve_id_filter:
+            continue
+        try:
+            with open(json_file, "r") as f:
+                cve = CVE.model_validate_json(f.read())
+        except Exception as e:
+            logger.debug("Skip %s: %s", cve_id, e)
+            continue
+
+        affected = _affects_with_purls(cve)
+        if not affected:
+            continue
+        qualifying.append((cve_id, cve, affected))
+
+    return qualifying
+
+
+def _build_cases(
+    sample_size: int | None = None,
+    seed: int = SAMPLE_SEED,
+    cve_id_filter: set[str] | None = None,
+) -> list["SuggestAffectedPackagesCase"]:
+    """Build cases from osidb_cache; optionally sample N."""
+    qualifying = _load_qualifying_cves(cve_id_filter=cve_id_filter)
+    cases = []
+
+    for cve_id, cve, affected in qualifying:
+        expected_pairs = [
+            (a["purl"], a["ps_update_stream"])
+            for a in affected
+            if a.get("affected") == "AFFECTED"
+        ]
+        metadata: dict[str, Any] = {"cve_id": cve_id}
+        if cve_id in KNOWN_TO_FAIL_CVE_IDS:
+            metadata["known_to_fail_evaluators"] = ["PackageOverlapEvaluator"]
+
+        case = SuggestAffectedPackagesCase(
+            name=f"suggest-affected-packages-{cve_id}",
+            inputs=cve_id,
+            expected_output=expected_pairs,
+            metadata=metadata,
+            evaluators=(),
+        )
+        cases.append(case)
+
+    if sample_size is not None and sample_size < len(cases):
+        rng = random.Random(seed)
+        cases = rng.sample(cases, sample_size)
+        logger.info(
+            "Sampled %d cases from %d qualifying (seed=%d)",
+            sample_size,
+            len(qualifying),
+            seed,
+        )
+
+    return cases
+
+
+class SuggestAffectedPackagesCase(Case):
+    """Evaluation case: inputs = cve_id, expected_output = list of (purl, ps_update_stream) pairs."""
+
+    inputs: str
+    expected_output: list[tuple[str, str]]
+
+
+def _normalize_pair(purl: str, stream: str) -> tuple[str, str]:
+    return (purl.lower().strip(), stream.lower().strip())
+
+
+class PackageOverlapEvaluator(Evaluator[str, SuggestAffectedPackagesModel]):
+    """Scores overlap between suggested and expected affected (purl, ps_update_stream) pairs.
+
+    Uses Jaccard similarity so that the same PURL in different streams is
+    treated as a distinct entry.
+    """
+
+    def evaluate(
+        self, ctx: EvaluatorContext[str, SuggestAffectedPackagesModel]
+    ) -> EvaluationReason:
+        expected_pairs = cast(list[tuple[str, str]], ctx.expected_output or [])
+        suggested = getattr(ctx.output, "affected_packages", None) or []
+        got_pairs = [(p.purl, p.ps_update_stream) for p in suggested if p.affected]
+
+        exp_set = {_normalize_pair(*p) for p in expected_pairs}
+        got_set = {_normalize_pair(*p) for p in got_pairs}
+
+        if not exp_set:
+            score = 1.0 if not got_set else 0.0
+            reason = (
+                None if score == 1.0 else f"got {got_pairs}, expected {expected_pairs}"
+            )
+            return EvaluationReason(value=score, reason=reason)
+
+        if exp_set == got_set:
+            return EvaluationReason(value=reflect_confidence(ctx, 1.0), reason=None)
+
+        inter = len(exp_set & got_set)
+        union = len(exp_set | got_set)
+        score = inter / union if union else 0.0
+        reason = f"got {got_pairs}, expected {expected_pairs}"
+        score = reflect_confidence(ctx, score)
+        return EvaluationReason(value=score, reason=reason)
+
+
+async def suggest_affected_packages(cve_id: CVEID) -> SuggestAffectedPackagesModel:
+    """Run SuggestAffectedPackages for the given CVE."""
+    feature = SuggestAffectedPackages(rh_feature_agent)
+    result = await feature.exec(cve_id)
+    return result.output
+
+
+evals = [
+    FeatureMetricsEvaluator(),
+    ToolsUsedEvaluator(),
+    PackageOverlapEvaluator(),
+]
+
+
+@pytest.fixture(scope="session")
+def suggest_affected_packages_cases(request):
+    """Build cases from osidb_cache."""
+    sample_size = request.config.getoption("sample", default=None)
+    if sample_size is None:
+        env_val = os.getenv("AEGIS_EVALS_SUGGEST_AFFECTED_PACKAGES_SAMPLE")
+        if env_val:
+            try:
+                sample_size = int(env_val)
+            except ValueError:
+                sample_size = None
+
+    raw = os.getenv("AEGIS_EVALS_SUGGEST_AFFECTED_PACKAGES_CVE_IDS", "").strip()
+    if raw:
+        cve_id_filter = {cve_id.strip() for cve_id in raw.split(",") if cve_id.strip()}
+    else:
+        cve_id_filter = set(DEFAULT_CVE_IDS) if DEFAULT_CVE_IDS else None
+    return _build_cases(
+        sample_size=sample_size,
+        seed=SAMPLE_SEED,
+        cve_id_filter=cve_id_filter,
+    )
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_eval_suggest_affected_packages(suggest_affected_packages_cases):
+    """Suggest affected packages evaluation entry point."""
+    if not suggest_affected_packages_cases:
+        pytest.skip(
+            "No qualifying cases in osidb_cache (need affects with purl and "
+            "ps_update_stream fields). Re-fetch CVEs with include_affects=True."
+        )
+    await run_evaluation(
+        suggest_affected_packages_cases,
+        evals,
+        suggest_affected_packages,
+        agent=rh_feature_agent,
+    )

--- a/evals/features/cve/test_suggest_affected_packages.py
+++ b/evals/features/cve/test_suggest_affected_packages.py
@@ -55,8 +55,8 @@ DEFAULT_CVE_IDS: tuple[str, ...] = (
 # CVEs where affects data is missing or incomplete (no PURLs).  The LLM
 # should report low data_quality and confidence rather than guessing.
 LOW_QUALITY_CVE_IDS: dict[str, tuple[float, float]] = {
-    # (expected data_quality, expected confidence)
-    "CVE-2026-84327": (0.3, 0.5),
+    # (max data_quality, max confidence)
+    "CVE-2026-84327": (0.5, 0.5),
 }
 
 KNOWN_TO_FAIL_CVE_IDS: tuple[str, ...] = ()
@@ -132,7 +132,7 @@ def _build_cases(
 
     # Add low-quality cases (CVEs with missing/incomplete affects data)
     cache_path = Path(OSIDB_CACHE_DIR)
-    for cve_id, (exp_dq, exp_conf) in LOW_QUALITY_CVE_IDS.items():
+    for cve_id, (max_dq, max_conf) in LOW_QUALITY_CVE_IDS.items():
         if cve_id_filter is not None and cve_id not in cve_id_filter:
             continue
         if not (cache_path / f"{cve_id}.json").is_file():
@@ -145,15 +145,15 @@ def _build_cases(
             cve_id=cve_id,
             affected_packages=[],
             explanation="",
-            data_quality=exp_dq,
-            confidence=exp_conf,
+            data_quality=max_dq,
+            confidence=max_conf,
             disclaimer=disclaimer,
         )
         metadata: dict[str, Any] = {"cve_id": cve_id}
         if cve_id in KNOWN_TO_FAIL_CVE_IDS:
             metadata["known_to_fail_evaluators"] = [
-                "DataQualityEvaluator",
                 "ConfidenceEvaluator",
+                "DataQualityEvaluator",
             ]
         cases.append(
             LowQualityCase(
@@ -161,7 +161,10 @@ def _build_cases(
                 inputs=cve_id,
                 expected_output=expected_output,
                 metadata=metadata,
-                evaluators=(DataQualityEvaluator(), ConfidenceEvaluator()),
+                evaluators=(
+                    DataQualityEvaluator(max_value=max_dq),
+                    ConfidenceEvaluator(max_value=max_conf),
+                ),
             )
         )
 

--- a/evals/features/cve/test_suggest_affected_packages.py
+++ b/evals/features/cve/test_suggest_affected_packages.py
@@ -17,7 +17,7 @@ import logging
 import os
 import random
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, cast, get_args
 
 import pytest
 from pydantic_evals import Case
@@ -29,6 +29,8 @@ from aegis_ai.features.cve import SuggestAffectedPackages
 from aegis_ai.features.cve.data_models import SuggestAffectedPackagesModel
 from aegis_ai.toolsets.tools.osidb import CVE
 from evals.features.common import (
+    ConfidenceEvaluator,
+    DataQualityEvaluator,
     FeatureMetricsEvaluator,
     ToolsUsedEvaluator,
     reflect_confidence,
@@ -50,6 +52,12 @@ DEFAULT_CVE_IDS: tuple[str, ...] = (
     "CVE-2026-34982",
 )
 
+# CVEs where affects data is missing or incomplete (no PURLs).  The LLM
+# should report low data_quality and confidence rather than guessing.
+LOW_QUALITY_CVE_IDS: dict[str, tuple[float, float]] = {
+    # (expected data_quality, expected confidence)
+    "CVE-2026-84327": (0.3, 0.5),
+}
 
 KNOWN_TO_FAIL_CVE_IDS: tuple[str, ...] = ()
 
@@ -98,7 +106,7 @@ def _build_cases(
     sample_size: int | None = None,
     seed: int = SAMPLE_SEED,
     cve_id_filter: set[str] | None = None,
-) -> list["SuggestAffectedPackagesCase"]:
+) -> list["SuggestAffectedPackagesCase | LowQualityCase"]:
     """Build cases from osidb_cache; optionally sample N."""
     qualifying = _load_qualifying_cves(cve_id_filter=cve_id_filter)
     cases = []
@@ -118,9 +126,44 @@ def _build_cases(
             inputs=cve_id,
             expected_output=expected_pairs,
             metadata=metadata,
-            evaluators=(),
+            evaluators=(FeatureMetricsEvaluator(),),
         )
         cases.append(case)
+
+    # Add low-quality cases (CVEs with missing/incomplete affects data)
+    cache_path = Path(OSIDB_CACHE_DIR)
+    for cve_id, (exp_dq, exp_conf) in LOW_QUALITY_CVE_IDS.items():
+        if cve_id_filter is not None and cve_id not in cve_id_filter:
+            continue
+        if not (cache_path / f"{cve_id}.json").is_file():
+            logger.debug("Skip low-quality case %s: no cache file", cve_id)
+            continue
+        disclaimer = get_args(
+            SuggestAffectedPackagesModel.model_fields["disclaimer"].annotation
+        )[0]
+        expected_output = SuggestAffectedPackagesModel(
+            cve_id=cve_id,
+            affected_packages=[],
+            explanation="",
+            data_quality=exp_dq,
+            confidence=exp_conf,
+            disclaimer=disclaimer,
+        )
+        metadata: dict[str, Any] = {"cve_id": cve_id}
+        if cve_id in KNOWN_TO_FAIL_CVE_IDS:
+            metadata["known_to_fail_evaluators"] = [
+                "DataQualityEvaluator",
+                "ConfidenceEvaluator",
+            ]
+        cases.append(
+            LowQualityCase(
+                name=f"suggest-affected-packages-{cve_id}",
+                inputs=cve_id,
+                expected_output=expected_output,
+                metadata=metadata,
+                evaluators=(DataQualityEvaluator(), ConfidenceEvaluator()),
+            )
+        )
 
     if sample_size is not None and sample_size < len(cases):
         rng = random.Random(seed)
@@ -156,7 +199,9 @@ class PackageOverlapEvaluator(Evaluator[str, SuggestAffectedPackagesModel]):
     def evaluate(
         self, ctx: EvaluatorContext[str, SuggestAffectedPackagesModel]
     ) -> EvaluationReason:
-        expected_pairs = cast(list[tuple[str, str]], ctx.expected_output or [])
+        if not isinstance(ctx.expected_output, list):
+            return EvaluationReason(value=1.0, reason=None)
+        expected_pairs = cast(list[tuple[str, str]], ctx.expected_output)
         suggested = getattr(ctx.output, "affected_packages", None) or []
         got_pairs = [(p.purl, p.ps_update_stream) for p in suggested if p.affected]
 
@@ -181,6 +226,13 @@ class PackageOverlapEvaluator(Evaluator[str, SuggestAffectedPackagesModel]):
         return EvaluationReason(value=score, reason=reason)
 
 
+class LowQualityCase(Case):
+    """Evaluation case for CVEs with insufficient affects data."""
+
+    inputs: str
+    expected_output: SuggestAffectedPackagesModel
+
+
 async def suggest_affected_packages(cve_id: CVEID) -> SuggestAffectedPackagesModel:
     """Run SuggestAffectedPackages for the given CVE."""
     feature = SuggestAffectedPackages(rh_feature_agent)
@@ -189,7 +241,6 @@ async def suggest_affected_packages(cve_id: CVEID) -> SuggestAffectedPackagesMod
 
 
 evals = [
-    FeatureMetricsEvaluator(),
     ToolsUsedEvaluator(),
     PackageOverlapEvaluator(),
 ]
@@ -211,7 +262,8 @@ def suggest_affected_packages_cases(request):
     if raw:
         cve_id_filter = {cve_id.strip() for cve_id in raw.split(",") if cve_id.strip()}
     else:
-        cve_id_filter = set(DEFAULT_CVE_IDS) if DEFAULT_CVE_IDS else None
+        all_ids = set(DEFAULT_CVE_IDS) | set(LOW_QUALITY_CVE_IDS)
+        cve_id_filter = all_ids if all_ids else None
     return _build_cases(
         sample_size=sample_size,
         seed=SAMPLE_SEED,

--- a/evals/features/cve/test_suggest_impact.py
+++ b/evals/features/cve/test_suggest_impact.py
@@ -1,4 +1,3 @@
-import math
 from typing import get_args
 
 import cvss
@@ -12,6 +11,7 @@ from aegis_ai.features.cve import SuggestImpact, SuggestImpactModel
 from aegis_ai.features.cve.impact_mappings import score_cvss3_diff, score_impact_diff
 from aegis_ai.kernel_classifier import is_kernel_component
 from evals.features.common import (
+    DataQualityEvaluator,
     common_feature_evals,
     create_llm_judge,
     make_eval_reason,
@@ -72,25 +72,6 @@ class CVSSVectorEvaluator(Evaluator[str, SuggestImpactModel]):
             reason = f"unhandled exception: {e}"
 
         score = reflect_confidence(ctx, score)
-        return EvaluationReason(value=score, reason=reason)
-
-
-class DataQualityEvaluator(Evaluator[str, SuggestImpactModel]):
-    """Compare data_quality with the expected value when specified"""
-
-    _sigma = 0.1  # controls tolerance: ~0.61 at ±0.1, ~0.14 at ±0.2
-
-    def evaluate(
-        self, ctx: EvaluatorContext[str, SuggestImpactModel]
-    ) -> EvaluationReason:
-        assert ctx.expected_output is not None
-        got = ctx.output.data_quality
-        expected = ctx.expected_output.data_quality
-        diff = got - expected
-
-        # Gaussian similarity
-        score = math.exp(-(diff**2) / (2 * self._sigma**2))
-        reason = None if score >= 1.0 else f"got {got}, expected {expected}"
         return EvaluationReason(value=score, reason=reason)
 
 

--- a/evals/osidb_cache/CVE-2014-9984.json
+++ b/evals/osidb_cache/CVE-2014-9984.json
@@ -1,0 +1,121 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2014-9984",
+    "cwe_id": "CWE-131",
+    "impact": "CRITICAL",
+    "title": "nscd buffer manipulation vulnerability could lead to code execution or crash",
+    "statement": "This issue did not affect the versions of glibc as shipped with Red Hat Enterprise Linux 5 as they did not include support for netgroups. Red Hat Enterprise Linux 6 and 7 already include the fixed version of the package.",
+    "mitigation": "",
+    "comment_zero": "A flaw was found in glibc where the size of an internal buffer was not correctly computed when processing netgroup requests. A remote attacker able to send netgroup requests that were processed by the nscd daemon could cause the ncsd to crash or, potentially, execute code as the user running nscd.\n\nUpstream bug:\n\nhttps://sourceware.org/bugzilla/show_bug.cgi?id=16695\n\nUpstream patch:\n\nhttps://sourceware.org/git/gitweb.cgi?p=glibc.git;a=commitdiff;h=c44496df2f090a56d3bf75df930592dac6bba46f",
+    "comments": "A flaw was found in glibc where the size of an internal buffer was not correctly computed when processing netgroup requests. A remote attacker able to send netgroup requests that were processed by the nscd daemon could cause the ncsd to crash or, potentially, execute code as the user running nscd.\n\nUpstream bug:\n\nhttps://sourceware.org/bugzilla/show_bug.cgi?id=16695\n\nUpstream patch:\n\nhttps://sourceware.org/git/gitweb.cgi?p=glibc.git;a=commitdiff;h=c44496df2f090a56d3bf75df930592dac6bba46f Statement:\n\nThis issue did not affect the versions of glibc as shipped with Red Hat Enterprise Linux 5 as they did not include support for netgroups. Red Hat Enterprise Linux 6 and 7 already include the fixed version of the package. All versions of glibc-linux-arm-gnu in Fedora are newer than 2.20. ",
+    "description": "",
+    "components": [
+        "glibc"
+    ],
+    "references": [],
+    "affects": [
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "rhel-5",
+            "ps_update_stream": "rhel-5.11.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "compat-glibc",
+            "purl": "pkg:rpm/redhat/compat-glibc?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "rhel-7",
+            "ps_update_stream": "rhel-7-els",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "glibc",
+            "purl": "pkg:rpm/redhat/glibc?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "rhel-5",
+            "ps_update_stream": "rhel-5.11.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "glibc",
+            "purl": "pkg:rpm/redhat/glibc?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "fedora-all",
+            "ps_update_stream": "fedora-all",
+            "ps_product": "Community Projects",
+            "ps_component": "glibc-arm-linux-gnu",
+            "purl": null,
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "fedora-all",
+            "ps_update_stream": "fedora-all",
+            "ps_product": "Community Projects",
+            "ps_component": "glibc",
+            "purl": null,
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "rhel-6",
+            "ps_update_stream": "rhel-6-els",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "glibc",
+            "purl": "pkg:rpm/redhat/glibc?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "rhel-7",
+            "ps_update_stream": "rhel-7-els",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "compat-glibc",
+            "purl": "pkg:rpm/redhat/compat-glibc?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "rhel-6",
+            "ps_update_stream": "rhel-6-els",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "compat-glibc",
+            "purl": "pkg:rpm/redhat/compat-glibc?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        }
+    ],
+    "cvss_scores": [
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+        },
+        {
+            "issuer": "NIST",
+            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
+        },
+        {
+            "issuer": "NIST",
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2025-49175.json
+++ b/evals/osidb_cache/CVE-2025-49175.json
@@ -1,0 +1,591 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2025-49175",
+    "cwe_id": "CWE-125",
+    "impact": "IMPORTANT",
+    "title": "Out-of-Bounds Read in X Rendering Extension Animated Cursors",
+    "statement": "This vulnerability is rated as an important severity because the flaw exists in the X Rendering extension of the X.Org X server, specifically in the handling of animated cursors, when a client request provides zero cursors, the server erroneously assumes that at least one cursor is present and proceeds to access elements in the non-existent array. This logic error causes an out-of-bounds read, which can lead to a server crash and denial of service, the flaw could expose limited uninitialized memory, potentially resulting in minor information disclosure.",
+    "mitigation": "Mitigation for this issue is either not available or the currently available options don't meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base, or stability.",
+    "comment_zero": "Out-of-Bounds Read vulnerability in the X Rendering extension's animated cursor handling. The server assumes at least one cursor is provided, but a client may pass none, causing an out-of-bounds read and server crash.",
+    "comments": "",
+    "description": "A flaw was found in the X Rendering extension's handling of animated cursors. If a client provides no cursors, the server assumes at least one is present, leading to an out-of-bounds read and potential crash.",
+    "components": [
+        "xorg-x11-server-Xwayland",
+        "xorg-x11-server",
+        "tigervnc"
+    ],
+    "references": [
+        {
+            "url": "https://gitlab.freedesktop.org/xorg/xserver/-/commit/0885e0b26225c90534642fe911632ec0779eebee"
+        },
+        {
+            "url": "https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2024"
+        },
+        {
+            "url": "https://www.x.org/wiki/Development/Security/"
+        }
+    ],
+    "affects": [
+        {
+            "affected": "AFFECTED",
+            "ps_module": "fedora-all",
+            "ps_update_stream": "fedora-all",
+            "ps_product": "Community Projects",
+            "ps_component": "tigervnc",
+            "purl": "pkg:rpm/fedora/tigervnc?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-6",
+            "ps_update_stream": "rhel-6-els",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "tigervnc",
+            "purl": "pkg:rpm/redhat/tigervnc?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-7",
+            "ps_update_stream": "rhel-7.7.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "tigervnc",
+            "purl": "pkg:rpm/redhat/tigervnc?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-7",
+            "ps_update_stream": "rhel-7-els",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "tigervnc",
+            "purl": "pkg:rpm/redhat/tigervnc?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-8",
+            "ps_update_stream": "rhel-8.4.0.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "tigervnc",
+            "purl": "pkg:rpm/redhat/tigervnc?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-8",
+            "ps_update_stream": "rhel-8.6.0.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "tigervnc",
+            "purl": "pkg:rpm/redhat/tigervnc?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-8",
+            "ps_update_stream": "rhel-8.2.0.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "tigervnc",
+            "purl": "pkg:rpm/redhat/tigervnc?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-8",
+            "ps_update_stream": "rhel-8.8.0.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "tigervnc",
+            "purl": "pkg:rpm/redhat/tigervnc?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-8",
+            "ps_update_stream": "rhel-8.10.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "tigervnc",
+            "purl": "pkg:rpm/redhat/tigervnc?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-9",
+            "ps_update_stream": "rhel-9.0.0.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "tigervnc",
+            "purl": "pkg:rpm/redhat/tigervnc?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-9",
+            "ps_update_stream": "rhel-9.6.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "tigervnc",
+            "purl": "pkg:rpm/redhat/tigervnc?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-9",
+            "ps_update_stream": "rhel-9.2.0.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "tigervnc",
+            "purl": "pkg:rpm/redhat/tigervnc?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-9",
+            "ps_update_stream": "rhel-9.4.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "tigervnc",
+            "purl": "pkg:rpm/redhat/tigervnc?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-9",
+            "ps_update_stream": "rhel-9.7",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "tigervnc",
+            "purl": "pkg:rpm/redhat/tigervnc?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhivos-1",
+            "ps_update_stream": "rhivos-1.0.z",
+            "ps_product": "Red Hat In-Vehicle OS",
+            "ps_component": "tigervnc",
+            "purl": "pkg:rpm/redhat/tigervnc?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhivos-1",
+            "ps_update_stream": "rhivos-1.1",
+            "ps_product": "Red Hat In-Vehicle OS",
+            "ps_component": "tigervnc",
+            "purl": "pkg:rpm/redhat/tigervnc?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhivos-1",
+            "ps_update_stream": "rhivos-1.0",
+            "ps_product": "Red Hat In-Vehicle OS",
+            "ps_component": "tigervnc",
+            "purl": "pkg:rpm/redhat/tigervnc?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "fedora-all",
+            "ps_update_stream": "fedora-all",
+            "ps_product": "Community Projects",
+            "ps_component": "xorg-x11-server",
+            "purl": "pkg:rpm/fedora/xorg-x11-server?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-6",
+            "ps_update_stream": "rhel-6-els",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "xorg-x11-server",
+            "purl": "pkg:rpm/redhat/xorg-x11-server?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-7",
+            "ps_update_stream": "rhel-7.7.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "xorg-x11-server",
+            "purl": "pkg:rpm/redhat/xorg-x11-server?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-7",
+            "ps_update_stream": "rhel-7-els",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "xorg-x11-server",
+            "purl": "pkg:rpm/redhat/xorg-x11-server?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-8",
+            "ps_update_stream": "rhel-8.6.0.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "xorg-x11-server",
+            "purl": "pkg:rpm/redhat/xorg-x11-server?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-8",
+            "ps_update_stream": "rhel-8.4.0.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "xorg-x11-server",
+            "purl": "pkg:rpm/redhat/xorg-x11-server?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-8",
+            "ps_update_stream": "rhel-8.2.0.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "xorg-x11-server",
+            "purl": "pkg:rpm/redhat/xorg-x11-server?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-8",
+            "ps_update_stream": "rhel-8.10.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "xorg-x11-server",
+            "purl": "pkg:rpm/redhat/xorg-x11-server?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-8",
+            "ps_update_stream": "rhel-8.8.0.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "xorg-x11-server",
+            "purl": "pkg:rpm/redhat/xorg-x11-server?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-9",
+            "ps_update_stream": "rhel-9.0.0.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "xorg-x11-server",
+            "purl": "pkg:rpm/redhat/xorg-x11-server?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-9",
+            "ps_update_stream": "rhel-9.6.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "xorg-x11-server",
+            "purl": "pkg:rpm/redhat/xorg-x11-server?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-9",
+            "ps_update_stream": "rhel-9.4.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "xorg-x11-server",
+            "purl": "pkg:rpm/redhat/xorg-x11-server?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-9",
+            "ps_update_stream": "rhel-9.7",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "xorg-x11-server",
+            "purl": "pkg:rpm/redhat/xorg-x11-server?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-9",
+            "ps_update_stream": "rhel-9.2.0.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "xorg-x11-server",
+            "purl": "pkg:rpm/redhat/xorg-x11-server?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhivos-1",
+            "ps_update_stream": "rhivos-1.0.z",
+            "ps_product": "Red Hat In-Vehicle OS",
+            "ps_component": "xorg-x11-server",
+            "purl": "pkg:rpm/redhat/xorg-x11-server?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhivos-1",
+            "ps_update_stream": "rhivos-1.1",
+            "ps_product": "Red Hat In-Vehicle OS",
+            "ps_component": "xorg-x11-server",
+            "purl": "pkg:rpm/redhat/xorg-x11-server?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhivos-1",
+            "ps_update_stream": "rhivos-1.0",
+            "ps_product": "Red Hat In-Vehicle OS",
+            "ps_component": "xorg-x11-server",
+            "purl": "pkg:rpm/redhat/xorg-x11-server?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "fedora-all",
+            "ps_update_stream": "fedora-all",
+            "ps_product": "Community Projects",
+            "ps_component": "xorg-x11-server-Xwayland",
+            "purl": "pkg:rpm/fedora/xorg-x11-server-Xwayland?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-10",
+            "ps_update_stream": "rhel-10.0.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "xorg-x11-server-Xwayland",
+            "purl": "pkg:rpm/redhat/xorg-x11-server-Xwayland?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-10",
+            "ps_update_stream": "rhel-10.1",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "xorg-x11-server-Xwayland",
+            "purl": "pkg:rpm/redhat/xorg-x11-server-Xwayland?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-8",
+            "ps_update_stream": "rhel-8.8.0.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "xorg-x11-server-Xwayland",
+            "purl": "pkg:rpm/redhat/xorg-x11-server-Xwayland?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-8",
+            "ps_update_stream": "rhel-8.10.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "xorg-x11-server-Xwayland",
+            "purl": "pkg:rpm/redhat/xorg-x11-server-Xwayland?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-8",
+            "ps_update_stream": "rhel-8.2.0.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "xorg-x11-server-Xwayland",
+            "purl": "pkg:rpm/redhat/xorg-x11-server-Xwayland?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-8",
+            "ps_update_stream": "rhel-8.6.0.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "xorg-x11-server-Xwayland",
+            "purl": "pkg:rpm/redhat/xorg-x11-server-Xwayland?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-8",
+            "ps_update_stream": "rhel-8.4.0.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "xorg-x11-server-Xwayland",
+            "purl": "pkg:rpm/redhat/xorg-x11-server-Xwayland?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-9",
+            "ps_update_stream": "rhel-9.7",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "xorg-x11-server-Xwayland",
+            "purl": "pkg:rpm/redhat/xorg-x11-server-Xwayland?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-9",
+            "ps_update_stream": "rhel-9.0.0.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "xorg-x11-server-Xwayland",
+            "purl": "pkg:rpm/redhat/xorg-x11-server-Xwayland?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-9",
+            "ps_update_stream": "rhel-9.2.0.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "xorg-x11-server-Xwayland",
+            "purl": "pkg:rpm/redhat/xorg-x11-server-Xwayland?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-9",
+            "ps_update_stream": "rhel-9.6.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "xorg-x11-server-Xwayland",
+            "purl": "pkg:rpm/redhat/xorg-x11-server-Xwayland?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-9",
+            "ps_update_stream": "rhel-9.4.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "xorg-x11-server-Xwayland",
+            "purl": "pkg:rpm/redhat/xorg-x11-server-Xwayland?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhivos-1",
+            "ps_update_stream": "rhivos-1.0",
+            "ps_product": "Red Hat In-Vehicle OS",
+            "ps_component": "xorg-x11-server-Xwayland",
+            "purl": "pkg:rpm/redhat/xorg-x11-server-Xwayland?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhivos-1",
+            "ps_update_stream": "rhivos-1.0.z",
+            "ps_product": "Red Hat In-Vehicle OS",
+            "ps_component": "xorg-x11-server-Xwayland",
+            "purl": "pkg:rpm/redhat/xorg-x11-server-Xwayland?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhivos-1",
+            "ps_update_stream": "rhivos-1.1",
+            "ps_product": "Red Hat In-Vehicle OS",
+            "ps_component": "xorg-x11-server-Xwayland",
+            "purl": "pkg:rpm/redhat/xorg-x11-server-Xwayland?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        }
+    ],
+    "cvss_scores": [
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:H"
+        },
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:H"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-34982.json
+++ b/evals/osidb_cache/CVE-2026-34982.json
@@ -1,0 +1,353 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-34982",
+    "cwe_id": "CWE-78",
+    "impact": "IMPORTANT",
+    "title": "arbitrary command execution via modeline sandbox bypass",
+    "statement": "To exploit this vulnerability, an attacker needs to convince a user to open a specially crafted file. The arbitrary OS command execution is restricted to the privileges of the user running Vim, limiting the potential of a full system compromise.",
+    "mitigation": "To mitigate this issue, disable the modeline support by adding the following command to the Vim configuration file:\n\n~~~\nset nomodeline\n~~~",
+    "comment_zero": "Vim is an open source, command line text editor. Prior to version 9.2.0276, a modeline sandbox bypass in Vim allows arbitrary OS command execution when a user opens a crafted file. The `complete`, `guitabtooltip` and `printheader` options are missing the `P_MLE` flag, allowing a modeline to be executed. Additionally, the `mapset()` function lacks a `check_secure()` call, allowing it to be abused from sandboxed expressions. Commit 9.2.0276 fixes the issue.",
+    "comments": "",
+    "description": "A flaw was found in Vim. A modeline is used to set specific editor options directly from a text file. However, the `complete`, `guitabtooltip`, `printheader` options and the `mapset` function lack proper security checks, allowing an attacker to bypass restrictions and cause arbitrary OS command execution.",
+    "components": [
+        "vim"
+    ],
+    "references": [
+        {
+            "url": "https://github.com/vim/vim/security/advisories/GHSA-8h6p-m6gr-mpw9"
+        },
+        {
+            "url": "https://github.com/vim/vim/commit/75661a66a1db1e1f3f1245c615"
+        },
+        {
+            "url": "http://www.openwall.com/lists/oss-security/2026/04/01/1"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-34982"
+        },
+        {
+            "url": "https://github.com/vim/vim/releases/tag/v9.2.0276"
+        }
+    ],
+    "affects": [
+        {
+            "affected": "AFFECTED",
+            "ps_module": "fedora-all",
+            "ps_update_stream": "fedora-all",
+            "ps_product": "Community Projects",
+            "ps_component": "vim",
+            "purl": "pkg:rpm/fedora/vim?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "openshift-4",
+            "ps_update_stream": "openshift-4.12.z",
+            "ps_product": "OpenShift Container Platform",
+            "ps_component": "openshift/ose-rhel-coreos-8",
+            "purl": "pkg:oci/ose-rhel-coreos-8?repository_url=registry.redhat.io/openshift/ose-rhel-coreos-8",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "openshift-4",
+            "ps_update_stream": "openshift-4.13.z",
+            "ps_product": "OpenShift Container Platform",
+            "ps_component": "rhcos",
+            "purl": "pkg:generic/redhat/rhcos",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "openshift-4",
+            "ps_update_stream": "openshift-4.14.z",
+            "ps_product": "OpenShift Container Platform",
+            "ps_component": "openshift/ose-rhel-coreos-9",
+            "purl": "pkg:oci/ose-rhel-coreos-9?repository_url=registry.redhat.io/openshift/ose-rhel-coreos-9",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "openshift-4",
+            "ps_update_stream": "openshift-4.15.z",
+            "ps_product": "OpenShift Container Platform",
+            "ps_component": "openshift/ose-rhel-coreos-9",
+            "purl": "pkg:oci/ose-rhel-coreos-9?repository_url=registry.redhat.io/openshift/ose-rhel-coreos-9",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "openshift-4",
+            "ps_update_stream": "openshift-4.16.z",
+            "ps_product": "OpenShift Container Platform",
+            "ps_component": "openshift/ose-rhel-coreos-9",
+            "purl": "pkg:oci/ose-rhel-coreos-9?repository_url=registry.redhat.io/openshift/ose-rhel-coreos-9",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "openshift-4",
+            "ps_update_stream": "openshift-4.17",
+            "ps_product": "OpenShift Container Platform",
+            "ps_component": "openshift/ose-rhel-coreos-9",
+            "purl": "pkg:oci/ose-rhel-coreos-9?repository_url=registry.redhat.io/openshift/ose-rhel-coreos-9",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "openshift-4",
+            "ps_update_stream": "openshift-4.18",
+            "ps_product": "OpenShift Container Platform",
+            "ps_component": "openshift/ose-rhel-coreos-9",
+            "purl": "pkg:oci/ose-rhel-coreos-9?repository_url=registry.redhat.io/openshift/ose-rhel-coreos-9",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "openshift-4",
+            "ps_update_stream": "openshift-4.19",
+            "ps_product": "OpenShift Container Platform",
+            "ps_component": "openshift/ose-rhel-coreos-9",
+            "purl": "pkg:oci/ose-rhel-coreos-9?repository_url=registry.redhat.io/openshift/ose-rhel-coreos-9",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-10",
+            "ps_update_stream": "rhel-10.0.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "vim",
+            "purl": "pkg:rpm/redhat/vim?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-10",
+            "ps_update_stream": "rhel-10.1.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "vim",
+            "purl": "pkg:rpm/redhat/vim?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-10",
+            "ps_update_stream": "rhel-10.2",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "vim",
+            "purl": "pkg:rpm/redhat/vim?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-10",
+            "ps_update_stream": "rhel-10.3",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "vim",
+            "purl": "pkg:rpm/redhat/vim?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-6",
+            "ps_update_stream": "rhel-6-els",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "vim",
+            "purl": "pkg:rpm/redhat/vim?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-7",
+            "ps_update_stream": "rhel-7-els",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "vim",
+            "purl": "pkg:rpm/redhat/vim?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-8",
+            "ps_update_stream": "rhel-8.10.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "vim",
+            "purl": "pkg:rpm/redhat/vim?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-8",
+            "ps_update_stream": "rhel-8.2.0.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "vim",
+            "purl": "pkg:rpm/redhat/vim?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-8",
+            "ps_update_stream": "rhel-8.4.0.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "vim",
+            "purl": "pkg:rpm/redhat/vim?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-8",
+            "ps_update_stream": "rhel-8.6.0.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "vim",
+            "purl": "pkg:rpm/redhat/vim?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-8",
+            "ps_update_stream": "rhel-8.8.0.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "vim",
+            "purl": "pkg:rpm/redhat/vim?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-9",
+            "ps_update_stream": "rhel-9.0.0.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "vim",
+            "purl": "pkg:rpm/redhat/vim?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-9",
+            "ps_update_stream": "rhel-9.2.0.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "vim",
+            "purl": "pkg:rpm/redhat/vim?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-9",
+            "ps_update_stream": "rhel-9.4.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "vim",
+            "purl": "pkg:rpm/redhat/vim?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-9",
+            "ps_update_stream": "rhel-9.6.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "vim",
+            "purl": "pkg:rpm/redhat/vim?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-9",
+            "ps_update_stream": "rhel-9.7.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "vim",
+            "purl": "pkg:rpm/redhat/vim?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-9",
+            "ps_update_stream": "rhel-9.8",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "vim",
+            "purl": "pkg:rpm/redhat/vim?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "rhel-9",
+            "ps_update_stream": "rhel-9.9",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "vim",
+            "purl": "pkg:rpm/redhat/vim?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "services-ansible-on-clouds",
+            "ps_update_stream": "services-ansible-on-clouds-default",
+            "ps_product": "Ansible Services",
+            "ps_component": "aoc/netshoot",
+            "purl": "pkg:oci/netshoot?repository_url=quay.io/aoc/netshoot",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        }
+    ],
+    "cvss_scores": [
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:N"
+        },
+        {
+            "issuer": "CVEORG",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:N"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-3904.json
+++ b/evals/osidb_cache/CVE-2026-3904.json
@@ -1,0 +1,474 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-3904",
+    "cwe_id": "CWE-366",
+    "impact": "MODERATE",
+    "title": "nscd client crash on x86_64 under high nscd load",
+    "statement": "This issue is only exploitable via applications using NSS-backed functions that support caching via nscd under a high load on x86_64 systems. It depends on a race condition on inputs that are concurrently modified by other processes or threads during memory access, increasing the complexity of exploitation. Also, this flaw can only cause an application crash, limiting the security impact to a denial of service. Due to these reasons, this vulnerability has been rated with a moderate severity.",
+    "mitigation": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability.",
+    "comment_zero": "Calling NSS-backed functions that support caching via nscd may call the \nnscd client side code and in the GNU C Library version 2.36 under high \nload on x86_64 systems, the client may call memcmp on inputs that are \nconcurrently modified by other processes or threads and crash.\n\n\n\n\nThe nscd client in the GNU C Library uses the memcmp function with \ninputs that may be concurrently modified by another thread, potentially \nresulting in spurious cache misses, which in itself is not a security \nissue.  However in the GNU C Library version 2.36 an optimized \nimplementation of memcmp was introduced for x86_64 which could crash \nwhen invoked with such undefined behaviour, turning this into a \npotential crash of the nscd client and the application that uses it. \nThis implementation was backported to the 2.35 branch, making the nscd \nclient in that branch vulnerable as well.  Subsequently, the fix for \nthis issue was backported to all vulnerable branches in the GNU C \nLibrary repository.\n\n\nIt is advised that distributions that may have cherry-picked the memcpy \nSSE2 optimization in their copy of the GNU C Library, also apply the fix \nto avoid the potential crash in the nscd client.",
+    "comments": "",
+    "description": "A flaw was found in glibc. When calling NSS-backed functions that support caching via nscd, the nscd client under high load on x86_64 systems may call the memcmp function on inputs that are concurrently modified by other processes or threads, causing a crash and resulting in a denial of service.",
+    "components": [
+        "glibc"
+    ],
+    "references": [
+        {
+            "url": "https://sourceware.org/git/?p=glibc.git;a=commit;h=8804157ad9da39631703b92315460808eac86b0c"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-3904"
+        },
+        {
+            "url": "https://sourceware.org/git/?p=glibc.git;a=blob_plain;f=advisories/GLIBC-SA-2026-0004;hb=HEAD"
+        },
+        {
+            "url": "https://sourceware.org/bugzilla/show_bug.cgi?id=29863"
+        },
+        {
+            "url": "https://sourceware.org/git/?p=glibc.git;a=commit;h=b712be52645282c706a5faa038242504feb06db5"
+        }
+    ],
+    "affects": [
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "epel-all",
+            "ps_update_stream": "epel-all",
+            "ps_product": "Community Projects",
+            "ps_component": "zig",
+            "purl": "pkg:rpm/fedora/zig?arch=src",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "fedora-all",
+            "ps_update_stream": "fedora-all",
+            "ps_product": "Community Projects",
+            "ps_component": "glibc",
+            "purl": "pkg:rpm/fedora/glibc?arch=src",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "fedora-all",
+            "ps_update_stream": "fedora-all",
+            "ps_product": "Community Projects",
+            "ps_component": "zig",
+            "purl": "pkg:rpm/fedora/zig?arch=src",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "openshift-4",
+            "ps_update_stream": "openshift-4.12.z",
+            "ps_product": "OpenShift Container Platform",
+            "ps_component": "openshift/ose-rhel-coreos-8",
+            "purl": "pkg:oci/ose-rhel-coreos-8?repository_url=registry.redhat.io/openshift/ose-rhel-coreos-8",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "openshift-4",
+            "ps_update_stream": "openshift-4.13.z",
+            "ps_product": "OpenShift Container Platform",
+            "ps_component": "openshift/ose-rhel-coreos-9",
+            "purl": "pkg:oci/ose-rhel-coreos-9?repository_url=registry.redhat.io/openshift/ose-rhel-coreos-9",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "openshift-4",
+            "ps_update_stream": "openshift-4.14.z",
+            "ps_product": "OpenShift Container Platform",
+            "ps_component": "openshift/ose-rhel-coreos-9",
+            "purl": "pkg:oci/ose-rhel-coreos-9?repository_url=registry.redhat.io/openshift/ose-rhel-coreos-9",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "openshift-4",
+            "ps_update_stream": "openshift-4.15.z",
+            "ps_product": "OpenShift Container Platform",
+            "ps_component": "openshift/ose-rhel-coreos-9",
+            "purl": "pkg:oci/ose-rhel-coreos-9?repository_url=registry.redhat.io/openshift/ose-rhel-coreos-9",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "openshift-4",
+            "ps_update_stream": "openshift-4.16.z",
+            "ps_product": "OpenShift Container Platform",
+            "ps_component": "openshift/ose-rhel-coreos-9",
+            "purl": "pkg:oci/ose-rhel-coreos-9?repository_url=registry.redhat.io/openshift/ose-rhel-coreos-9",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "openshift-4",
+            "ps_update_stream": "openshift-4.17",
+            "ps_product": "OpenShift Container Platform",
+            "ps_component": "openshift/ose-rhel-coreos-9",
+            "purl": "pkg:oci/ose-rhel-coreos-9?repository_url=registry.redhat.io/openshift/ose-rhel-coreos-9",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "openshift-4",
+            "ps_update_stream": "openshift-4.18",
+            "ps_product": "OpenShift Container Platform",
+            "ps_component": "openshift/ose-rhel-coreos-9",
+            "purl": "pkg:oci/ose-rhel-coreos-9?repository_url=registry.redhat.io/openshift/ose-rhel-coreos-9",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "openshift-4",
+            "ps_update_stream": "openshift-4.19",
+            "ps_product": "OpenShift Container Platform",
+            "ps_component": "openshift/ose-rhel-coreos-9",
+            "purl": "pkg:oci/ose-rhel-coreos-9?repository_url=registry.redhat.io/openshift/ose-rhel-coreos-9",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "rhel-10",
+            "ps_update_stream": "rhel-10.0.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "glibc",
+            "purl": "pkg:rpm/redhat/glibc?arch=src",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "rhel-10",
+            "ps_update_stream": "rhel-10.1.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "glibc",
+            "purl": "pkg:rpm/redhat/glibc?arch=src",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "rhel-10",
+            "ps_update_stream": "rhel-10.2",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "glibc",
+            "purl": "pkg:rpm/redhat/glibc?arch=src",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "rhel-10",
+            "ps_update_stream": "rhel-10.3",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "glibc",
+            "purl": "pkg:rpm/redhat/glibc?arch=src",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "rhel-6",
+            "ps_update_stream": "rhel-6-els",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "compat-glibc",
+            "purl": "pkg:rpm/redhat/compat-glibc?arch=src",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "rhel-6",
+            "ps_update_stream": "rhel-6-els",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "glibc",
+            "purl": "pkg:rpm/redhat/glibc?arch=src",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "rhel-7",
+            "ps_update_stream": "rhel-7-els",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "compat-glibc",
+            "purl": "pkg:rpm/redhat/compat-glibc?arch=src",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "rhel-7",
+            "ps_update_stream": "rhel-7-els",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "glibc",
+            "purl": "pkg:rpm/redhat/glibc?arch=src",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "rhel-8",
+            "ps_update_stream": "rhel-8.10.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "glibc",
+            "purl": "pkg:rpm/redhat/glibc?arch=src",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "rhel-8",
+            "ps_update_stream": "rhel-8.2.0.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "glibc",
+            "purl": "pkg:rpm/redhat/glibc?arch=src",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "rhel-8",
+            "ps_update_stream": "rhel-8.4.0.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "glibc",
+            "purl": "pkg:rpm/redhat/glibc?arch=src",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "rhel-8",
+            "ps_update_stream": "rhel-8.6.0.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "glibc",
+            "purl": "pkg:rpm/redhat/glibc?arch=src",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "rhel-8",
+            "ps_update_stream": "rhel-8.8.0.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "glibc",
+            "purl": "pkg:rpm/redhat/glibc?arch=src",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "rhel-9",
+            "ps_update_stream": "rhel-9.0.0.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "glibc",
+            "purl": "pkg:rpm/redhat/glibc?arch=src",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "rhel-9",
+            "ps_update_stream": "rhel-9.2.0.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "glibc",
+            "purl": "pkg:rpm/redhat/glibc?arch=src",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "rhel-9",
+            "ps_update_stream": "rhel-9.4.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "glibc",
+            "purl": "pkg:rpm/redhat/glibc?arch=src",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "rhel-9",
+            "ps_update_stream": "rhel-9.6.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "glibc",
+            "purl": "pkg:rpm/redhat/glibc?arch=src",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "rhel-9",
+            "ps_update_stream": "rhel-9.7.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "glibc",
+            "purl": "pkg:rpm/redhat/glibc?arch=src",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "rhel-9",
+            "ps_update_stream": "rhel-9.8",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "glibc",
+            "purl": "pkg:rpm/redhat/glibc?arch=src",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "rhel-9",
+            "ps_update_stream": "rhel-9.9",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "glibc",
+            "purl": "pkg:rpm/redhat/glibc?arch=src",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "rhel-br-9",
+            "ps_update_stream": "rhel-br-9.0.0.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "glibc32",
+            "purl": "pkg:rpm/redhat/glibc32?arch=src",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "rhel-br-9",
+            "ps_update_stream": "rhel-br-9.2.0.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "glibc32",
+            "purl": "pkg:rpm/redhat/glibc32?arch=src",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "rhel-br-9",
+            "ps_update_stream": "rhel-br-9.4.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "glibc32",
+            "purl": "pkg:rpm/redhat/glibc32?arch=src",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "rhel-br-9",
+            "ps_update_stream": "rhel-br-9.6.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "glibc32",
+            "purl": "pkg:rpm/redhat/glibc32?arch=src",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "rhel-br-9",
+            "ps_update_stream": "rhel-br-9.7.z",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "glibc32",
+            "purl": "pkg:rpm/redhat/glibc32?arch=src",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "rhel-br-9",
+            "ps_update_stream": "rhel-br-9.8",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "glibc32",
+            "purl": "pkg:rpm/redhat/glibc32?arch=src",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "NOTAFFECTED",
+            "ps_module": "rhel-br-9",
+            "ps_update_stream": "rhel-br-9.9",
+            "ps_product": "Red Hat Enterprise Linux",
+            "ps_component": "glibc32",
+            "purl": "pkg:rpm/redhat/glibc32?arch=src",
+            "impact": "",
+            "not_affected_justification": "Vulnerable Code not Present",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "hummingbird-1",
+            "ps_update_stream": "hummingbird-1",
+            "ps_product": "Red Hat Hardened Images",
+            "ps_component": "glibc",
+            "purl": "pkg:rpm/redhat/glibc?arch=src",
+            "impact": "",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        }
+    ],
+    "cvss_scores": [
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        },
+        {
+            "issuer": "CISA",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        }
+    ]
+}

--- a/evals/osidb_cache/CVE-2026-84327.json
+++ b/evals/osidb_cache/CVE-2026-84327.json
@@ -1,0 +1,61 @@
+{
+    "status": "success",
+    "error_message": null,
+    "cve_id": "CVE-2026-84327",
+    "cwe_id": "CWE-551",
+    "impact": "MODERATE",
+    "title": "Google Chrome Autofill: Information Disclosure via Incorrect Authorization",
+    "statement": "",
+    "mitigation": "",
+    "comment_zero": "Incorrect authorization in Autofill in Google Chrome on on Android prior to 152.0.7977.75 allowed a remote attacker leveraging social engineering to obtain sensitive information via a crafted HTML page. (Chromium security severity: Low)",
+    "comments": "",
+    "description": "A flaw was found in Autofill in Google Chrome for Android. Incorrect authorization in the Autofill feature could allow a remote attacker, through social engineering, to exploit a crafted HTML page. This could lead to the disclosure of sensitive user information.",
+    "components": [
+        "chromium-browser"
+    ],
+    "references": [
+        {
+            "url": "https://issues.chromium.org/issues/498725213"
+        },
+        {
+            "url": "https://www.cve.org/CVERecord?id=CVE-2026-84327"
+        },
+        {
+            "url": "https://chromereleases.googleblog.com/2026/09/stable-channel-update-for-desktop.html"
+        }
+    ],
+    "affects": [
+        {
+            "affected": "AFFECTED",
+            "ps_module": "fedora-all",
+            "ps_update_stream": "fedora-all",
+            "ps_product": "Community Projects",
+            "ps_component": "chromium",
+            "purl": null,
+            "impact": "MODERATE",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        },
+        {
+            "affected": "AFFECTED",
+            "ps_module": "epel-all",
+            "ps_update_stream": "epel-all",
+            "ps_product": "Community Projects",
+            "ps_component": "chromium",
+            "purl": null,
+            "impact": "MODERATE",
+            "not_affected_justification": "",
+            "delegated_not_affected_justification": ""
+        }
+    ],
+    "cvss_scores": [
+        {
+            "issuer": "RH",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:N/A:N"
+        },
+        {
+            "issuer": "CISA",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:N/A:N"
+        }
+    ]
+}

--- a/src/aegis_ai/features/cve/__init__.py
+++ b/src/aegis_ai/features/cve/__init__.py
@@ -18,6 +18,7 @@ from aegis_ai.features.cve.data_models import (
     QueryAffectedComponentsModel,
     RevisedExplanationModel,
     SuggestAffectedComponentsModel,
+    SuggestAffectedPackagesModel,
     SuggestCWEModel,
     SuggestDescriptionModel,
     SuggestImpactModel,
@@ -1243,6 +1244,54 @@ The three core questions every review must address:
         )
 
         return await self.guarded_run(prompt, deps=deps, output_type=QualityReviewModel)
+
+
+class SuggestAffectedPackages(Feature):
+    """LLM-driven suggestion of source RPM package affectedness."""
+
+    async def exec(self, cve_id: CVEID, static_context: Any = None):
+        # Only use static_context for deps when it contains affects data;
+        # otherwise let the OSIDB tool fetch the full flaw record.
+        deps_context = (
+            static_context
+            if isinstance(static_context, dict) and "affects" in static_context
+            else None
+        )
+        deps = feature_deps(exclude_osidb_fields=[], static_context=deps_context)
+        prompt = AegisPrompt(
+            user_instruction=(
+                "Analyze the CVE and its OSIDB affects data (including PURLs and "
+                "product streams) to determine which source RPM packages are affected "
+                "by the vulnerability. Use the OSIDB tool to retrieve flaw data."
+            ),
+            goals="""\
+- For each affect entry with a PURL, determine whether the source RPM package is affected by the specific vulnerability described in the CVE.
+- Produce a per-package affectedness suggestion with rationale.
+- Where possible, identify which internal sub-components within the package are affected (e.g., a specific kernel module, a library within a larger source package).
+- Signal low data_quality when the CVE description or affects data is insufficient for confident analysis.
+- Provide an overall explanation summarizing the affectedness analysis.
+""",
+            rules="""\
+- Use the osidb_tool with the provided cve_id to retrieve CVE flaw data, including affects with PURLs.
+- The affects array is valid in PRE_SECONDARY_ASSESSMENT and later flaw states. In earlier states, the array can be empty or incomplete — this does NOT mean no packages are affected, only that the data is not yet available.
+- If the affects array is empty or appears incomplete (e.g., flaw is in an early state like NEW or TRIAGE), set low data_quality and explain that affects data is not yet available.
+- Analyze CVE description, references, patches, and comments to understand the technical scope of the vulnerability.
+- For each source RPM package identified by PURL in the affects list:
+  - Determine whether the package contains the vulnerable code or functionality.
+  - Consider the ps_update_stream context — different streams may have different codebases.
+  - Provide a concise per-package explanation.
+  - If you can identify specific sub-components (kernel modules, libraries, binaries) within the package that are affected, include them in affected_subcomponents.
+- Use github MCP tool to inspect commit diffs or repository structure when reference URLs are available.
+- The affected field in each AffectedPackageEntry reflects YOUR analysis of whether the package is affected by the vulnerability, considering the technical context.
+- Set confidence based on how much technical evidence is available to support your determination.
+- Output format: affected_packages (list of AffectedPackageEntry), explanation (string), data_quality, confidence.
+""",
+            context=_build_cve_input(cve_id, static_context),
+            output_schema=SuggestAffectedPackagesModel.model_json_schema(),
+        )
+        return await self.guarded_run(
+            prompt, deps=deps, output_type=SuggestAffectedPackagesModel
+        )
 
 
 class QueryAffectedComponents(DeterministicFeature):

--- a/src/aegis_ai/features/cve/data_models.py
+++ b/src/aegis_ai/features/cve/data_models.py
@@ -77,6 +77,60 @@ class QueryAffectedComponentsModel(BaseModel):
         return f"{len(self.affected_components)} affected component(s)"
 
 
+class AffectedPackageEntry(BaseModel):
+    """A single package-level affectedness suggestion with rationale."""
+
+    purl: str = Field(
+        ...,
+        description="Package URL identifying the source RPM package.",
+    )
+
+    ps_update_stream: str = Field(
+        ...,
+        description="The product stream update identifier (e.g., 'rhel-9.6.0.z').",
+    )
+
+    affected: bool = Field(
+        ...,
+        description="Whether this source RPM package is affected by the vulnerability.",
+    )
+
+    explanation: str = Field(
+        ...,
+        description="Per-package rationale for the affectedness determination.",
+    )
+
+    affected_subcomponents: str | None = Field(
+        default=None,
+        description="Optional free-text hint about which internal components within "
+        "the package are affected (e.g., 'XFS kernel module', 'libcurl HTTP/2 handler').",
+    )
+
+
+class SuggestAffectedPackagesModel(AegisFeatureModel):
+    """LLM-driven suggestion of source RPM package affectedness."""
+
+    cve_id: CVEID = Field(
+        ...,
+        description="The CVE identifier for the analyzed flaw.",
+    )
+
+    affected_packages: list[AffectedPackageEntry] = Field(
+        default_factory=list,
+        description="Per-package affectedness suggestions with PURLs and rationale.",
+    )
+
+    explanation: str = Field(
+        ...,
+        description="Overall rationale for the affectedness analysis.",
+    )
+
+    def printable_outcome(self) -> str:
+        affected = sum(1 for p in self.affected_packages if p.affected)
+        total = len(self.affected_packages)
+        return f"{affected}/{total} package(s) affected"
+
+
 class SuggestAffectedComponentsModel(AegisFeatureModel):
     """Model for suggested affected components inferred from CVE data."""
 

--- a/src/aegis_ai_cli/main.py
+++ b/src/aegis_ai_cli/main.py
@@ -389,6 +389,23 @@ def suggest_affected_components(cve_id):
 
 @aegis_cli.command()
 @click.argument("cve_id", type=CVEID)
+def suggest_affected_packages(cve_id):
+    """
+    Suggest affected source RPM packages for a CVE (LLM-driven).
+    """
+
+    async def _doit():
+        feature = cve.SuggestAffectedPackages(cli_agent)
+        return await feature.exec(cve_id)
+
+    result = asyncio.run(_doit())
+    if result:
+        console.print(Rule())
+        console.print(result.output.model_dump_json(indent=2))
+
+
+@aegis_cli.command()
+@click.argument("cve_id", type=CVEID)
 def query_affected_components(cve_id):
     """
     Query OSIDB for affected components (deterministic, no LLM).

--- a/src/aegis_ai_web/src/main.py
+++ b/src/aegis_ai_web/src/main.py
@@ -336,6 +336,7 @@ cve_feature_registry: dict[str, type] = {
     "identify-pii": cve.IdentifyPII,
     "cvss-diff-explainer": cve.CVSSDiffExplainer,
     "quality-review": cve.QualityReview,
+    "suggest-affected-packages": cve.SuggestAffectedPackages,
     "query-affected-components": cve.QueryAffectedComponents,
 }
 DEFAULT_CVE_FEATURES = [


### PR DESCRIPTION
## What

Add `SuggestAffectedPackages` — an LLM-driven feature that analyzes CVE
affects data (including PURLs and product streams) to suggest which source
RPM packages are affected by a vulnerability. Includes output model,
web/CLI registration, evaluation suite with OSIDB cache entries, and
reusable bound-mode evaluators for `data_quality`/`confidence`.

## Why

Story 2 of the "Suggest Affected Build Artifacts" epic (AEGIS-460). Aegis
can already suggest affected *components* but has no concept of source RPM
packages. This feature bridges the gap by consuming OSIDB affect PURLs
(added in AEGIS-489) and producing per-package affectedness suggestions
with explanations and optional sub-component hints.

## How to Test

```bash
# All checks pass
make all

# CLI (requires LLM API key + OSIDB access)
uv run aegis suggest-affected-packages CVE-2026-34982

# Evaluation suite (requires LLM API key)
uv run pytest evals/features/cve/test_suggest_affected_packages.py

# Web API
make run-web
# POST /api/v1/cve/CVE-2026-34982/suggest-affected-packages
```

Related: https://redhat.atlassian.net/browse/AEGIS-490

## Summary by Sourcery

Add source RPM package affectedness suggestions based on CVE affects data and technical vulnerability analysis.

New Features:
- Add an LLM-driven feature that suggests affected source RPM packages for a CVE, including per-package rationales, product streams, and optional sub-component hints.
- Expose the feature through the CLI, web API, and OpenAPI schema.

Enhancements:
- Provide reusable data-quality and confidence evaluators supporting expected-value and maximum-bound scoring.

Tests:
- Add an OSIDB-backed evaluation suite covering package overlap and low-quality CVE data scenarios.
- Add cached OSIDB affect data and external reference data for package-level evaluations.