### PR TITLE
fix(osidb-bot): record aegis_meta when suggestion is empty

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
             echo ""
             echo "::group::[$CURRENT/$TOTAL] $SHORT — $SUBJECT"
             git checkout --force "$COMMIT"
-            git clean -dfx --exclude=.venv
+            git clean -df
             if ! (uv sync --all-extras --dev && make all); then
               echo "::endgroup::"
               echo ""

--- a/src/aegis_ai/osidb_bot/suggest.py
+++ b/src/aegis_ai/osidb_bot/suggest.py
@@ -90,12 +90,8 @@ def update_field(
     output: AegisAnswer,
     src: str | None = None,
     value: str | None = None,
-    only_if_missing: bool = False,
 ) -> set[str]:
     assert (not src) or (not value)
-    if only_if_missing and flaw_data.get(dst):
-        # do not override existing field
-        return set()
 
     cve_id = flaw_data.get("cve_id", "")
     skip_reason = check_metrics(dst, cve_id, output)

--- a/src/aegis_ai/osidb_bot/suggest.py
+++ b/src/aegis_ai/osidb_bot/suggest.py
@@ -88,7 +88,7 @@ def record_aegis_failure(
     timestamp: datetime,
     dst: str,
     output: AegisAnswer,
-) -> None:
+) -> set[str]:
     record_aegis_meta(
         flaw_data,
         timestamp,
@@ -99,6 +99,7 @@ def record_aegis_failure(
         skip_description=f"{dst} suggestion failed",
         explanation=output.explanation,
     )
+    return {"aegis_meta"}
 
 
 def update_field(
@@ -127,7 +128,7 @@ def update_field(
                 f" is below threshold {METRICS_THR[skip_reason]['skip_thr']}"
             ),
         )
-        return set()
+        return {"aegis_meta"}
 
     # get source value
     if value is None:
@@ -205,8 +206,7 @@ async def suggest_cwe(agent: Agent, flaw_data: FlawData, ts: datetime) -> set[st
     suggested_cwes = output.cwe
     if not suggested_cwes:
         logger.warning(f"{cve_id}: CWE suggestion failed")
-        record_aegis_failure(flaw_data, ts, "cwe_id", output)
-        return set()
+        return record_aegis_failure(flaw_data, ts, "cwe_id", output)
 
     # pick the first CWE in the list off suggested CWEs
     cwe = suggested_cwes[0]
@@ -229,22 +229,26 @@ async def suggest_impact(agent: Agent, flaw_data: FlawData, ts: datetime) -> set
     feature = cve.SuggestImpact(agent)
     output = await exec_feature(feature, flaw_data)
 
+    changed: set[str] = set()
+
     if not output.impact:
-        record_aegis_failure(flaw_data, ts, "impact", output)
+        changed |= record_aegis_failure(flaw_data, ts, "impact", output)
 
     if not output.cvss3_vector:
-        record_aegis_failure(flaw_data, ts, "_cvss3_vector", output)
+        changed |= record_aegis_failure(flaw_data, ts, "_cvss3_vector", output)
 
     if not output.impact or not output.cvss3_vector:
-        return set()
+        return changed
 
     # pick the "impact" field
-    changed = update_field(flaw_data, ts, "impact", output)
+    changed |= update_field(flaw_data, ts, "impact", output)
 
     # record aegis_meta for RH CVSS (in the format used by OSIM)
-    if not update_field(
+    cvss_changed = update_field(
         flaw_data, ts, "_cvss3_vector", output, value=output.cvss3_vector
-    ):
+    )
+    changed |= cvss_changed
+    if "_cvss3_vector" not in cvss_changed:
         # do not update CVSS when check_metrics() decides to skip the update
         return changed
 

--- a/src/aegis_ai/osidb_bot/suggest.py
+++ b/src/aegis_ai/osidb_bot/suggest.py
@@ -83,6 +83,24 @@ def record_aegis_meta(
     dst_field.append(entry)
 
 
+def record_aegis_failure(
+    flaw_data: FlawData,
+    timestamp: datetime,
+    dst: str,
+    output: AegisAnswer,
+) -> None:
+    record_aegis_meta(
+        flaw_data,
+        timestamp,
+        dst,
+        output,
+        type="AI-Bot-Skipped",
+        skip_reason="failure",
+        skip_description=f"{dst} suggestion failed",
+        explanation=output.explanation,
+    )
+
+
 def update_field(
     flaw_data: FlawData,
     timestamp: datetime,
@@ -187,6 +205,7 @@ async def suggest_cwe(agent: Agent, flaw_data: FlawData, ts: datetime) -> set[st
     suggested_cwes = output.cwe
     if not suggested_cwes:
         logger.warning(f"{cve_id}: CWE suggestion failed")
+        record_aegis_failure(flaw_data, ts, "cwe_id", output)
         return set()
 
     # pick the first CWE in the list off suggested CWEs
@@ -198,10 +217,11 @@ async def suggest_cwe(agent: Agent, flaw_data: FlawData, ts: datetime) -> set[st
 
 
 async def suggest_impact(agent: Agent, flaw_data: FlawData, ts: datetime) -> set[str]:
+    cve_id = flaw_data.get("cve_id")
+
     # look for existing RH CVSS
     for cvss in flaw_data["cvss_scores"]:
         if cvss["issuer"] == "RH":
-            cve_id = flaw_data.get("cve_id")
             logger.warning(f"{cve_id}: refusing to overwrite RH CVSS")
             return set()
 
@@ -209,9 +229,13 @@ async def suggest_impact(agent: Agent, flaw_data: FlawData, ts: datetime) -> set
     feature = cve.SuggestImpact(agent)
     output = await exec_feature(feature, flaw_data)
 
+    if not output.impact:
+        record_aegis_failure(flaw_data, ts, "impact", output)
+
+    if not output.cvss3_vector:
+        record_aegis_failure(flaw_data, ts, "_cvss3_vector", output)
+
     if not output.impact or not output.cvss3_vector:
-        cve_id = flaw_data.get("cve_id")
-        logger.warning(f"{cve_id}: impact suggestion incomplete, skipping")
         return set()
 
     # pick the "impact" field

--- a/src/aegis_ai/osidb_bot/suggest.py
+++ b/src/aegis_ai/osidb_bot/suggest.py
@@ -123,12 +123,6 @@ def update_field(
 
         value = getattr(output, src)
 
-    # check the original value in flaw_data
-    orig_val = flaw_data.get(dst)
-    if type(orig_val) is type(value) and orig_val == value:
-        # skip the update if the field already has the same type and value
-        return set()
-
     # write to destination
     flaw_data[dst] = value
 

--- a/tests/test_flaw_updater.py
+++ b/tests/test_flaw_updater.py
@@ -298,7 +298,7 @@ def test_update_field_skipped_low_data_quality():
 
     changed = update_field(flaw_data, TS, "cwe_id", output, value="CWE-79")
 
-    assert changed == set()
+    assert changed == {"aegis_meta"}
     assert flaw_data["cwe_id"] == ""
 
     entries = flaw_data["aegis_meta"]["cwe_id"]
@@ -329,7 +329,7 @@ def test_update_field_skipped_low_confidence():
 
     changed = update_field(flaw_data, TS, "impact", output, value="LOW")
 
-    assert changed == set()
+    assert changed == {"aegis_meta"}
     assert flaw_data["impact"] == ""
 
     entries = flaw_data["aegis_meta"]["impact"]
@@ -357,7 +357,7 @@ def test_update_field_skipped_both_metrics_low():
 
     changed = update_field(flaw_data, TS, "title", output, value="Bad title")
 
-    assert changed == set()
+    assert changed == {"aegis_meta"}
     assert flaw_data["title"] == ""
 
     entries = flaw_data["aegis_meta"]["title"]
@@ -419,7 +419,7 @@ async def test_flaw_updater_all_skipped_records_aegis_meta(mock_exec_feature):
     result = await updater.apply_suggestions()
     assert result is False
 
-    assert updater.updated_fields == set()
+    assert updater.updated_fields == {"aegis_meta"}
 
     aegis_meta = flaw_data["aegis_meta"]
     for field in ("components", "title", "cve_description", "cwe_id", "impact"):
@@ -433,6 +433,43 @@ async def test_flaw_updater_all_skipped_records_aegis_meta(mock_exec_feature):
             assert entry["data_quality"] == LOW_QUALITY
             assert entry["confidence"] == LOW_CONFIDENCE
             datetime.fromisoformat(entry["timestamp"])
+
+
+@pytest.mark.asyncio
+@patch("aegis_ai.osidb_bot.suggest.exec_feature", new_callable=AsyncMock)
+async def test_flaw_updater_empty_cwe_records_aegis_meta(mock_exec_feature):
+    """Empty CWE suggestion records AI-Bot-Skipped and adds aegis_meta to updated_fields."""
+
+    async def _empty_cwe_exec(feature, flaw_data):
+        name = feature.__class__.__name__
+        if name == "SuggestCWE":
+            return SimpleNamespace(
+                cwe=[],
+                explanation="No CWE found",
+                data_quality=1.0,
+                confidence=1.0,
+                tools_used=[],
+            )
+        return await _canned_exec_feature(feature, flaw_data)
+
+    mock_exec_feature.side_effect = _empty_cwe_exec
+
+    flaw_data = _minimal_flaw_data()
+    session = _mock_session(flaw_data)
+    agent = MagicMock()
+
+    updater = FlawUpdater(session, agent, CVE_ID)
+    result = await updater.apply_suggestions()
+
+    assert result is False
+    assert "aegis_meta" in updater.updated_fields
+
+    entries = flaw_data["aegis_meta"]["cwe_id"]
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["type"] == "AI-Bot-Skipped"
+    assert entry["skip_reason"] == "failure"
+    assert "cwe_id" in entry["skip_description"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What
Record `AI-Bot-Skipped` entries in `aegis_meta` when CWE or impact suggestions come back empty, and clean up related dead code in `update_field()`. Also remove an optimization that skipped writing `aegis_meta` when the suggested value matched the existing value in OSIDB.

## Why
When all suggested CWE IDs are filtered out as disallowed (e.g., CWE-352 not in the CWE-699 view), the bot silently skips the field with no trace in OSIDB. Analysts have no way to tell whether the bot failed, was skipped, or simply hasn't run — leading them to report outages or ask dev to check logs.

Additionally, the undocumented same-value optimization in `update_field()` was causing KPI data to be unexpectedly sparse, especially for the `impact` field — when the bot re-suggested the same value already stored in OSIDB, no `aegis_meta` entry was recorded at all.

## How to Test
- Deploy and trigger a flaw where the LLM suggests a disallowed CWE — verify an `AI-Bot-Skipped` entry appears in `aegis_meta` for `cwe_id`
- Trigger a flaw where impact or CVSS vector comes back empty — verify separate `AI-Bot-Skipped` entries for `impact` / `_cvss3_vector`

## Related Tickets
Related: https://redhat.atlassian.net/browse/AEGIS-445
Related: https://redhat.atlassian.net/browse/AEGIS-488

## Summary by Sourcery

Record skipped bot suggestions in `aegis_meta` and retain metadata for unchanged or metric-rejected fields.

New Features:
- Record `AI-Bot-Skipped` metadata when CWE, impact, or CVSS suggestions are empty or rejected by quality metrics.

Bug Fixes:
- Preserve bot execution and skip information in `aegis_meta` instead of silently omitting updates.

Enhancements:
- Always record metadata when suggested values match existing OSIDB values, improving KPI completeness.
- Remove obsolete field-update optimization and related dead code.

CI:
- Adjust historical test workflow cleanup to retain the virtual environment.

Tests:
- Add coverage for empty CWE suggestions and update expectations for metadata-only updates.